### PR TITLE
Modification time issue

### DIFF
--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -296,7 +296,7 @@ ProjectList MerginApi::updateMerginProjectList( const ProjectList &serverProject
     {
       QDateTime localUpdate = projectUpdates.value( project->name ).get()->updated;
       project->lastSync = projectUpdates.value( project->name ).get()->lastSync;
-      QDateTime lastModified = QFileInfo( mDataDir + project->name ).lastModified();
+      QDateTime lastModified = getLastModifiedFileDateTime( mDataDir + project->name );
       project->updated = localUpdate;
       project->status = getProjectStatus( project->updated, project->serverUpdated, project->lastSync, lastModified );
     }
@@ -1043,6 +1043,24 @@ ProjectStatus MerginApi::getProjectStatus( const QDateTime &localUpdated, const 
   }
 
   return ProjectStatus::UpToDate;
+}
+
+QDateTime MerginApi::getLastModifiedFileDateTime( const QString &path )
+{
+  QDateTime lastModified = QFileInfo( path ).lastModified();
+  QDirIterator it( path, QStringList() << QStringLiteral( "*" ), QDir::Files, QDirIterator::Subdirectories );
+  while ( it.hasNext() )
+  {
+    it.next();
+    if ( !mIgnoreFiles.contains( it.fileInfo().suffix() ) )
+    {
+      if ( it.fileInfo().lastModified() > lastModified )
+      {
+        lastModified = it.fileInfo().lastModified();
+      }
+    }
+  }
+  return lastModified;
 }
 
 QByteArray MerginApi::getChecksum( const QString &filePath )

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -147,6 +147,7 @@ class MerginApi: public QObject
     bool saveFile( const QByteArray &data, QFile &file, bool closeFile );
     void createPathIfNotExists( const QString &filePath );
     ProjectStatus getProjectStatus( const QDateTime &localUpdated, const QDateTime &updated, const QDateTime &lastSync, const QDateTime &lastMod );
+    QDateTime getLastModifiedFileDateTime( const QString &path );
     QByteArray getChecksum( const QString &filePath );
     QSet<QString> listFiles( const QString &projectPath );
     void downloadProjectFiles( const QString &projectName, const QByteArray &json );


### PR DESCRIPTION
Get latest modification datetime out of all files rather than from only project's folder.
In case of shapefiles, project's folder has the same mod timestamp although shapefile has been changed.

possibly closing #264 