### PR TITLE
Fix of doubling project while doing sync

### DIFF
--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -44,10 +44,15 @@ void ProjectModel::addProjectFromPath(QString path)
     QDirIterator it(path, QStringList() << QStringLiteral("*.qgs"), QDir::Files, QDirIterator::Subdirectories);
     QSet<QString> projectFilePaths;
 
+    int i = 0;
+    int projectExistsAt = -1;
     for (ProjectFile projectFile: mProjectFiles) {
         projectFilePaths << projectFile.path;
+        if (mDataDir + "/" + projectFile.folderName == path) {
+            projectExistsAt = i;
+        }
+        i++;
     }
-
 
     QList<ProjectFile> foundProjects;
     while (it.hasNext())
@@ -63,9 +68,7 @@ void ProjectModel::addProjectFromPath(QString path)
         projectFile.info = QString(created.toString());
         projectFile.isValid = true;
 
-        if (!projectFilePaths.contains(projectFile.path))
-            foundProjects.append(projectFile);
-
+        foundProjects.append(projectFile);
         qDebug() << "Found QGIS project: " << it.filePath();
     }
 
@@ -84,7 +87,11 @@ void ProjectModel::addProjectFromPath(QString path)
         project.info = "invalid project";
         project.isValid = false;
     }
-     mProjectFiles.append(project);
+
+    if (projectExistsAt >= 0)
+        mProjectFiles.removeAt(projectExistsAt);
+
+    mProjectFiles.append(project);
 }
 
 
@@ -156,8 +163,10 @@ QString ProjectModel::dataDir() const {
     return mDataDir;
 }
 
-void ProjectModel::addProject(QString projectFolder, QString projectName)
+void ProjectModel::addProject(QString projectFolder, QString projectName, bool successful)
 {
+    if (!successful) return;
+
     Q_UNUSED(projectName);
     beginResetModel();
     addProjectFromPath(projectFolder);

--- a/app/projectsmodel.h
+++ b/app/projectsmodel.h
@@ -61,7 +61,7 @@ signals:
     void projectDeleted(QString folderName);
 
 public slots:
-    void addProject(QString projectFolder, QString projectName);
+    void addProject(QString projectFolder, QString projectName, bool successful);
 
   private:
     void findProjectFiles();


### PR DESCRIPTION
If sync hasn't been successful, skip adding project
If such project exists according project folder name, update reference (a project can become invalid/valid after sync, has to be updated also reference in model)

closes #202 