### PR TITLE
Documentation about Installing Input with docker and building Input with Qt Creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,19 @@ docker cp 71eef3e8038a:/opt/android-ndk /home/apps/android
 docker cp 71eef3e8038a:/opt/android-sdk /home/apps/android
 ```
 - The folder copied from docker has root permission, so we cannot compile any app in Qt Creator with root files. Change these folder's permissions to your user name.
-- Then you are ready to build it with Qt Creator! Set up SDK and NDK path of Qt Creator, install ant and and Java JDK 8. Open Input's pro file and build it :)
+- Configure config.pri according to new osgeo path:
+Example:
+```
+android {
+  OSGEO4A_DIR = /home/apps/osgeo4a
+  OSGEO4A_STAGE_DIR = $${OSGEO4A_DIR}
+  QGIS_INSTALL_PATH = $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH
+  QGIS_QUICK_DATA_PATH = INPUT # should be relative path
+}
+!android {
+}
+```
+- Then you are ready to build it with Qt Creator! Set up SDK and NDK path in Qt Creator's Android settings, install ant and and Java JDK 8. Open Input's pro file and build it :)
 
 Note: Before you develop the app for Android with Qt Creator, you should create a new folder in Android's SD Card named "INPUT" and copy your projects and data manually to INPUT folder under your SD Card. Unless you don't do it, Input may not see any project.
 

--- a/README.md
+++ b/README.md
@@ -8,105 +8,47 @@ Mobile application based on QGIS's library QgsQuick.
 
 # Development
 
-Tested: Linux, MacOs (Desktop only)
-In general you need `qgis_core` and `qgis_quick` libraries build for target platform.
-
-You need to copy and edit config.in with your paths!
-```
-cd app
-cp config.pri.default config.pri
-# nano config.pri
-```
-
-## Development Linux - Desktop
-
-Requirements:
-
-- Qt5.x
-- QGIS 3.x prerequsities
-
-You can either build qgis_quick library or use ony from QGIS 3.4+ installation
-For building QGIS use these flags WITH_QUICK=TRUE, WITH_GUI=FALSE, WITH_DESKTOP=FALSE, WITH_BINDINGS=FALSE
-
-```
-cd repo/QGIS/build-cmd
-cmake \
-   -GNinja \
-   -DCMAKE_BUILD_TYPE=Release \
-   -DCMAKE_INSTALL_PREFIX=~/qmobile/apps \
-   -DWITH_GUI=FALSE \
-   -DWITH_QUICK=TRUE \
-   -DWITH_QTWEBKIT=FALSE \
-   -DENABLE_TESTS=FALSE \
-   -DWITH_BINDINGS=FALSE \
-   ..
-ninja
-ninja install
-```
-
-Now you need to edit input/config.pri with paths to your QGIS installation and build with qmake
-
-And run
-
-```
-#!/bin/bash
-APP=~/qmobile/apps
-
-LD_LIBRARY_PATH=$APP/lib/ \
-QML2_IMPORT_PATH=$APP/qml \
-QGIS_PREFIX_PATH=$APP \
-$APP/bin/input
-```
+Tested: Linux (Ubuntu, Manjaro), MacOs (Desktop only), Android
+You need to copy config.pri.default file in /app folder, rename it to config.pri and paste in the current folder.
 
 ## Development Linux Cross-Compilation for Android
-
-Same requirements as for Linux Desktop
-
 Requirements Android:
+- Qt5.11.2
+- QGIS 3.x prerequsities
+- Docker
 - OSGeo4A
+- Minimum 20GB free space (For NDK, SDK, Qt, OsGeo4A and others)
 
-Build `qgis_core` and `qgis_quick` libraries with OSGeo4A.
-Now you need to edit input/config.pri with paths to your OSGeo4A installation and build with qmake
+Now you need to edit input/config.pri with paths to your OSGeo4A installation. 
 
-## Development MacOS Desktop
+# OSGeo4A Installation from Docker
+- First install Docker, you can install it from software manager or command line (Ubuntu: sudo apt-get install docker.io)
+- Build OsGeo4A:
+cd OSGeo4A
+sudo docker build -t osgeo4a .
 
-So far only working if you want to build desktop version of the application
+Clone Input:
+git clone https://github.com/lutraconsulting/input.git
+cd Input
 
-Requirements:
- - All QGIS dependencies for qgis-3 receipt from https://github.com/OSGeo/homebrew-osgeo4mac
+To compite input from docker directly, use this :
+docker run -v $(pwd):/usr/src/input -e "BUILD_FOLDER=build-armv7" -e "ARCH=armv7" -it osgeo4a
+After you built it, open Android-Build folder in Input. Find APK file in output folder.
 
-You can either build qgis_quick library or use ony from QGIS 3.4+ installation. Use same flags as for Linux
-Now you need to edit input/config.pri with paths to your QGIS installation and build with qmake
+Another way is to copy all OsGeo4A dependencies to host machine.
+To do so, use these commands:
+first get the image id number and copy 
+sudo docker ps
+example:
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                                            NAMES
+1b4ad9311e93        bamos/openface      "/bin/bash"         33 minutes ago 
+Then copy the image folder to the host folder:
+docker cp <containerId>:/file/path/within/container /host/path/target
 
-To run the application from build tree, you need to:
 
-```
-#!/bin/bash
-APP=~/qmobile/Applications
+The folder copied from docker has root permission, so we cannot compile an app with QtCreator with root files. To change permission folder copied from docker image, it should be user’s permission, not root:
+sudo chown -R edip:edip ./osgeo4a/
 
-DYLD_FRAMEWORK_PATH=$DYLD_FRAMEWORK_PATH:$APP/QGIS.app/Contents/MacOS/lib:$APP/QGIS.app/Contents/Frameworks \
-QML2_IMPORT_PATH=$APP/QGIS.app/Contents/MacOS/qml \
-QGIS_PREFIX_PATH=$APP/QGIS.app/Contents/MacOS \
-$APP/bin/qgis-quick-components-test
-```
 
-1. append QGIS Frameworks paths to `DYLD_FRAMEWORK_PATH`
-2. append QML path for `qgis_quick` qml dir
+Before you develop the app for Android with Qt Creator, you should create a new folder named "INPUT" and copy your projects and data manually to INPUT folder under your SD Card. Then you can compile the app with Qt Creator.
 
-## Development MacOS Cross-Compilation for Android
-
-Same requirements as for Cross-Compilation for Android
-
-Quick guide:
-- `brew tap caskroom/versions`
-- `brew cask install java8`
-- `brew install ant`
-- `brew install bison`
-- `sudo mkdir -p /opt; sudo chown <your name>:admin /opt`
-- download SDK command line tools and unzip to `/opt/android-sdk`
-- sdk: install lldb, build tools, platform android X, cmake, platform-tools
-- download QT armv7 to `/opt/Qt`
-- download crystax and install to `/opt/crystax-10.3.2`
-- compile OSGeo4a
-- open QtCreator -> Manage Kits -> add SDK and NDK. compilers should be autodetected
-- enable connection on the device from MacOS when requested

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ docker cp 71eef3e8038a:/opt/android-sdk /home/apps/android
 Example:
 ```
 android {
-  OSGEO4A_DIR = /home/apps/osgeo4a
-  OSGEO4A_STAGE_DIR = $${OSGEO4A_DIR}
+  OSGEO4A_DIR = /home/apps
+  OSGEO4A_STAGE_DIR = /home/apps/osgeo4a
   QGIS_INSTALL_PATH = $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH
   QGIS_QUICK_DATA_PATH = INPUT # should be relative path
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Mobile application based on QGIS's library QgsQuick.
 
 # Development
 
-Tested: Linux (Ubuntu, Manjaro), MacOs (Desktop only), Android
+Tested: Linux (Ubuntu, Manjaro), MacOs (Desktop only), Android.
+
 You need to copy config.pri.default file in /app folder, rename it to config.pri and paste in the current folder.
 
 ## Development Linux Cross-Compilation for Android
@@ -24,13 +25,16 @@ Now you need to edit input/config.pri with paths to your OSGeo4A installation.
 # OSGeo4A Installation from Docker
 - First install Docker, you can install it from software manager or command line (Ubuntu: sudo apt-get install docker.io)
 - Build OsGeo4A:
+```
 cd OSGeo4A
 sudo docker build -t osgeo4a .
+```
 
 Clone Input:
+```
 git clone https://github.com/lutraconsulting/input.git
 cd Input
-
+```
 To compite input from docker directly, use this :
 docker run -v $(pwd):/usr/src/input -e "BUILD_FOLDER=build-armv7" -e "ARCH=armv7" -it osgeo4a
 After you built it, open Android-Build folder in Input. Find APK file in output folder.
@@ -40,15 +44,19 @@ To do so, use these commands:
 first get the image id number and copy 
 sudo docker ps
 example:
+```
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                                            NAMES
 1b4ad9311e93        bamos/openface      "/bin/bash"         33 minutes ago 
+```
 Then copy the image folder to the host folder:
+```
 docker cp <containerId>:/file/path/within/container /host/path/target
-
+```
 
 The folder copied from docker has root permission, so we cannot compile an app with QtCreator with root files. To change permission folder copied from docker image, it should be user’s permission, not root:
+```
 sudo chown -R edip:edip ./osgeo4a/
-
+```
 
 Before you develop the app for Android with Qt Creator, you should create a new folder named "INPUT" and copy your projects and data manually to INPUT folder under your SD Card. Then you can compile the app with Qt Creator.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ docker cp 71eef3e8038a:/opt/android-ndk /home/apps/android
 docker cp 71eef3e8038a:/opt/android-sdk /home/apps/android
 ```
 - The folder copied from docker has root permission, so we cannot compile any app in Qt Creator with root files. Change these folder's permissions to your user name.
-- Then you are ready to build it with Qt Creator! Set up SDK and NDK path of Qt Creator, install and ant and Java JDK 8. Open Input's pro file and build it :)
+- Then you are ready to build it with Qt Creator! Set up SDK and NDK path of Qt Creator, install ant and and Java JDK 8. Open Input's pro file and build it :)
 
 Note: Before you develop the app for Android with Qt Creator, you should create a new folder in Android's SD Card named "INPUT" and copy your projects and data manually to INPUT folder under your SD Card. Unless you don't do it, Input may not see any project.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Tested: Linux (Ubuntu, Manjaro), MacOs (Desktop only), Android.
 ## Development Linux Cross-Compilation for Android
 Requirements Android:
 - Qt5.11.2
-- QGIS 3.x prerequsities
 - Docker
 - OSGeo4A
 - Minimum 20GB free space (For NDK, SDK, Qt, OsGeo4A and others)

--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ Now you need to edit input/config.pri with paths to your OSGeo4A installation.
 - First install Docker, you can install it from software manager or command line (Ubuntu: ```sudo apt-get install docker.io```)
 - Building OSGeo4A:
 ```
+git clone https://github.com/opengisch/OSGeo4A.git
 cd OSGeo4A
 sudo docker build -t osgeo4a .
 ```
 It will take for a long time to build everything.
 ## Running Input for Android
+### Building with Docker
 Clone Input:
 ```
 git clone https://github.com/lutraconsulting/input.git
@@ -47,32 +49,36 @@ android {
 }
 ```
 
-To compite input from docker directly, use this :
+To compile Input from docker directly, use this :
 ```
 cd Input
 docker run -v $(pwd):/usr/src/input -e "BUILD_FOLDER=build-armv7" -e "ARCH=armv7" -it osgeo4a
 ```
 After you built it, open Android-Build folder in Input path. Find APK file in output folder. And install it for Android.
+### Building with Qt Creator
+- If you wanna customize the app with Qt Creator without docker, copy all OsGeo4A dependencies to your local host.
+- To do so, use these commands:
+first get the image id number of OSGeo4A. Copy the ID of osgeo4a:
+```
+cd OSGeo4A
+sudo docker image ls
+```
+example output:
+```
+REPOSITORY             TAG                 IMAGE ID            CREATED             SIZE
+osgeo4a                latest              71eef3e8038a        7 days ago          10.5GB
+<none>                 <none>              8a34148c5af2        8 days ago          11.2GB
+<none>                 <none>              bd72457905ca        8 days ago          9.71GB
+opengisch/qt-crystax   5.11.3_v2           8db89632ab85        12 days ago         9.7GB
+```
+- Then copy the necessary folders in OSGeo4A's docker image to the host folder:
+```
+docker cp 71eef3e8038a:/home/osgeo4a /home/apps
+docker cp 71eef3e8038a:/opt/android-ndk /home/apps/android
+docker cp 71eef3e8038a:/opt/android-sdk /home/apps/android
+```
+- The folder copied from docker has root permission, so we cannot compile any app in Qt Creator with root files. Change these folder's permissions to your user name.
+- Then you are ready to build it with Qt Creator! Set up SDK and NDK path of Qt Creator, install and ant and Java JDK 8. Open Input's pro file and build it :)
 
-If you wanna customize the app with Qt Creator without docker, copy all OsGeo4A dependencies to your local host.
-To do so, use these commands:
-first get the image id number of OSGeo4A. Copy the ID
-```
-sudo docker ps
-```
-example:
-```
-CONTAINER ID        IMAGE               COMMAND             CREATED           
-1b4ad9311e93        bamos/openface      "/bin/bash"         33 minutes ago 
-```
-Then copy the necessary folders in OSGeo4A's docker image to the host folder:
-```
-docker cp <containerId>:/file/path/within/container /host/path/target
-```
-The folder copied from docker has root permission, so we cannot compile an app with Qt Creator with root files. To change permission folder copied from docker image, it should be user’s permission, not root:
-```
-sudo chown -R edip:edip ./osgeo4a/
-```
-
-Note: Before you develop the app for Android with Qt Creator, you should create a new folder in Android's SD Card named "INPUT" and copy your projects and data manually to INPUT folder under your SD Card. Then you can compile the app with Qt Creator.
+Note: Before you develop the app for Android with Qt Creator, you should create a new folder in Android's SD Card named "INPUT" and copy your projects and data manually to INPUT folder under your SD Card. Unless you don't do it, Input may not see any project.
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Mobile application based on QGIS's library QgsQuick.
 
 Tested: Linux (Ubuntu, Manjaro), MacOs (Desktop only), Android.
 
-You need to copy config.pri.default file in /app folder, rename it to config.pri and paste in the current folder.
-
 ## Development Linux Cross-Compilation for Android
 Requirements Android:
 - Qt5.11.2
@@ -19,44 +17,62 @@ Requirements Android:
 - Docker
 - OSGeo4A
 - Minimum 20GB free space (For NDK, SDK, Qt, OsGeo4A and others)
+I recommend you to setup Lubuntu to Virtual Box with 80GB space.
 
 Now you need to edit input/config.pri with paths to your OSGeo4A installation. 
 
-# OSGeo4A Installation from Docker
-- First install Docker, you can install it from software manager or command line (Ubuntu: sudo apt-get install docker.io)
-- Build OsGeo4A:
+## OSGeo4A Installation from Docker
+- First install Docker, you can install it from software manager or command line (Ubuntu: ```sudo apt-get install docker.io```)
+- Building OSGeo4A:
 ```
 cd OSGeo4A
 sudo docker build -t osgeo4a .
 ```
-
+It will take for a long time to build everything.
+## Running Input for Android
 Clone Input:
 ```
 git clone https://github.com/lutraconsulting/input.git
-cd Input
 ```
-To compite input from docker directly, use this :
-docker run -v $(pwd):/usr/src/input -e "BUILD_FOLDER=build-armv7" -e "ARCH=armv7" -it osgeo4a
-After you built it, open Android-Build folder in Input. Find APK file in output folder.
+You need to copy config.pri.default file in /input/app folder, rename it to config.pri and paste it in the current folder.
+Example:
+```
+android {
+  OSGEO4A_DIR = /home/osgeo4a
+  OSGEO4A_STAGE_DIR = $${OSGEO4A_DIR}
+  QGIS_INSTALL_PATH = $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH
+  QGIS_QUICK_DATA_PATH = INPUT # should be relative path
+}
+!android {
+}
+```
 
-Another way is to copy all OsGeo4A dependencies to host machine.
+To compite input from docker directly, use this :
+```
+cd Input
+docker run -v $(pwd):/usr/src/input -e "BUILD_FOLDER=build-armv7" -e "ARCH=armv7" -it osgeo4a
+```
+After you built it, open Android-Build folder in Input path. Find APK file in output folder. And install it for Android.
+
+If you wanna customize the app with Qt Creator without docker, copy all OsGeo4A dependencies to your local host.
 To do so, use these commands:
-first get the image id number and copy 
+first get the image id number of OSGeo4A. Copy the ID
+```
 sudo docker ps
+```
 example:
 ```
-CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                                            NAMES
+CONTAINER ID        IMAGE               COMMAND             CREATED           
 1b4ad9311e93        bamos/openface      "/bin/bash"         33 minutes ago 
 ```
-Then copy the image folder to the host folder:
+Then copy the necessary folders in OSGeo4A's docker image to the host folder:
 ```
 docker cp <containerId>:/file/path/within/container /host/path/target
 ```
-
-The folder copied from docker has root permission, so we cannot compile an app with QtCreator with root files. To change permission folder copied from docker image, it should be user’s permission, not root:
+The folder copied from docker has root permission, so we cannot compile an app with Qt Creator with root files. To change permission folder copied from docker image, it should be user’s permission, not root:
 ```
 sudo chown -R edip:edip ./osgeo4a/
 ```
 
-Before you develop the app for Android with Qt Creator, you should create a new folder named "INPUT" and copy your projects and data manually to INPUT folder under your SD Card. Then you can compile the app with Qt Creator.
+Note: Before you develop the app for Android with Qt Creator, you should create a new folder in Android's SD Card named "INPUT" and copy your projects and data manually to INPUT folder under your SD Card. Then you can compile the app with Qt Creator.
 

--- a/app/config.pri.default
+++ b/app/config.pri.default
@@ -1,20 +1,8 @@
-BASE_DIR=</home/folder>/Projects/quick
-
 android {
-  OSGEO4A_DIR = $${BASE_DIR}/OSGeo4A
-  OSGEO4A_STAGE_DIR = $${OSGEO4A_DIR}/stage
+  OSGEO4A_DIR = /home/apps
+  OSGEO4A_STAGE_DIR = /home/apps/osgeo4a
   QGIS_INSTALL_PATH = $${OSGEO4A_STAGE_DIR}/$$ANDROID_TARGET_ARCH
   QGIS_QUICK_DATA_PATH = INPUT # should be relative path
-  # we try to use it as /sdcard/path and if not writable, use /storage/emulated/0/path (user home path)
 }
 !android {
-
-  # option 1: using QGIS from installed path
-  QGIS_INSTALL_PATH = $${BASE_DIR}/Applications
-
-  # option 2: using QGIS from build directory (not installed)
-  #QGIS_SRC_DIR = </home/folder>/Projects/qgis
-  #QGIS_BUILD_DIR = $${QGIS_SRC_DIR}/build
-
-  QGIS_QUICK_DATA_PATH = $${BASE_DIR}/input/app/android/assets/qgis-data
 }


### PR DESCRIPTION
I tried to install OSGeo4A for Ubuntu and Manjaro, I got errors installing some recipes like geos. And installing QGIS from the source is difficult for Ubuntu because of many dependencies. I think installing Input with docker is easier.