### PR TITLE
Improve "update before upload" handling in mergin client

### DIFF
--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -81,6 +81,7 @@ struct TransactionStatus
   QString projectDir;
   QByteArray projectMetadata;  //!< metadata of the new project (not parsed)
   bool firstTimeDownload = false;   //!< only for update. whether this is first time to download the project (on failure we would also remove the project folder)
+  bool updateBeforeUpload = false; //!< true when we're first doing update before doing actual upload. Used in sync finalization to figure out whether restart with upload or finish.
 
   int version = -1;  //!< version to which we are updating / the version which we have uploaded
 
@@ -308,7 +309,6 @@ class MerginApi: public QObject
     void uploadFileReplyFinished();
     void uploadFinishReplyFinished();
     void uploadCancelReplyFinished();
-    void continueWithUpload( const QString &projectDir, const QString &projectName, bool successfully = true );
 
     void getUserInfoFinished();
     void saveAuthData();
@@ -403,6 +403,8 @@ class MerginApi: public QObject
 
     //! Takes care of removal of the transaction, writing new metadata and emits syncProjectFinished()
     void finishProjectSync( const QString &projectFullName, bool syncSuccessful );
+
+    void startProjectUpdate( const QString &projectFullName, const QByteArray &data );
 
     QNetworkAccessManager mManager;
     QString mApiRoot;

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -41,6 +41,7 @@ class TestMerginApi: public QObject
     void testUpdateRemovedVsModifiedFiles();
     void testConflictRemoteUpdateLocalUpdate();
     void testConflictRemoteAddLocalAdd();
+    void testUploadWithUpdate();
 
   private:
     int SHORT_REPLY = 1000;


### PR DESCRIPTION
- removes a message box triggered from mergin api (closes #324)
- more precise server version check (using most recent server version instead of cached)
- added a test for this situation