### PR TITLE
Show title in preview as specified in display field (expression)

### DIFF
--- a/app/loader.cpp
+++ b/app/loader.cpp
@@ -74,16 +74,25 @@ void Loader::zoomToProject(QgsQuickMapSettings *mapSettings)
     mapSettings->setExtent(extent);
 }
 
+QString Loader::featureTitle(QgsQuickFeatureLayerPair pair)
+{
+  QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( pair.layer() ) );
+  context.setFeature( pair.feature() );
+  QgsExpression expr( pair.layer()->displayExpression() );
+  return expr.evaluate( &context ).toString();
+}
+
 QStringList Loader::mapTip(QgsQuickFeatureLayerPair pair)
 {
     QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( pair.layer() ) );
     QString mapTip = pair.layer()->mapTipTemplate();
+    QString featureTitleExpression = pair.layer()->displayExpression();
     int LIMIT = 2;
     QStringList previewFields;
 
     QStringList fields;
     for (QgsField field: pair.layer()->fields()) {
-        if (pair.layer()->displayField() != field.name()) {
+        if (featureTitleExpression != field.name()) {
             fields << field.name();
         }
     }
@@ -97,7 +106,7 @@ QStringList Loader::mapTip(QgsQuickFeatureLayerPair pair)
 
     if (previewFields.empty()) {
         for (QgsField field: pair.layer()->fields()) {
-            if (pair.layer()->displayField() != field.name()) {
+            if (featureTitleExpression != field.name()) {
                 previewFields << field.name();
             }
             if (previewFields.length() == LIMIT) return previewFields;

--- a/app/loader.h
+++ b/app/loader.h
@@ -41,6 +41,7 @@ public:
 
     Q_INVOKABLE bool load(const QString& filePath);
     Q_INVOKABLE void zoomToProject(QgsQuickMapSettings *mapSettings);
+    Q_INVOKABLE QString featureTitle(QgsQuickFeatureLayerPair pair);
     Q_INVOKABLE QStringList mapTip(QgsQuickFeatureLayerPair pair);
 
 signals:

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -58,8 +58,7 @@ Drawer {
         featurePanel.isReadOnly = feature.layer.readOnly
 
         if (panelState === "preview") {
-            var index = currentAttributeModel.index(0, 0)
-            previewPanel.title = currentAttributeModel.data(index, QgsQuick.AttributeFormModel.Name)
+            previewPanel.title = __loader.featureTitle(feature)
             previewPanel.previewFields = __loader.mapTip(feature)
         }
         stateManager.state = panelState

--- a/app/qml/PreviewPanel.qml
+++ b/app/qml/PreviewPanel.qml
@@ -56,6 +56,7 @@ Item {
                         font.bold: true
                         horizontalAlignment: Text.AlignLeft
                         verticalAlignment: Text.AlignVCenter
+                        elide: Qt.ElideRight
                     }
 
                     Item {


### PR DESCRIPTION
Until now we were showing just value of the first field, but this changes it to show the proper name (or expression) defined in layer properties in QGIS.