### PR TITLE
Small improvements

### DIFF
--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -90,6 +90,7 @@ void TestMerginApi::initTestCase()
   deleteRemoteProject( mApiExtra, mUsername, "testCancelDownloadProject" );
   deleteRemoteProject( mApiExtra, mUsername, "testCreateDeleteProject" );
   deleteRemoteProject( mApiExtra, mUsername, "testMultiChunkUploadDownload" );
+  deleteRemoteProject( mApiExtra, mUsername, "testCreateProjectTwice" );
 }
 
 void TestMerginApi::cleanupTestCase()
@@ -443,12 +444,12 @@ void TestMerginApi::testMultiChunkUploadDownload()
   QVERIFY( !checksum.isEmpty() );
 
   // upload
-  uploadRemoteProject( mApi, mUsername, projectName );
+  uploadRemoteProject( mApi, mUsername, projectName, LONG_REPLY * 10 );
 
   // download again
   deleteLocalProject( mApi, mUsername, projectName );
   QVERIFY( !QFileInfo::exists( bigFilePath ) );
-  downloadRemoteProject( mApi, mUsername, projectName );
+  downloadRemoteProject( mApi, mUsername, projectName, LONG_REPLY * 10 );
 
   // verify it's there and with correct content
   QByteArray checksum2 = MerginApi::getChecksum( bigFilePath );
@@ -840,19 +841,19 @@ void TestMerginApi::deleteLocalProject( MerginApi *api, const QString &projectNa
   api->localProjectsManager().removeProject( project.projectDir );
 }
 
-void TestMerginApi::downloadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName )
+void TestMerginApi::downloadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName, int timeout )
 {
   QSignalSpy spy( api, &MerginApi::syncProjectFinished );
   api->updateProject( projectNamespace, projectName );
   QCOMPARE( api->transactions().count(), 1 );
-  QVERIFY( spy.wait( LONG_REPLY * 5 ) );
+  QVERIFY( spy.wait( timeout ) );
 }
 
-void TestMerginApi::uploadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName )
+void TestMerginApi::uploadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName, int timeout )
 {
   api->uploadProject( projectNamespace, projectName );
   QSignalSpy spy( api, &MerginApi::syncProjectFinished );
-  QVERIFY( spy.wait( LONG_REPLY ) );
+  QVERIFY( spy.wait( timeout ) );
   QCOMPARE( spy.count(), 1 );
 }
 

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -43,8 +43,8 @@ class TestMerginApi: public QObject
     void testConflictRemoteAddLocalAdd();
 
   private:
-    int SHORT_REPLY = 1000;
-    int LONG_REPLY = 5000;
+    static const int SHORT_REPLY = 1000;
+    static const int LONG_REPLY = 5000;
 
     MerginApi *mApi;
     MerginProjectModel *mMerginProjectModel;
@@ -63,10 +63,10 @@ class TestMerginApi: public QObject
     void deleteRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName );
 
     //! Downloads a remote project to the local drive
-    void downloadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName );
+    void downloadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName, int timeout = LONG_REPLY * 5 );
 
     //! Uploads any local changes in the local project to the remote project
-    void uploadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName );
+    void uploadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName, int timeout = LONG_REPLY );
 
     //! Deletes a project from the local drive
     void deleteLocalProject( MerginApi *api, const QString &projectNamespace, const QString &projectName );


### PR DESCRIPTION
Added removal of a testCreateProjectTwice test project
Added timeout attribute and increased timeout for uploading a big file.

Tests are **sometimes** failing and generating `Received signal 11` fatal error. Happens mostly on dev.dev server, but also on local instance. 