### PR TITLE
Overlapping components in the feature form in 'Add' state

### DIFF
--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -142,6 +142,7 @@ Drawer {
             anchors.top: photoContainer.bottom
             anchors.bottom: toolbar.top
             externalResourceHandler: externalResourceBundle.handler
+            toolbarVisible: false
             style: QgsQuick.FeatureFormStyling {
                 property color backgroundColor: "white  "
                 property real backgroundOpacity: 1


### PR DESCRIPTION
Default feature form toolbar is overlapping form in 'Add' state. Its unused anyway, therefore invisible.
However, it need proper fix in qgsquick lib.