### PR TITLE
Custom opacity for highlights depending on geometry

### DIFF
--- a/app/digitizingcontroller.cpp
+++ b/app/digitizingcontroller.cpp
@@ -60,6 +60,11 @@ bool DigitizingController::hasLineGeometry(QgsVectorLayer *layer) const
   return layer && layer->geometryType() == QgsWkbTypes::LineGeometry;
 }
 
+bool DigitizingController::hasPolygonGeometry(QgsVectorLayer *layer) const
+{
+  return layer && layer->geometryType() == QgsWkbTypes::PolygonGeometry;
+}
+
 void DigitizingController::fixZ(QgsPoint* point) const {
     Q_ASSERT(point);
 

--- a/app/digitizingcontroller.h
+++ b/app/digitizingcontroller.h
@@ -36,6 +36,7 @@ public:
 
 
   Q_INVOKABLE bool hasLineGeometry( QgsVectorLayer *layer ) const;
+  Q_INVOKABLE bool hasPolygonGeometry( QgsVectorLayer *layer ) const;
 
   //! Creates a new QgsFeature with point geometry from the current GPS point
   Q_INVOKABLE QgsQuickFeatureLayerPair pointFeature();

--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -37,6 +37,8 @@ QtObject {
     property real shadowRadius: 8 * QgsQuick.Utils.dp
     property real shadowSamples: 12
     property real panelOpacity: 1
+    property real lowHighlightOpacity: 0.4
+    property real highHighlightOpacity: 0.8
 
     property real refWidth: 640
     property real refHeight: 1136

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -118,6 +118,7 @@ ApplicationWindow {
       color: "red"
       mapSettings: mapCanvas.mapSettings
       z: 1
+      opacity: digitizing.hasPolygonGeometry(highlight.featureLayerPair.layer) ? InputStyle.lowHighlightOpacity : InputStyle.highHighlightOpacity
     }
 
     QgsQuick.FeatureHighlight {
@@ -126,6 +127,7 @@ ApplicationWindow {
       color: "yellow"
       mapSettings: mapCanvas.mapSettings
       z: 1
+      opacity: digitizing.hasPolygonGeometry(digitizingHighlight.featureLayerPair.layer) ? InputStyle.lowHighlightOpacity : InputStyle.highHighlightOpacity
     }
 
     Item {


### PR DESCRIPTION
Custom opacity for highlights depending on feature's geometry.
Possible improvements could be create general function for getting feature's geometry if it will be used more in the future.
Feel free to check and comment on opacity values defined in InputStyle.

closes #100 