### PR TITLE
Fix of uploading subdir gpkg file

### DIFF
--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -12,6 +12,7 @@
 
 #include "inpututils.h"
 #include "geodiffutils.h"
+#include "qgsquickutils.h"
 
 #include <geodiff.h>
 
@@ -1602,12 +1603,13 @@ void MerginApi::uploadInfoReplyFinished()
         if ( geodiffRes == GEODIFF_SUCCESS )
         {
           QByteArray checksumDiff = getChecksum( diffPath );
+          //QByteArray checksumBase = getChecksum( basePath );
 
           // TODO: this is ugly. our basefile may not need to have the same checksum as the server's
           // basefile (because each of them have applied the diff independently) so we have to fake it
           QByteArray checksumBase = serverProject.fileInfo( filePath ).checksum.toLatin1();
 
-          merginFile.diffName = QFileInfo( diffPath ).fileName();
+          merginFile.diffName = QgsQuickUtils::getRelativePath( diffPath, transaction.projectDir + "/.mergin/" );
           merginFile.diffChecksum = QString::fromLatin1( checksumDiff.data(), checksumDiff.size() );
           merginFile.diffSize = QFileInfo( diffPath ).size();
           merginFile.chunks = generateChunkIdsForSize( merginFile.diffSize );

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -1603,7 +1603,6 @@ void MerginApi::uploadInfoReplyFinished()
         if ( geodiffRes == GEODIFF_SUCCESS )
         {
           QByteArray checksumDiff = getChecksum( diffPath );
-          //QByteArray checksumBase = getChecksum( basePath );
 
           // TODO: this is ugly. our basefile may not need to have the same checksum as the server's
           // basefile (because each of them have applied the diff independently) so we have to fake it

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -44,6 +44,7 @@ class TestMerginApi: public QObject
     void testConflictRemoteAddLocalAdd();
     void testUploadWithUpdate();
     void testDiffUpload();
+    void testDiffSubdirsUpload();
     void testDiffUpdateBasic();
     void testDiffUpdateWithRebase();
     void testDiffUpdateWithRebaseFailed();


### PR DESCRIPTION
Fixed relative path to project's .mergin folder while uploading files to the server

closes #534 