### PR TITLE
[Mergin] - changes after mergin parser update

### DIFF
--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -32,6 +32,7 @@ struct MerginProject {
 struct MerginFile {
     QString path;
     QString checksum;
+    qint64 size;
 };
 
 


### PR DESCRIPTION
Sending size info in data-sync changes json.
Changed order of headers.