### PR TITLE
Mergin/download_project_data_stream

### DIFF
--- a/app/img/check.svg
+++ b/app/img/check.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+</svg>

--- a/app/img/download.svg
+++ b/app/img/download.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="baseline-cloud_download-24px.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="765"
+     inkscape:window-height="480"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <path
+     d="M0 0h24v24H0z"
+     fill="none"
+     id="path2" />
+  <path
+     d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"
+     id="path4"
+     style="fill:#ffffff" />
+</svg>

--- a/app/img/pics.qrc
+++ b/app/img/pics.qrc
@@ -24,5 +24,8 @@
         <file>gps_marker_no_position.svg</file>
         <file>gps_marker_position.svg</file>
         <file>no.svg</file>
+        <file>update.svg</file>
+        <file>check.svg</file>
+        <file>download.svg</file>
     </qresource>
 </RCC>

--- a/app/img/update.svg
+++ b/app/img/update.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>
+</svg>

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -240,11 +240,12 @@ int main(int argc, char *argv[])
 #ifdef MERGIN_TOKEN
   merginToken.append(STR(MERGIN_TOKEN));
 #endif
-  MerginApi* ma=  new MerginApi(QString("https://mergin.dev.cloudmappin.com"), merginToken );
-  engine.rootContext()->setContextProperty( "__merginApi", ma );
+
+  std::unique_ptr<MerginApi> ma =  std::unique_ptr<MerginApi>(new MerginApi(QString("https://mergin.dev.cloudmappin.com"), dataDir, merginToken ));
+  engine.rootContext()->setContextProperty( "__merginApi", ma.get() );
 
   // Create mergin projects model
-  MerginProjectModel mpm( ma );
+  MerginProjectModel mpm;
   engine.rootContext()->setContextProperty( "__merginProjectsModel", &mpm );
 
   // Connections
@@ -252,6 +253,9 @@ int main(int argc, char *argv[])
   QObject::connect(&loader, &Loader::projectReloaded, &lm, &LayersModel::reloadLayers);
   QObject::connect(&loader, &Loader::projectReloaded, &mtm, &MapThemesModel::reloadMapThemes);
   QObject::connect(&mtm, &MapThemesModel::reloadLayers, &lm, &LayersModel::reloadLayers);
+  QObject::connect(ma.get(), &MerginApi::downloadProjectFinished, &mpm, &MerginProjectModel::downloadProjectFinished);
+  QObject::connect(ma.get(), &MerginApi::downloadProjectFinished, &pm, &ProjectModel::addProject);
+  QObject::connect(ma.get(), &MerginApi::listProjectsFinished, &mpm, &MerginProjectModel::resetProjects);
 
 #ifdef ANDROID
   engine.rootContext()->setContextProperty( "__appwindowvisibility", "Maximized");

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -5,27 +5,134 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QDate>
+#include <QByteArray>
+#include <QSet>
 
-
-MerginApi::MerginApi(const QString &root, QByteArray token, QObject *parent)
+MerginApi::MerginApi(const QString &root, const QString& dataDir, QByteArray token, QObject *parent)
   : QObject (parent)
   , mApiRoot(root)
+  , mDataDir(dataDir + "/downloads/")
+  , mCacheFile(".projectsCache.txt")
   , mToken(token)
 {
+    QObject::connect(this, &MerginApi::merginProjectsChanged,this, &MerginApi::cacheProjects);
 }
 
 void MerginApi::listProjects()
 {
-    mMerginProjects.clear();
+    if (mToken.isEmpty()) {
+        emit networkErrorOccurred( "Auth token is invalid", "Mergin API error: listProjects" );
+        return;
+    }
+
     QNetworkRequest request;
     // projects filtered by tag "input_use"
     QUrl url(mApiRoot + "/v1/project?tags=input_use");
-
     request.setUrl(url);
     request.setRawHeader("Authorization", QByteArray("Basic " + mToken));
 
     QNetworkReply *reply = mManager.get(request);
     connect(reply, &QNetworkReply::finished, this, &MerginApi::listProjectsReplyFinished);
+}
+
+void MerginApi::downloadProject(QString projectName)
+{
+    if (mToken.isEmpty()) {
+        emit networkErrorOccurred( "Auth token is invalid", "Mergin API error: downloadProject" );
+    }
+
+    QNetworkRequest request;
+    QUrl url(mApiRoot + "/v1/project/download/" + projectName);
+
+    if (mPendingRequests.contains(url)) {
+        QString errorMsg = QStringLiteral("Download request for %1 is already pending.").arg(projectName);
+        qDebug() << errorMsg;
+        emit networkErrorOccurred( errorMsg, "Mergin API error: downloadProject" );
+        return;
+    }
+
+    request.setUrl(url);
+    request.setRawHeader("Authorization", QByteArray("Basic " + mToken));
+
+    QNetworkReply *reply = mManager.get(request);
+    mPendingRequests.insert(url, projectName);
+    connect(reply, &QNetworkReply::finished, this, &MerginApi::downloadProjectReplyFinished);
+}
+
+void MerginApi::updateProject(QString projectName)
+{
+
+    if (mToken.isEmpty()) {
+        emit networkErrorOccurred( "Auth token is invalid", "Mergin API error: projectInfo" );
+    }
+
+    QNetworkRequest request;
+    QUrl url(mApiRoot + "/v1/project/" + projectName);
+
+    request.setUrl(url);
+    request.setRawHeader("Authorization", QByteArray("Basic " + mToken));
+
+    QNetworkReply *reply = mManager.get(request);
+    connect(reply, &QNetworkReply::finished, this, &MerginApi::updateInfoReplyFinished);
+
+}
+
+void MerginApi::downloadProjectFiles(QString projectName, QByteArray json)
+{
+    if (mToken.isEmpty()) {
+        emit networkErrorOccurred( "Auth token is invalid", "Mergin API error: fetchProject" );
+        return;
+    }
+
+    QNetworkRequest request;
+    QUrl url(mApiRoot + "/v1/project/fetch/" + projectName);
+    request.setUrl(url);
+    request.setRawHeader("Authorization", QByteArray("Basic " + mToken));
+    request.setRawHeader("Content-Type", "application/json");
+    request.setRawHeader("Accept", "application/json");
+    mPendingRequests.insert(url, projectName);
+
+    QNetworkReply *reply = mManager.post(request, json);
+    connect(reply, &QNetworkReply::finished, this, &MerginApi::downloadProjectReplyFinished);
+}
+
+ProjectList MerginApi::updateMerginProjectList(ProjectList serverProjects)
+{
+    QHash<QString, QDateTime> projectUpdates;
+    for (std::shared_ptr<MerginProject> project: mMerginProjects) {
+        projectUpdates.insert(project->name, project->updated);
+    }
+
+    for (std::shared_ptr<MerginProject> project: serverProjects) {
+        if (projectUpdates.contains(project->name)) {
+            QDateTime localUpdate = projectUpdates.value(project->name);
+            project->updated = localUpdate;
+            project->status = getProjectStatus(project->updated, project->serverUpdated);
+        }
+    }
+    return serverProjects;
+}
+
+void MerginApi::setUpdateToProject(QString projectName)
+{
+    for (std::shared_ptr<MerginProject> project: mMerginProjects) {
+        if (projectName == project->name) {
+            project->updated = project->serverUpdated;
+            emit merginProjectsChanged();
+            return;
+        }
+    }
+}
+
+void MerginApi::deleteObsoleteFiles(QString projectPath)
+{
+    if (!mObsoleteFiles.value(projectPath).isEmpty()) {
+        for (QString filename: mObsoleteFiles.value(projectPath)) {
+            QFile file (projectPath + filename);
+            file.remove();
+        }
+       mObsoleteFiles.remove(projectPath);
+    }
 }
 
 ProjectList MerginApi::projects()
@@ -41,20 +148,127 @@ void MerginApi::listProjectsReplyFinished()
 
     if (r->error() == QNetworkReply::NoError)
     {
+
+        if (mMerginProjects.isEmpty()) {
+            QFile file(mDataDir + mCacheFile);
+            if (file.open(QIODevice::ReadOnly)) {
+                QByteArray cachedData = file.readAll();
+                file.close();
+
+                mMerginProjects = parseProjectsData(cachedData);
+            }
+        }
+
+
       QByteArray data = r->readAll();
-      mMerginProjects = parseProjectsData(data);
+      ProjectList serverProjects = parseProjectsData(data, true);
+      mMerginProjects = updateMerginProjectList(serverProjects);
+      emit merginProjectsChanged();
     }
     else {
         QString message = QStringLiteral("Network API error: %1(): %2").arg("listProjects", r->errorString());
         qDebug("%s", message.toStdString().c_str());
-        emit networkErrorOccurred( r->errorString() );
+        emit networkErrorOccurred( r->errorString(), "Mergin API error: listProjects" );
     }
 
     r->deleteLater();
-    emit listProjectsFinished();
+    emit listProjectsFinished(mMerginProjects);
 }
 
-ProjectList MerginApi::parseProjectsData(const QByteArray &data)
+void MerginApi::downloadProjectReplyFinished()
+{
+
+    QNetworkReply* r = qobject_cast<QNetworkReply*>(sender());
+    Q_ASSERT(r);
+
+    if (r->error() == QNetworkReply::NoError)
+    {
+        QString projectName = mPendingRequests.value(r->url());
+        QString projectDir = mDataDir + projectName;
+
+        deleteObsoleteFiles(projectDir + "/");
+        handleDataStream(r, projectDir);
+        setUpdateToProject(projectName);
+
+        emit downloadProjectFinished(projectDir, projectName);
+        emit notify("Download successful");
+    }
+    else {
+        qDebug() << r->errorString();
+        emit networkErrorOccurred( r->errorString(), "Mergin API error: downloadProject" );
+    }
+    mPendingRequests.remove(r->url());
+    r->deleteLater();
+}
+
+void MerginApi::updateInfoReplyFinished()
+{
+    QNetworkReply* r = qobject_cast<QNetworkReply*>(sender());
+    Q_ASSERT(r);
+
+    QList<MerginFile> files;
+    QUrl url = r->url();
+    QStringList res = url.path().split("/");
+    QString projectName;
+    projectName = res.last();
+    QString projectPath = QString(mDataDir + projectName + "/");
+
+    if (r->error() == QNetworkReply::NoError)
+    {
+      QByteArray data = r->readAll();
+      QJsonDocument doc = QJsonDocument::fromJson(data);
+      if (doc.isObject()) {
+          QJsonObject docObj = doc.object();
+          QString updated = docObj.value("updated").toString();
+          auto it = docObj.constFind("files");
+          QJsonValue v = *it;
+          Q_ASSERT( v.isArray() );
+          QJsonArray vArray = v.toArray();
+
+          QSet<QString> localFiles = listFiles(projectPath);
+          for ( auto it = vArray.constBegin(); it != vArray.constEnd(); ++it)
+          {
+            QJsonObject projectInfoMap = it->toObject();
+            QString serverChecksum = projectInfoMap.value("checksum").toString();
+            QString path = projectInfoMap.value("path").toString();
+            QByteArray localChecksumBytes = getChecksum(projectPath + path);
+            QString localChecksum = QString::fromLatin1(localChecksumBytes.data(), localChecksumBytes.size());
+            if (serverChecksum != localChecksum) {
+                MerginFile file;
+                file.checksum = serverChecksum;
+                file.path = path;
+                files.append(file);
+            } else {
+                localFiles.remove(path);
+            }
+          }
+
+          // will be removed after successful download
+          mObsoleteFiles.insert(projectPath, localFiles);
+      }
+      QJsonDocument jsonDoc;
+      QJsonArray fileArray;
+
+      for(MerginFile file: files) {
+        QJsonObject fileObject;
+        fileObject.insert("path", file.path);
+        fileObject.insert("checksum", file.checksum);
+        fileArray.append(fileObject);
+      }
+
+      jsonDoc.setArray(fileArray);
+      downloadProjectFiles(projectName, jsonDoc.toJson(QJsonDocument::Compact));
+    }
+    else {
+        QString message = QStringLiteral("Network API error: %1(): %2").arg("listProjects", r->errorString());
+        qDebug("%s", message.toStdString().c_str());
+        emit networkErrorOccurred( r->errorString(), "Mergin API error: projectInfo" );
+    }
+
+    r->deleteLater();
+}
+
+ProjectList MerginApi::parseProjectsData(const QByteArray &data, bool dataFromServer)
 {
     ProjectList result;
 
@@ -64,13 +278,222 @@ ProjectList MerginApi::parseProjectsData(const QByteArray &data)
 
         for ( auto it = vArray.constBegin(); it != vArray.constEnd(); ++it)
         {
-            QJsonObject designMap = it->toObject();
+            QJsonObject projectMap = it->toObject();
             MerginProject p;
-            p.name = designMap.value("name").toString();
-            QString created = designMap.value("created").toString();
-            p.info = QDateTime::fromString(created, Qt::ISODateWithMs).toString();
+            p.name = projectMap.value("name").toString();
+            QJsonValue tags = projectMap.value("tags");
+            if (tags.isArray()) {
+                for (QJsonValueRef tag: tags.toArray()) {
+                    p.tags.append(tag.toString());
+                }
+                tags.toArray().toVariantList();
+            }
+            p.created = QDateTime::fromString(projectMap.value("created").toString(), Qt::ISODateWithMs);
+            QDateTime updated = QDateTime::fromString(projectMap.value("updated").toString(), Qt::ISODateWithMs);
+
+            if (dataFromServer) {
+                if (!updated.isValid()) {
+                    updated = p.created;
+                }
+                p.serverUpdated = updated;
+            } else {
+                p.updated = updated;
+            }
             result << std::make_shared<MerginProject>(p);
         }
     }
     return result;
+}
+
+bool MerginApi::cacheProjectsData(const QByteArray &data)
+{
+    QFile file(mDataDir + mCacheFile);
+    createPathIfNotExists(mDataDir + mCacheFile);
+    if (!file.open(QIODevice::WriteOnly)) {
+        return false;
+    }
+
+    file.write(data);
+    file.close();
+
+    return true;
+}
+
+void MerginApi::cacheProjects()
+{
+    QJsonDocument doc;
+    QJsonArray array;
+    for (std::shared_ptr<MerginProject> p: mMerginProjects) {
+        QJsonObject projectMap;
+        projectMap.insert("created", p->created.toString(Qt::ISODateWithMs));
+        projectMap.insert("updated", p->updated.toString(Qt::ISODateWithMs));
+        projectMap.insert("name", p->name);
+        QJsonArray tags;
+        projectMap.insert("tags", tags.fromStringList(p->tags));
+        array.append(projectMap);
+    }
+    doc.setArray(array);
+    cacheProjectsData(doc.toJson());
+}
+
+void MerginApi::handleDataStream(QNetworkReply* r, QString projectDir)
+{
+    // Read content type from reply's header
+    QByteArray contentType;
+    QString contentTypeString;
+    QList<QByteArray> headerList = r->rawHeaderList();
+    QString headString;
+    foreach(QByteArray head, headerList) {
+        headString = QString::fromLatin1(head.data(), head.size());
+        if (headString == QStringLiteral("Content-Type")) {
+            contentType = r->rawHeader(head);
+            contentTypeString = QString::fromLatin1(contentType.data(), contentType.size());
+        }
+    }
+
+    // Read boundary hash from content types
+    QString boundary;
+    QRegularExpression re;
+    re.setPattern("[^;]+; boundary=(?<boundary>.+)");
+    QRegularExpressionMatch match = re.match(contentTypeString);
+    if (match.hasMatch()) {
+        boundary = match.captured("boundary");
+    }
+
+    // Depends on boundary size itself + special chars which number may vary
+    int boundarySize = boundary.length() + 8;
+    QRegularExpression boundaryPattern("(\r\n)?--" + boundary + "\r\n");
+    QRegularExpression headerPattern("Content-Disposition: form-data; name=\"(?P<name>[^'\"]+)\"(; filename=\"(?P<filename>[^\"]+)\")?\r\n(Content-Type: (?P<content_type>.+))?\r\n");
+    QRegularExpression endPattern("(\r\n)?--" + boundary +  "--\r\n");
+
+    QByteArray data;
+    QString dataString;
+    QString activeFilePath;
+    QFile activeFile;
+
+    while (true) {
+        QByteArray chunk = r->read(CHUNK_SIZE);
+        if (chunk.isEmpty()) {
+            // End of stream - write rest of data to active file
+            if (!activeFile.fileName().isEmpty()) {
+                QRegularExpressionMatch endMatch = endPattern.match(data);
+                int tillIndex = data.indexOf(endMatch.captured(0));
+                saveFile(data.left(tillIndex), activeFile, true);
+            }
+            return;
+        }
+
+        data = data.append(chunk);
+        dataString = QString::fromLatin1(data.data(), data.size());
+        QRegularExpressionMatch boundaryMatch = boundaryPattern.match(dataString);
+
+        while (boundaryMatch.hasMatch()) {
+            if (!activeFile.fileName().isEmpty()) {
+                int tillIndex = data.indexOf(boundaryMatch.captured(0));
+                saveFile(data.left(tillIndex), activeFile, true);
+            }
+
+            // delete previously written data with next boundary part
+            int tillIndex = data.indexOf(boundaryMatch.captured(0)) + boundaryMatch.captured(0).length();
+            data = data.remove(0, tillIndex);
+            dataString = QString::fromLatin1(data.data(), data.size());
+
+            QRegularExpressionMatch headerMatch = headerPattern.match(dataString);
+            if (!headerMatch.hasMatch()) {
+                qDebug() << "Received corrupted header";
+                data = data + r->read(CHUNK_SIZE);
+                dataString = QString::fromLatin1(data.data(), data.size());
+            }
+            headerMatch = headerPattern.match(dataString);
+            data = data.remove(0, headerMatch.captured(0).length());
+            dataString = QString::fromLatin1(data.data(), data.size());
+            QString filename = headerMatch.captured("filename");
+
+            activeFilePath = projectDir + "/" + filename;
+            activeFile.setFileName(activeFilePath);
+            if (activeFile.exists()) {
+                // Remove file if want to override
+                activeFile.remove();
+            } else {
+                createPathIfNotExists(activeFilePath);
+            }
+
+            boundaryMatch = boundaryPattern.match(dataString);
+        }
+
+        // Write rest of chunk to file
+        if (!activeFile.fileName().isEmpty()) {
+            saveFile(data.left(data.size() - boundarySize), activeFile, false);
+        }
+        data = data.remove(0, data.size() - boundarySize);
+    }
+}
+
+bool MerginApi::saveFile(const QByteArray &data, QFile &file, bool closeFile)
+{
+    if (!file.isOpen()) {
+        if (!file.open(QIODevice::Append)) {
+            return false;
+        }
+    }
+
+    file.write(data);
+    if (closeFile)
+        file.close();
+
+    return true;
+}
+
+void MerginApi::createPathIfNotExists(QString filePath)
+{
+    QDir dir;
+    if (!dir.exists(mDataDir))
+        dir.mkpath(mDataDir);
+
+    QFileInfo newFile( filePath );
+    if ( !newFile.absoluteDir().exists() )
+    {
+      if ( !QDir( dir ).mkpath( newFile.absolutePath() ) )
+        qDebug() << "Creating folder failed";
+    }
+}
+
+ProjectStatus MerginApi::getProjectStatus(QDateTime localUpdated, QDateTime updated)
+{
+    if (!localUpdated.isValid()) {
+        return ProjectStatus::NoVersion;
+    }
+
+    if (localUpdated < updated) {
+        return ProjectStatus::OutOfDate;
+    }
+    return ProjectStatus::UpToDate;
+}
+
+QByteArray MerginApi::getChecksum(QString filePath) {
+    QFile f(filePath);
+    if (f.open(QFile::ReadOnly)) {
+        QCryptographicHash hash(QCryptographicHash::Sha1);
+        QByteArray chunk = f.read(CHUNK_SIZE);
+        while (!chunk.isEmpty()) {
+           hash.addData(chunk);
+           chunk = f.read(CHUNK_SIZE);
+           hash.addData(chunk);
+        }
+        return hash.result().toHex();
+    }
+    f.close();
+    return QByteArray();
+}
+
+QSet<QString> MerginApi::listFiles(QString path)
+{
+    QSet<QString> files;
+    QDirIterator it(path, QStringList() << QStringLiteral("*"), QDir::Files, QDirIterator::Subdirectories);
+    while (it.hasNext())
+    {
+        it.next();
+        files << it.filePath().replace(path, "");
+    }
+    return files;
 }

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -5,37 +5,109 @@
 #include <QNetworkAccessManager>
 #include <QEventLoop>
 #include <memory>
+#include <QFile>
+
+enum ProjectStatus
+{
+  NoVersion,
+  UpToDate,
+  OutOfDate
+};
+Q_ENUMS( ProjectStatus )
 
 struct MerginProject {
     QString name;
     QStringList tags;
-    QString info;
+    QDateTime created;
+    QDateTime updated; // last local update
+    QDateTime serverUpdated; // last update on server
+    bool pending = false; // if there is a pending request for downlaod/update a project
+    ProjectStatus status = NoVersion;
 };
+
+struct MerginFile {
+    QString path;
+    QString checksum;
+};
+
+
 typedef QList<std::shared_ptr<MerginProject>> ProjectList;
 
 class MerginApi: public QObject {
-     Q_OBJECT
+    Q_OBJECT
 public:
-    explicit MerginApi(const QString& root, QByteArray token, QObject* parent = nullptr );
+    explicit MerginApi(const QString& root, const QString& dataDir, QByteArray token, QObject* parent = nullptr );
     ~MerginApi() = default;
+
+    /**
+     * Sends non-blocking GET request to the server to listProjects. On listProjectsReplyFinished,
+     * when a response is received, parses project json, writes it to a cache text file and sets mMerginProjects.
+     * Eventually emits listProjectsFinished on which ProjectPanel (qml component) updates content.
+     * If listing has been successful, updates cached merginProjects list.
+     * @param
+     */
     Q_INVOKABLE void listProjects();
+
+    /**
+     * Sends non-blocking GET request to the server to download a project with a given name. On downloadProjectReplyFinished,
+     * when a response is received, parses data-stream and creates files. Eventually emits downloadProjectFinished on which
+     * MerginProjectModel updates status of the project item. On downloadProjectFinished, ProjectModel adds the project item to the project list.
+     * If download has been successful, updates cached merginProjects list.
+     * Emits also notify signal with a message for the GUI.
+     * @param projectName Name of project to download.
+     */
+    Q_INVOKABLE void downloadProject(QString projectName);
+
+    /**
+     * Sends non-blocking GET request to the server to update a project with a given name. On downloadProjectReplyFinished,
+     * when a response is received, parses data-stream to files and rewrites local files with them. Extra files which don't match server
+     * files are removed. Eventually emits downloadProjectFinished on which MerginProjectModel updates status of the project item.
+     * If update has been successful, updates cached merginProjects list.
+     * Emits also notify signal with a message for the GUI.
+     * @param projectName Name of project to update.
+     */
+    Q_INVOKABLE void updateProject(QString projectName);
+
     ProjectList projects();
 
 signals:
-    void listProjectsFinished();
-    void networkErrorOccurred(QString errorMessage);
+    void listProjectsFinished(ProjectList merginProjects);
+    void downloadProjectFinished(QString projectDir, QString projectName);
+    void updateProjectFinished(QString projectDir, QString projectName);
+    void networkErrorOccurred(QString message, QString additionalInfo);
+    void notify(QString message);
+    void merginProjectsChanged();
 
 private slots:
     void listProjectsReplyFinished();
+    void downloadProjectReplyFinished(); // download + update
+    void updateInfoReplyFinished();
+    void cacheProjects();
 
 private:
-    ProjectList parseProjectsData( const QByteArray &data );
+    ProjectList parseProjectsData(const QByteArray &data, bool dataFromServer = false);
+    bool cacheProjectsData(const QByteArray &data);
+    void handleDataStream(QNetworkReply* r, QString projectDir);
+    bool saveFile(const QByteArray &data, QFile &file, bool closeFile);
+    void createPathIfNotExists(QString filePath);
+    ProjectStatus getProjectStatus(QDateTime localUpdated, QDateTime updated);
+    QByteArray getChecksum(QString filePath);
+    QSet<QString> listFiles(QString projectPath);
+    void downloadProjectFiles(QString projectName, QByteArray json);
+    ProjectList updateMerginProjectList(ProjectList serverProjects);
+    void setUpdateToProject(QString projectName);
+    void deleteObsoleteFiles(QString projectName);
 
     QNetworkAccessManager mManager;
     QString mApiRoot;
     ProjectList mMerginProjects;
+    QString mDataDir;
+    QString mCacheFile;
     QByteArray mToken;
+    QHash<QUrl, QString>mPendingRequests;
+    QHash<QString, QSet<QString>> mObsoleteFiles;
 
+    const int CHUNK_SIZE = 65536;
 };
 
 #endif // MERGINAPI_H

--- a/app/merginprojectmodel.h
+++ b/app/merginprojectmodel.h
@@ -16,27 +16,27 @@ class MerginProjectModel: public QAbstractListModel
     {
       Name = Qt::UserRole + 1,
       Size,
-      ProjectInfo
+      ProjectInfo,
+      Status,
+      Pending
     };
     Q_ENUMS( Roles )
 
-    explicit MerginProjectModel(MerginApi *merginApi, QObject* parent = nullptr);
+    explicit MerginProjectModel(QObject* parent = nullptr);
 
     Q_INVOKABLE QVariant data( const QModelIndex& index, int role ) const override;
-    Q_INVOKABLE QModelIndex index( int row ) const;
+    Q_INVOKABLE void setPending(int row, bool pending);
     ProjectList projects();
 
     QHash<int, QByteArray> roleNames() const override;
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
-    void resetProjects();
+    void resetProjects(const ProjectList &merginProjects);
 
-signals:
-    void merginProjectsChanged();
-
+public slots:
+    void downloadProjectFinished(QString projectFolder, QString projectName);
   private:
-    MerginApi* mApi;
     ProjectList mMerginProjects;
 
 };

--- a/app/projectsmodel.h
+++ b/app/projectsmodel.h
@@ -54,9 +54,15 @@ class ProjectModel : public QAbstractListModel
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
 
     QString dataDir() const;
+signals:
+    void projectsChanged();
+
+public slots:
+    void addProject(QString projectFolder, QString projectName);
 
   private:
     void findProjectFiles();
+    void addProjectsFromPath(QString path);
 
     struct ProjectFile {
         QString name;

--- a/app/qml/ProjectDelegateItem.qml
+++ b/app/qml/ProjectDelegateItem.qml
@@ -14,9 +14,10 @@ Rectangle {
     property int cellWidth: width
     property int cellHeight: height
     property int borderWidth: 1
-    property int activeProjectIndex
     property string state
     property bool highlight: false
+    property bool pending: false
+    property string statusIconSource: "more_menu.svg"
 
     signal itemClicked();
     signal menuClicked()
@@ -95,21 +96,38 @@ Rectangle {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        menuClicked()
+                        if (!pending) menuClicked()
                     }
                 }
 
-                Text {
+                Image {
+                    anchors.margins: (itemContainer.cellHeight/4)
+                    id: statusIcon
                     anchors.fill: parent
-                    text: "..."
-                    height: textContainer.height/2
-                    font.pixelSize: InputStyle.fontPixelSizeSmall
-                    font.weight: Font.Bold
+                    source: statusIconSource
+                    sourceSize.width: width
+                    sourceSize.height: height
+                    fillMode: Image.PreserveAspectFit
+                    visible: !pending
+                }
+
+                ColorOverlay {
+                    anchors.fill: statusIcon
+                    source: statusIcon
                     color: itemContainer.highlight ? itemContainer.primaryColor : itemContainer.secondaryColor
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
+                    visible: !pending
+                }
+
+                BusyIndicator {
+                    id: busyIndicator
+                    implicitHeight: itemContainer.cellHeight/2
+                    implicitWidth: implicitHeight
+                    running: pending
+                    anchors.centerIn: parent
                 }
             }
+
+
         }
 
         Rectangle {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -62,6 +62,15 @@ ApplicationWindow {
         return positionKit.accuracy < __appSettings.gpsAccuracyTolerance ? InputStyle.softGreen : InputStyle.softOrange
     }
 
+    function showMessage(message) {
+        if (!__androidUtils.isAndroid) {
+            popup.text = message
+            popup.open()
+        } else {
+            __androidUtils.showToast(message)
+        }
+    }
+
     Component.onCompleted: {
         if (__appSettings.defaultProject) {
             var path = __appSettings.defaultProject ? __appSettings.defaultProject : openProjectPanel.activeProjectPath
@@ -318,13 +327,10 @@ ApplicationWindow {
     Connections {
         target: __merginApi
         onNetworkErrorOccurred: {
-            console.log("__androidUtils.isAndroid", __androidUtils.isAndroid)
-            if (!__androidUtils.isAndroid) {
-                popup.text = errorMessage
-                popup.open()
-            } else {
-                __androidUtils.showToast(errorMessage)
-            }
+            showMessage(message)
+        }
+        onNotify: {
+            showMessage(message)
         }
     }
 


### PR DESCRIPTION
Downloading project from data stream reading chunks and parsing files. Data handling implementation is similar to one in Mergin. Same signal is emitted for download/update project. If download/update request got data, obsolate files (extra files + modified files) are deleted. 
MerginApi is using a new instance of Mergin where "updated" value has been added for listing projects. Projects list is cached in a local file (.cachedProjects.txt) which is updated after any project list request or successful download/update request. Project status heavily depends on this file and list of Projects from the server. If is missing, mergin projects appears as with "noVersion" projectStatus otherwise server and local updated values are compared to get projectStastus. According projectStatus, the app sends either donwload or update requests.

closes #119 closes #121 
This PR makes #122 downloading project with zip out of date.