### PR TITLE
App data in each request

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1,8 +1,5 @@
 #include "inpututils.h"
 
-#define STR1(x)  #x
-#define STR(x)  STR1(x)
-
 #include "qcoreapplication.h"
 #include "qgsgeometrycollection.h"
 #include "qgslinestring.h"
@@ -266,14 +263,8 @@ QString InputUtils::filesToString( QList<MerginFile> files )
 
 QString InputUtils::appInfo()
 {
-#ifdef INPUT_VERSION
-  QString version = STR( INPUT_VERSION );
-#elif
-  QString version = QStringLiteral( ". unknown" );
-#endif
-  QString info = QString( "%1 v%2; %3 %4" ).arg( QCoreApplication::applicationName() ).arg( QCoreApplication::applicationVersion() )
+  return QString( "%1/%2 (%3/%4)" ).arg( QCoreApplication::applicationName() ).arg( QCoreApplication::applicationVersion() )
                  .arg( QSysInfo::productType() ).arg( QSysInfo::productVersion() );
-  return info;
 }
 
 bool InputUtils::cpDir( const QString &srcPath, const QString &dstPath, bool onlyDiffable )

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1,5 +1,9 @@
 #include "inpututils.h"
 
+#define STR1(x)  #x
+#define STR(x)  STR1(x)
+
+#include "qcoreapplication.h"
 #include "qgsgeometrycollection.h"
 #include "qgslinestring.h"
 #include "qgspolygon.h"
@@ -258,6 +262,18 @@ QString InputUtils::filesToString( QList<MerginFile> files )
     resultList << file.path;
   }
   return resultList.join( ", " );
+}
+
+QString InputUtils::appInfo()
+{
+#ifdef INPUT_VERSION
+  QString version = STR( INPUT_VERSION );
+#elif
+  QString version = QStringLiteral( ". unknown" );
+#endif
+  QString info = QString( "%1 v%2; %3 %4" ).arg( QCoreApplication::applicationName() ).arg( QCoreApplication::applicationVersion() )
+                 .arg( QSysInfo::productType() ).arg( QSysInfo::productVersion() );
+  return info;
 }
 
 bool InputUtils::cpDir( const QString &srcPath, const QString &dstPath, bool onlyDiffable )

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -70,6 +70,8 @@ class InputUtils: public QObject
 
     static QString filesToString( QList<MerginFile> files );
 
+    static QString appInfo();
+
   signals:
     Q_INVOKABLE void showNotificationRequested( const QString &message );
 

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -705,7 +705,7 @@ QNetworkReply *MerginApi::getProjectInfo( const QString &projectFullName, bool w
   QUrl url( mApiRoot + QStringLiteral( "/v1/project/%1" ).arg( projectFullName ) );
   url.setQuery( query );
 
-  QNetworkRequest request = getDefaultRequest(!withoutAuth);
+  QNetworkRequest request = getDefaultRequest( !withoutAuth );
   request.setUrl( url );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
 

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -473,6 +473,8 @@ class MerginApi: public QObject
     //! Starts download request of another item
     void downloadNextItem( const QString &projectFullName );
 
+    QNetworkRequest getDefaultRequest( bool withAuth = true );
+
     QNetworkAccessManager mManager;
     QString mApiRoot;
     LocalProjectsManager &mLocalProjects;


### PR DESCRIPTION
Default request constructor with custom agent header and optional auth.
Sample: "Input/0.4.90; (osx/10.14)"

closes #490 