### PR TITLE
Loading indicators

### DIFF
--- a/app/loader.cpp
+++ b/app/loader.cpp
@@ -54,6 +54,14 @@ void Loader::setRecording( bool isRecordingOn )
 bool Loader::load( const QString &filePath )
 {
   qDebug() << "Loading " << filePath;
+  emit loadingStarted();
+
+  // Give some time to other (GUI) processes before loading a project in the main thread
+  QEventLoop loop;
+  QTimer t;
+  t.connect( &t, &QTimer::timeout, &loop, &QEventLoop::quit );
+  t.start( 10 );
+  loop.exec();
 
   // Just clear project if empty
   if ( filePath.isEmpty() )
@@ -70,6 +78,7 @@ bool Loader::load( const QString &filePath )
     emit projectReloaded();
   }
 
+  emit loadingFinished();
   return res;
 }
 

--- a/app/loader.h
+++ b/app/loader.h
@@ -55,6 +55,9 @@ class Loader: public QObject
     void positionKitChanged();
     void recordingChanged();
 
+    void loadingStarted();
+    void loadingFinished();
+
   public slots:
     void appStateChanged( Qt::ApplicationState state );
     // Reloads project if current project path matches given path (its the same project)

--- a/app/qml/LoadingIndicator.qml
+++ b/app/qml/LoadingIndicator.qml
@@ -6,13 +6,13 @@ ProgressBar {
     id: loadingIndicator
     anchors.top: parent.top
     value: 0
-    height: 5
-    width: parent.width
     clip: true
 
     property int easingType: Easing.InOutQuad
 
     function toggle(value) {
+      if (loadingIndicatorAnimation.running === value) return
+
       loadingIndicatorAnimation.running = value
       visible = value
     }
@@ -73,6 +73,7 @@ ProgressBar {
         property: "value"
         from: 1
         to: 1
+        duration: 100
         running: true
         loops: Animation.Infinite
         easing.type: easingType

--- a/app/qml/LoadingIndicator.qml
+++ b/app/qml/LoadingIndicator.qml
@@ -2,80 +2,37 @@ import QtQuick 2.7
 import QtQuick.Controls 2.2
 import QtGraphicalEffects 1.0
 
-ProgressBar {
-    id: loadingIndicator
-    anchors.top: parent.top
-    value: 0
-    clip: true
 
-    property int easingType: Easing.InOutQuad
+Rectangle {
+  id: loadingIndicator
+  anchors.top: parent.top
+  color: InputStyle.fontColor
 
-    function toggle(value) {
-      if (loadingIndicatorAnimation.running === value) return
+  Rectangle {
+    id: bar
+    width: parent.width
+    height: parent.height
 
-      loadingIndicatorAnimation.running = value
-      visible = value
-    }
-
-    background: Rectangle {
-        implicitWidth: loadingIndicator.width
-        implicitHeight: loadingIndicator.height
-        border.color: InputStyle.panelBackgroundDarker
-        radius: 0
-    }
-    contentItem: Item {
-        implicitWidth: loadingIndicator.width
-        implicitHeight: loadingIndicator.height
-
-        Rectangle {
-            id: bar
-            width: loadingIndicator.visualPosition * parent.width
-            height: parent.height
-            radius: 0
-        }
-
-        LinearGradient {
-            anchors.fill: bar
-            start: Qt.point(0, 0)
-            end: Qt.point(bar.width, 0)
-            source: bar
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: InputStyle.fontColor }
-                GradientStop { id: grad; position: 0.5; color: Qt.lighter(InputStyle.fontColor, 2) }
-                GradientStop { position: 1.0; color: InputStyle.fontColor }
-            }
-            PropertyAnimation {
-                target: grad
-                property: "position"
-                from: 0.0
-                to: 1.0
-                duration: 1000
-                running: true
-                loops: Animation.Infinite
-                easing.type: easingType
-            }
-        }
-        LinearGradient {
-            anchors.fill: bar
-            start: Qt.point(0, 0)
-            end: Qt.point(0, bar.height)
-            source: bar
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: Qt.rgba(0,0,0,0) }
-                GradientStop { position: 0.5; color: Qt.rgba(1,1,1,0.3) }
-                GradientStop { position: 1.0; color: Qt.rgba(0,0,0,0.05) }
-            }
-        }
-    }
     PropertyAnimation {
-        id: loadingIndicatorAnimation
-        target: loadingIndicator
-        property: "value"
-        from: 1
-        to: 1
-        duration: 100
-        running: true
-        loops: Animation.Infinite
-        easing.type: easingType
+      running: loadingIndicator.visible
+      target: bar
+      property: "x"
+      from: -bar.width
+      to: bar.width
+      duration: 1500
+      loops: Animation.Infinite
     }
+
+    LinearGradient {
+      anchors.fill: bar
+      start: Qt.point(0, 0)
+      end: Qt.point(bar.width, 0)
+      source: bar
+      gradient: Gradient {
+        GradientStop { position: 0.0; color: InputStyle.fontColor }
+        GradientStop { position: 0.5; color: Qt.lighter(InputStyle.fontColor, 2) }
+        GradientStop { position: 1.0; color: InputStyle.fontColor }
+      }
+    }
+  }
 }

--- a/app/qml/LoadingIndicator.qml
+++ b/app/qml/LoadingIndicator.qml
@@ -1,0 +1,80 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.2
+import QtGraphicalEffects 1.0
+
+ProgressBar {
+    id: loadingIndicator
+    anchors.top: parent.top
+    value: 0
+    height: 5
+    width: parent.width
+    clip: true
+
+    property int easingType: Easing.InOutQuad
+
+    function toggle(value) {
+      loadingIndicatorAnimation.running = value
+      visible = value
+    }
+
+    background: Rectangle {
+        implicitWidth: loadingIndicator.width
+        implicitHeight: loadingIndicator.height
+        border.color: InputStyle.panelBackgroundDarker
+        radius: 0
+    }
+    contentItem: Item {
+        implicitWidth: loadingIndicator.width
+        implicitHeight: loadingIndicator.height
+
+        Rectangle {
+            id: bar
+            width: loadingIndicator.visualPosition * parent.width
+            height: parent.height
+            radius: 0
+        }
+
+        LinearGradient {
+            anchors.fill: bar
+            start: Qt.point(0, 0)
+            end: Qt.point(bar.width, 0)
+            source: bar
+            gradient: Gradient {
+                GradientStop { position: 0.0; color: InputStyle.fontColor }
+                GradientStop { id: grad; position: 0.5; color: Qt.lighter(InputStyle.fontColor, 2) }
+                GradientStop { position: 1.0; color: InputStyle.fontColor }
+            }
+            PropertyAnimation {
+                target: grad
+                property: "position"
+                from: 0.0
+                to: 1.0
+                duration: 1000
+                running: true
+                loops: Animation.Infinite
+                easing.type: easingType
+            }
+        }
+        LinearGradient {
+            anchors.fill: bar
+            start: Qt.point(0, 0)
+            end: Qt.point(0, bar.height)
+            source: bar
+            gradient: Gradient {
+                GradientStop { position: 0.0; color: Qt.rgba(0,0,0,0) }
+                GradientStop { position: 0.5; color: Qt.rgba(1,1,1,0.3) }
+                GradientStop { position: 1.0; color: Qt.rgba(0,0,0,0.05) }
+            }
+        }
+    }
+    PropertyAnimation {
+        id: loadingIndicatorAnimation
+        target: loadingIndicator
+        property: "value"
+        from: 1
+        to: 1
+        running: true
+        loops: Animation.Infinite
+        easing.type: easingType
+    }
+}

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -428,10 +428,9 @@ Item {
 
       onItemClicked: {
         if (showMergin) return
+
         projectsPanel.activeProjectIndex = index
-        __appSettings.defaultProject = path
         projectsPanel.visible = false
-        projectsPanel.activeProjectIndexChanged()
       }
 
       onMenuClicked: {

--- a/app/qml/ProjectLoadingScreen.qml
+++ b/app/qml/ProjectLoadingScreen.qml
@@ -1,0 +1,32 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.5
+
+Item {
+
+  Rectangle {
+    anchors.fill: parent
+    color: InputStyle.fontColor
+  }
+
+  Image {
+    id: logo
+    anchors.centerIn: parent
+    source: "input.svg"
+    width: parent.width/2
+    sourceSize.height: 0
+    fillMode: Image.PreserveAspectFit
+    sourceSize.width: width
+  }
+
+  Text {
+    text: "Project loading ..."
+    anchors.verticalCenterOffset: parent.height/6
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.verticalCenter: parent.verticalCenter
+    font.italic: true
+    font.pixelSize: InputStyle.fontPixelSizeNormal
+    color: "white"
+    opacity: 0.75
+  }
+
+}

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -508,9 +508,9 @@ ApplicationWindow {
 
         onActiveProjectIndexChanged: {
             openProjectPanel.activeProjectPath = __projectsModel.data(__projectsModel.index(openProjectPanel.activeProjectIndex), ProjectModel.Path)
+            __appSettings.defaultProject = openProjectPanel.activeProjectPath
             __appSettings.activeProject = openProjectPanel.activeProjectPath
             __loader.load(openProjectPanel.activeProjectPath)
-
             updateActiveLayerByName(__appSettings.defaultLayer)
         }
     }
@@ -560,9 +560,6 @@ ApplicationWindow {
         onNotify: {
             showMessage(message)
         }
-        onNotifyDialog: {
-          showDialog(message)
-        }
     }
 
     FeaturePanel {
@@ -589,5 +586,21 @@ ApplicationWindow {
 
     LoadingIndicator {
         id: loadingIndicator
+        width: parent.width
+        height: 8 * QgsQuick.Utils.dp
+        z: zPanel + 1000 // the most top
+    }
+
+    Connections {
+        target: __loader
+        onLoadingStarted: projectLoadingScreen.visible = true
+        onLoadingFinished: projectLoadingScreen.visible = false
+    }
+
+    ProjectLoadingScreen {
+      id: projectLoadingScreen
+      anchors.fill: parent
+      visible: false
+      z: zPanel + 1000 // the most top
     }
 }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -202,6 +202,10 @@ ApplicationWindow {
         identifyMode: QgsQuick.IdentifyKit.TopDownAll
       }
 
+      onIsRenderingChanged: {
+        loadingIndicator.toggle(isRendering)
+      }
+
       onClicked: {
        // no identify action in record state
        if (stateManager.state === "record") return
@@ -581,5 +585,9 @@ ApplicationWindow {
         onEditGeometryClicked: {
             stateManager.state = "edit"
         }
+    }
+
+    LoadingIndicator {
+        id: loadingIndicator
     }
 }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -203,7 +203,7 @@ ApplicationWindow {
       }
 
       onIsRenderingChanged: {
-        loadingIndicator.toggle(isRendering)
+        loadingIndicator.visible = isRendering
       }
 
       onClicked: {
@@ -586,8 +586,9 @@ ApplicationWindow {
 
     LoadingIndicator {
         id: loadingIndicator
+        visible: false
         width: parent.width
-        height: 8 * QgsQuick.Utils.dp
+        height: 7 * QgsQuick.Utils.dp
         z: zPanel + 1000 // the most top
     }
 

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -33,5 +33,6 @@
         <file>MerginProjectPanel.qml</file>
         <file>AccountPage.qml</file>
         <file>Highlight.qml</file>
+        <file>LoadingIndicator.qml</file>
     </qresource>
 </RCC>

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -34,5 +34,6 @@
         <file>AccountPage.qml</file>
         <file>Highlight.qml</file>
         <file>LoadingIndicator.qml</file>
+        <file>ProjectLoadingScreen.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Added loading indicator for rendering
Added loading screen for loading projects - therefore added signals in Loader class.
Since loading projects seems to be blocking GUI for redrawing a new component just before, a short event loop has been added. 

Note: Current implementation shows loading screen even if a loading is super quick which might be annoying in a user-perspective.

closes #321 
closes #354 