### PR TITLE
Update map extent to a selected feature if its below preview panel.

### DIFF
--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -2,6 +2,8 @@
 #define INPUTUTILS_H
 
 #include <QObject>
+#include "qgsquickfeaturelayerpair.h"
+#include "qgsquickmapsettings.h"
 
 class InputUtils: public QObject
 {
@@ -13,6 +15,8 @@ public:
     Q_INVOKABLE bool removeFile( const QString &filePath );
     Q_INVOKABLE bool copyFile( const QString &srcPath, const QString &dstPath );
     Q_INVOKABLE QString getFileName( const QString &filePath);
+
+    Q_INVOKABLE void setExtentToFeature(const QgsQuickFeatureLayerPair& pair, QgsQuickMapSettings *mapSettings, double panelOffsetRatio );
 };
 
 #endif // INPUTUTILS_H

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -181,6 +181,13 @@ ApplicationWindow {
         var res = identifyKit.identifyOne(screenPoint);
         if (res.valid) {
           highlight.featureLayerPair = res
+
+          // update extent to fit feature above preview panel
+          if (mouse.y > window.height - featurePanel.previewHeight) {
+              var panelOffsetRatio = featurePanel.previewHeight/window.height
+              __inputUtils.setExtentToFeature(res, mapCanvas.mapSettings, panelOffsetRatio)
+          }
+
           highlight.visible = true
           featurePanel.show_panel(res, "ReadOnly", "preview" )
         } else if (featurePanel.visible) {


### PR DESCRIPTION
Current implementation updates extent only if feature would be hidden under preview panel. Possible improvement would be to make a transition while updating extent, so change wouldn't be sudden and can be used to centered any identified feature.

Notes: Currently identify color is set to red - it differs from record feature highlight.

closes #172

