### PR TITLE
Overwrite mode in copy function

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -286,8 +286,13 @@ bool InputUtils::cpDir( const QString &srcPath, const QString &dstPath )
     {
       if ( !QFile::copy( srcItemPath, dstItemPath ) )
       {
-        qDebug() << "Cannot copy file " << srcItemPath << " > " << dstItemPath;
-        return false;
+        QFile::remove( dstItemPath );
+        if ( !QFile::copy( srcItemPath, dstItemPath ) )
+        {
+          qDebug() << "Cannot copy file " << srcItemPath << " > " << dstItemPath;
+          return false;
+        }
+
       }
       QFile::setPermissions( dstItemPath, QFile::ReadUser | QFile::WriteUser | QFile::ReadOwner | QFile::WriteOwner );
     }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -262,6 +262,7 @@ QString InputUtils::filesToString( QList<MerginFile> files )
 
 bool InputUtils::cpDir( const QString &srcPath, const QString &dstPath )
 {
+  bool result  = true;
   QDir parentDstDir( QFileInfo( dstPath ).path() );
   if ( !parentDstDir.mkpath( dstPath ) )
   {
@@ -278,19 +279,23 @@ bool InputUtils::cpDir( const QString &srcPath, const QString &dstPath )
     {
       if ( !cpDir( srcItemPath, dstItemPath ) )
       {
-        qDebug() << "Cannot copy dir " << srcItemPath << " > " << dstItemPath;
-        return false;
+        log( QString( "Cannot copy a dir from %1 to %2" ).arg( srcItemPath ).arg( dstItemPath ) );
+        result = false;
       }
     }
     else if ( info.isFile() )
     {
       if ( !QFile::copy( srcItemPath, dstItemPath ) )
       {
-        QFile::remove( dstItemPath );
-        if ( !QFile::copy( srcItemPath, dstItemPath ) )
+        if ( !QFile::remove( dstItemPath ) )
         {
-          qDebug() << "Cannot copy file " << srcItemPath << " > " << dstItemPath;
-          return false;
+          log( QString( "Cannot remove a file from %1" ).arg( dstItemPath ) );
+          result =  false;
+        }
+        else if ( !QFile::copy( srcItemPath, dstItemPath ) )
+        {
+          log( QString( "Cannot overwrite a file %1 with %2" ).arg( dstItemPath ).arg( dstItemPath ) );
+          result =  false;
         }
 
       }
@@ -298,10 +303,10 @@ bool InputUtils::cpDir( const QString &srcPath, const QString &dstPath )
     }
     else
     {
-      qDebug() << "Unhandled item" << info.filePath() << "in cpDir";
+      log( QString( "Unhandled item %1 in cpDir" ).arg( info.filePath() ) );
     }
   }
-  return true;
+  return result;
 }
 
 QString InputUtils::renameWithDateTime( const QString &srcPath, const QDateTime &dateTime )

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -53,6 +53,13 @@ class InputUtils: public QObject
      */
     Q_INVOKABLE static QString renameWithDateTime( const QString &srcPath, const QDateTime &dateTime = QDateTime() );
 
+    /**
+     * Method copies all entries from given source path to destination path. If cannot copy a file for the first time,
+     * removes it and tries again (overwrite a file).
+     * \param srcPath Source path
+     * \param dstPath Destination path
+     * \result True if operation was successful otherwise false.
+     */
     static bool cpDir( const QString &srcPath, const QString &dstPath );
 
     static void log( const QString &msg, const QString &info = QStringLiteral() );

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -55,10 +55,10 @@ class InputUtils: public QObject
 
     /**
      * Method copies all entries from given source path to destination path. If cannot copy a file for the first time,
-     * removes it and tries again (overwrite a file).
+     * removes it and tries again (overwrite a file). If failes again, skips the file, sets result to false and continue.
      * \param srcPath Source path
      * \param dstPath Destination path
-     * \result True if operation was successful otherwise false.
+     * \result True if operation was fully successful otherwise false.
      */
     static bool cpDir( const QString &srcPath, const QString &dstPath );
 


### PR DESCRIPTION
Copy function was ended after the first problem with copying a file (QFile::copy returns false if a file at destination already exists). Therefore some files might be skipped afterwards. However, in the cases where functions is used, it should be in overwrite mode anyway.

The investigation and change has been invoked by https://github.com/lutraconsulting/qgis-mergin-plugin/issues/50 