### PR TITLE
Double check if a project folder exists

### DIFF
--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -207,7 +207,10 @@ ProjectList MerginApi::updateMerginProjectList(ProjectList serverProjects)
 {
     QHash<QString, std::shared_ptr<MerginProject>> projectUpdates;
     for (std::shared_ptr<MerginProject> project: mMerginProjects) {
-        projectUpdates.insert(project->name, project);
+        QDir projectFolder(mDataDir + "/" + project->name);
+        if (projectFolder.exists()) {
+             projectUpdates.insert(project->name, project);
+        }
     }
 
     for (std::shared_ptr<MerginProject> project: serverProjects) {
@@ -636,7 +639,11 @@ void MerginApi::cacheProjects()
         projectMap.insert("name", p->name);
         QJsonArray tags;
         projectMap.insert("tags", tags.fromStringList(p->tags));
-        array.append(projectMap);
+
+        QDir projectFolder(mDataDir + "/" + p->name);
+        if (projectFolder.exists()) {
+            array.append(projectMap);
+        }
     }
     doc.setArray(array);
     cacheProjectsData(doc.toJson());


### PR DESCRIPTION
Firstly, when a cache is read before fetching a list from server and merging info - if project folder doesnt exists, cache info is ignored and project status is purely based on server data. This is just to get proper status before mergin info from cache and server.
Secondly, when cache is created/overwriten after fetch. This is actual cleanup of cache.

closes #237 