### PR TITLE
Bug/digitizing z coord

### DIFF
--- a/app/digitizingcontroller.cpp
+++ b/app/digitizingcontroller.cpp
@@ -132,23 +132,23 @@ bool DigitizingController::hasEnoughPoints() const
 
 bool DigitizingController::useGpsPoint() const
 {
-    return mUseGpsPoint;
+  return mUseGpsPoint;
 }
 
-void DigitizingController::setUseGpsPoint(bool useGpsPoint)
+void DigitizingController::setUseGpsPoint( bool useGpsPoint )
 {
-    mUseGpsPoint = useGpsPoint;
-    emit useGpsPointChanged();
+  mUseGpsPoint = useGpsPoint;
+  emit useGpsPointChanged();
 }
 
 bool DigitizingController::manualRecording() const
 {
-    return mManualRecording;
+  return mManualRecording;
 }
 
 void DigitizingController::setManualRecording( bool manualRecording )
 {
-    mManualRecording = manualRecording;
+  mManualRecording = manualRecording;
   emit manualRecordingChanged();
 }
 
@@ -174,11 +174,14 @@ QgsQuickFeatureLayerPair DigitizingController::pointFeatureFromPoint( const QgsP
   }
 
   QgsPoint *mapPoint = nullptr;
-  if (isGpsPoint) {
-      mapPoint = new QgsPoint( point );
-  } else {
-      QgsPointXY layerPoint = mMapSettings->mapSettings().mapToLayerCoordinates( featureLayerPair().layer(), QgsPointXY( point.x(), point.y() ) );
-      mapPoint = new QgsPoint( layerPoint );
+  if ( isGpsPoint )
+  {
+    mapPoint = new QgsPoint( point );
+  }
+  else
+  {
+    QgsPointXY layerPoint = mMapSettings->mapSettings().mapToLayerCoordinates( featureLayerPair().layer(), QgsPointXY( point.x(), point.y() ) );
+    mapPoint = new QgsPoint( layerPoint );
   }
   fixZ( mapPoint );
   QgsGeometry geom( mapPoint );
@@ -294,12 +297,15 @@ void DigitizingController::addRecordPoint( const QgsPoint &point, bool isGpsPoin
   if ( !mRecording )
     return;
 
-   QgsPoint layerPoint;
-  if (isGpsPoint) {
-      layerPoint = QgsPoint( point );
-  } else {
-      QgsPointXY layerPointXY = mMapSettings->mapSettings().mapToLayerCoordinates( featureLayerPair().layer(), QgsPointXY( point.x(), point.y() ) );
-      layerPoint = QgsPoint( layerPointXY );
+  QgsPoint layerPoint;
+  if ( isGpsPoint )
+  {
+    layerPoint = QgsPoint( point );
+  }
+  else
+  {
+    QgsPointXY layerPointXY = mMapSettings->mapSettings().mapToLayerCoordinates( featureLayerPair().layer(), QgsPointXY( point.x(), point.y() ) );
+    layerPoint = QgsPoint( layerPointXY );
   }
 
   fixZ( &layerPoint );

--- a/app/digitizingcontroller.cpp
+++ b/app/digitizingcontroller.cpp
@@ -173,16 +173,15 @@ QgsQuickFeatureLayerPair DigitizingController::pointFeatureFromPoint( const QgsP
     return QgsQuickFeatureLayerPair();
   }
 
-  QgsGeometry geom;
+  QgsPoint *mapPoint = nullptr;
   if (isGpsPoint) {
-      QgsPoint *mapPoint = new QgsPoint( point );
-      geom = QgsGeometry( mapPoint );
+      mapPoint = new QgsPoint( point );
   } else {
       QgsPointXY layerPoint = mMapSettings->mapSettings().mapToLayerCoordinates( featureLayerPair().layer(), QgsPointXY( point.x(), point.y() ) );
-      QgsPoint *mapPoint = new QgsPoint( layerPoint );
-      fixZ( mapPoint );
-      geom = QgsGeometry( mapPoint );
+      mapPoint = new QgsPoint( layerPoint );
   }
+  fixZ( mapPoint );
+  QgsGeometry geom( mapPoint );
 
   QgsAttributes attrs( featureLayerPair().layer()->fields().count() );
   QgsExpressionContext context = featureLayerPair().layer()->createExpressionContext();

--- a/app/digitizingcontroller.cpp
+++ b/app/digitizingcontroller.cpp
@@ -298,10 +298,9 @@ QgsPoint DigitizingController::pointFeatureMapCoordinates( QgsQuickFeatureLayerP
   return QgsPoint( res );
 }
 
-QgsQuickFeatureLayerPair DigitizingController::changePointGeometry( QgsQuickFeatureLayerPair pair, QgsPoint point )
+QgsQuickFeatureLayerPair DigitizingController::changePointGeometry( QgsQuickFeatureLayerPair pair, QgsPoint point, bool isGpsPoint )
 {
-  QgsGeometry geom = getPointGeometry( point, false );
-
+  QgsGeometry geom = getPointGeometry( point, isGpsPoint );
   pair.featureRef().setGeometry( geom );
   return pair;
 }

--- a/app/digitizingcontroller.cpp
+++ b/app/digitizingcontroller.cpp
@@ -77,33 +77,26 @@ bool DigitizingController::isPairValid( QgsQuickFeatureLayerPair pair ) const
   return pair.isValid() && hasEnoughPoints();
 }
 
-void DigitizingController::fixZ( std::unique_ptr<QgsPoint> &point ) const
+void DigitizingController::fixZ( QgsPoint &point ) const
 {
-  Q_ASSERT( point );
-
   if ( !featureLayerPair().layer() )
     return;
 
   bool layerIs3D = QgsWkbTypes::hasZ( featureLayerPair().layer()->wkbType() );
-  bool pointIs3D = QgsWkbTypes::hasZ( point->wkbType() );
+  bool pointIs3D = QgsWkbTypes::hasZ( point.wkbType() );
 
-
-  QgsWkbTypes::GeometryType faeetureType = featureLayerPair().feature().geometry().type();
-  QgsWkbTypes::GeometryType layerType = featureLayerPair().layer()->geometryType();
-
-  qDebug() << "!!!!!COMPATE TYPES !!!!" << faeetureType << layerType;
   if ( layerIs3D )
   {
     if ( !pointIs3D )
     {
-      point->addZValue();
+      point.addZValue();
     }
   }
   else /* !layerIs3D */
   {
     if ( pointIs3D )
     {
-      point->dropZValue();
+      point.dropZValue();
     }
   }
 }
@@ -187,7 +180,7 @@ std::unique_ptr<QgsPoint> DigitizingController::getLayerPoint( const QgsPoint &p
     QgsPointXY layerPointXY = mMapSettings->mapSettings().mapToLayerCoordinates( featureLayerPair().layer(), QgsPointXY( point.x(), point.y() ) );
     layerPoint = std::unique_ptr<QgsPoint>( new QgsPoint( layerPointXY ) );
   }
-  fixZ( layerPoint );
+  fixZ( *layerPoint );
 
   return layerPoint;
 }

--- a/app/digitizingcontroller.h
+++ b/app/digitizingcontroller.h
@@ -24,6 +24,7 @@ class DigitizingController : public QObject
     Q_PROPERTY( QgsQuickPositionKit *positionKit READ positionKit WRITE setPositionKit NOTIFY positionKitChanged )
     Q_PROPERTY( QgsQuickAttributeModel *recordingFeatureModel READ recordingFeatureModel NOTIFY recordingFeatureModelChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings MEMBER mMapSettings NOTIFY mapSettingsChanged )
+    Q_PROPERTY( bool useGpsPoint MEMBER mUseGpsPoint NOTIFY useGpsPointChanged )
 
   public:
     explicit DigitizingController( QObject *parent = nullptr );
@@ -43,7 +44,7 @@ class DigitizingController : public QObject
     Q_INVOKABLE bool isPairValid( QgsQuickFeatureLayerPair pair ) const;
 
     //! Creates a new QgsFeature with point geometry from the given point with map coordinates.
-    Q_INVOKABLE QgsQuickFeatureLayerPair pointFeatureFromPoint( const QgsPoint &point );
+    Q_INVOKABLE QgsQuickFeatureLayerPair pointFeatureFromPoint( const QgsPoint &point, bool isGpsPoint );
     //! Creates a new QgsFeature with line/polygon geometry from the points stored since the start of recording
     Q_INVOKABLE QgsQuickFeatureLayerPair lineOrPolygonFeature();
     //! Returns (point geom) featurePair coords in map coordinates.
@@ -51,7 +52,7 @@ class DigitizingController : public QObject
     //! Changes point geometry of given pair according given point.
     Q_INVOKABLE QgsQuickFeatureLayerPair changePointGeometry( QgsQuickFeatureLayerPair pair, QgsPoint point );
 
-    Q_INVOKABLE void addRecordPoint( const QgsPoint &point );
+    Q_INVOKABLE void addRecordPoint( const QgsPoint &point, bool isGpsPoint );
     Q_INVOKABLE void removeLastPoint();
 
     Q_INVOKABLE void startRecording();
@@ -66,7 +67,10 @@ class DigitizingController : public QObject
     bool manualRecording() const;
     void setManualRecording( bool manualRecording );
 
-  signals:
+    bool useGpsPoint() const;
+    void setUseGpsPoint(bool useGpsPoint);
+
+signals:
     void layerChanged();
     void recordingChanged();
     void manualRecordingChanged();
@@ -74,6 +78,7 @@ class DigitizingController : public QObject
     void recordingFeatureModelChanged();
     void mapSettingsChanged();
     void lineRecordingIntervalChanged();
+    void useGpsPointChanged();
 
   private slots:
     void onPositionChanged();
@@ -95,6 +100,7 @@ class DigitizingController : public QObject
     QgsQuickMapSettings *mMapSettings = nullptr;
     int mLineRecordingInterval = 3; // in seconds
     QDateTime mLastTimeRecorded;
+    bool mUseGpsPoint = false;
 };
 
 #endif // DIGITIZINGCONTROLLER_H

--- a/app/digitizingcontroller.h
+++ b/app/digitizingcontroller.h
@@ -24,6 +24,7 @@ class DigitizingController : public QObject
     Q_PROPERTY( QgsQuickPositionKit *positionKit READ positionKit WRITE setPositionKit NOTIFY positionKitChanged )
     Q_PROPERTY( QgsQuickAttributeModel *recordingFeatureModel READ recordingFeatureModel NOTIFY recordingFeatureModelChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings MEMBER mMapSettings NOTIFY mapSettingsChanged )
+    //! If True, recorded point is from GPS and contains z-coord
     Q_PROPERTY( bool useGpsPoint MEMBER mUseGpsPoint NOTIFY useGpsPointChanged )
 
   public:
@@ -59,7 +60,7 @@ class DigitizingController : public QObject
     Q_INVOKABLE void stopRecording();
     bool isRecording() const { return mRecording; }
 
-    QgsPoint *getLayerPoint( const QgsPoint &point, bool isGpsPoint );
+    std::unique_ptr<QgsPoint> getLayerPoint( const QgsPoint &point, bool isGpsPoint );
     QgsGeometry getPointGeometry( const QgsPoint &point, bool isGpsPoint );
     QgsQuickFeatureLayerPair createFeatureLayerPair( const QgsGeometry &geometry );
     QgsQuickAttributeModel *recordingFeatureModel() const { return mRecordingModel; }
@@ -87,7 +88,7 @@ class DigitizingController : public QObject
     void onPositionChanged();
 
   private:
-    void fixZ( QgsPoint *point ) const; // add/remove Z coordinate based on layer wkb type
+    void fixZ( std::unique_ptr<QgsPoint> &point ) const; // add/remove Z coordinate based on layer wkb type
     QgsCoordinateTransform transformer() const;
     QgsQuickFeatureLayerPair lineFeature();
     QgsQuickFeatureLayerPair polygonFeature();

--- a/app/digitizingcontroller.h
+++ b/app/digitizingcontroller.h
@@ -68,9 +68,9 @@ class DigitizingController : public QObject
     void setManualRecording( bool manualRecording );
 
     bool useGpsPoint() const;
-    void setUseGpsPoint(bool useGpsPoint);
+    void setUseGpsPoint( bool useGpsPoint );
 
-signals:
+  signals:
     void layerChanged();
     void recordingChanged();
     void manualRecordingChanged();

--- a/app/digitizingcontroller.h
+++ b/app/digitizingcontroller.h
@@ -52,6 +52,10 @@ class DigitizingController : public QObject
     //! Changes point geometry of given pair according given point.
     Q_INVOKABLE QgsQuickFeatureLayerPair changePointGeometry( QgsQuickFeatureLayerPair pair, QgsPoint point );
 
+    QgsPoint *getLayerPoint( const QgsPoint &point, bool isGpsPoint );
+    QgsGeometry getPointGeometry( const QgsPoint &point, bool isGpsPoint );
+    QgsQuickFeatureLayerPair createFeatureLayerPair( const QgsGeometry &geometry );
+
     Q_INVOKABLE void addRecordPoint( const QgsPoint &point, bool isGpsPoint );
     Q_INVOKABLE void removeLastPoint();
 

--- a/app/digitizingcontroller.h
+++ b/app/digitizingcontroller.h
@@ -50,11 +50,7 @@ class DigitizingController : public QObject
     //! Returns (point geom) featurePair coords in map coordinates.
     Q_INVOKABLE QgsPoint pointFeatureMapCoordinates( QgsQuickFeatureLayerPair pair );
     //! Changes point geometry of given pair according given point.
-    Q_INVOKABLE QgsQuickFeatureLayerPair changePointGeometry( QgsQuickFeatureLayerPair pair, QgsPoint point );
-
-    QgsPoint *getLayerPoint( const QgsPoint &point, bool isGpsPoint );
-    QgsGeometry getPointGeometry( const QgsPoint &point, bool isGpsPoint );
-    QgsQuickFeatureLayerPair createFeatureLayerPair( const QgsGeometry &geometry );
+    Q_INVOKABLE QgsQuickFeatureLayerPair changePointGeometry( QgsQuickFeatureLayerPair pair, QgsPoint point, bool isGpsPoint );
 
     Q_INVOKABLE void addRecordPoint( const QgsPoint &point, bool isGpsPoint );
     Q_INVOKABLE void removeLastPoint();
@@ -63,6 +59,9 @@ class DigitizingController : public QObject
     Q_INVOKABLE void stopRecording();
     bool isRecording() const { return mRecording; }
 
+    QgsPoint *getLayerPoint( const QgsPoint &point, bool isGpsPoint );
+    QgsGeometry getPointGeometry( const QgsPoint &point, bool isGpsPoint );
+    QgsQuickFeatureLayerPair createFeatureLayerPair( const QgsGeometry &geometry );
     QgsQuickAttributeModel *recordingFeatureModel() const { return mRecordingModel; }
 
     int lineRecordingInterval() const;

--- a/app/digitizingcontroller.h
+++ b/app/digitizingcontroller.h
@@ -88,7 +88,7 @@ class DigitizingController : public QObject
     void onPositionChanged();
 
   private:
-    void fixZ( std::unique_ptr<QgsPoint> &point ) const; // add/remove Z coordinate based on layer wkb type
+    void fixZ( QgsPoint &point ) const; // add/remove Z coordinate based on layer wkb type
     QgsCoordinateTransform transformer() const;
     QgsQuickFeatureLayerPair lineFeature();
     QgsQuickFeatureLayerPair polygonFeature();

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -112,41 +112,23 @@ ApplicationWindow {
     }
 
     function recordFeature() {
-      // digitizing.manualRecording @???
-        //if (digitizing.useGpsPoint) {
-      console.log("Point with Z!±!±±±!@#!#@", digitizing.useGpsPoint)
-        if (digitizing.useGpsPoint) {
+      var pointToAdd
+      if (digitizing.useGpsPoint) {
+         pointToAdd = positionKit.projectedPosition
+      } else {
+        var screenPoint = Qt.point( mapCanvas.width/2, mapCanvas.height/2 )
+        pointToAdd = mapCanvas.mapSettings.screenToCoordinate(screenPoint)
+      }
 
-          if (digitizing.hasPointGeometry(__layersModel.activeLayer())) {
-              var pair = digitizing.pointFeatureFromPoint(positionKit.projectedPosition, true)
-              saveRecordedFeature(pair)
-          } else {
-            if (!digitizing.recording) {
-                digitizing.startRecording()
-                digitizing.useGpsPoint = true  // TODO @vsklencar move to cpp
-            }
-            digitizing.addRecordPoint(positionKit.projectedPosition, true)
+      if (digitizing.hasPointGeometry(__layersModel.activeLayer())) {
+          var pair = digitizing.pointFeatureFromPoint(pointToAdd, digitizing.useGpsPoint)
+          saveRecordedFeature(pair)
+      } else {
+          if (!digitizing.recording) {
+              digitizing.startRecording()
           }
-        }
-
-
-        else {
-          var screenPoint = Qt.point( mapCanvas.width/2, mapCanvas.height/2 )
-          var centerPoint = mapCanvas.mapSettings.screenToCoordinate(screenPoint)
-
-          if (digitizing.hasPointGeometry(__layersModel.activeLayer())) {
-              var pair = digitizing.pointFeatureFromPoint(centerPoint, false)
-              saveRecordedFeature(pair)
-          } else {
-              if (!digitizing.recording) {
-                  digitizing.startRecording()
-                  digitizing.useGpsPoint = true  // TODO @vsklencar move to cpp
-              }
-              digitizing.addRecordPoint(centerPoint, false)
-          }
-        }
-
-
+          digitizing.addRecordPoint(pointToAdd, digitizing.useGpsPoint)
+      }
     }
 
     function getGpsIndicatorColor() {
@@ -338,11 +320,10 @@ ApplicationWindow {
       simulatePositionLongLatRad: __use_simulated_position ? [-2.9207148, 51.3624998, 0.05] : []
 
       onScreenPositionChanged: {
-        if (__appSettings.autoCenterMapChecked) {
-          var border = mainPanel.height
-          if (isPositionOutOfExtent(border)) {
+        if (digitizing.useGpsPoint || (__appSettings.autoCenterMapChecked && isPositionOutOfExtent(mainPanel.height))) {
+            var useGpsPoint = digitizing.useGpsPoint
             mapCanvas.mapSettings.setCenter(positionKit.projectedPosition);
-          }
+            digitizing.useGpsPoint = useGpsPoint
         }
       }
     }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -114,10 +114,10 @@ ApplicationWindow {
     function recordFeature() {
       var pointToAdd
       if (digitizing.useGpsPoint) {
-         pointToAdd = positionKit.projectedPosition
+         pointToAdd = positionKit.position  // WGS84
       } else {
         var screenPoint = Qt.point( mapCanvas.width/2, mapCanvas.height/2 )
-        pointToAdd = mapCanvas.mapSettings.screenToCoordinate(screenPoint)
+        pointToAdd = mapCanvas.mapSettings.screenToCoordinate(screenPoint)  // map CRS
       }
 
       if (digitizing.hasPointGeometry(__layersModel.activeLayer())) {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -322,6 +322,7 @@ ApplicationWindow {
         if (digitizing.useGpsPoint || (__appSettings.autoCenterMapChecked && isPositionOutOfExtent(mainPanel.height))) {
             var useGpsPoint = digitizing.useGpsPoint
             mapCanvas.mapSettings.setCenter(positionKit.projectedPosition);
+            // sets previous useGpsPoint value, because setCenter triggers extentChanged signal which changes this property
             digitizing.useGpsPoint = useGpsPoint
         }
       }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -84,7 +84,7 @@ ApplicationWindow {
             popup.open()
         }
         stateManager.state = "view"
-        digitizing.useGpsPoint = false  // TODO @vsklendar move to cpp??
+        digitizing.useGpsPoint = false
     }
 
 
@@ -438,7 +438,7 @@ ApplicationWindow {
             digitizing.manualRecording = !digitizing.manualRecording
             if (!digitizing.manualRecording && stateManager.state === "record") {
                 digitizing.startRecording()
-                digitizing.useGpsPoint = true  // TODO @vsklencar move to cpp
+                digitizing.useGpsPoint = true
             }
         }
 


### PR DESCRIPTION
Z coord recording is activated either immediately when entering record mode or after clicking on GPS icon on record toolbar. It is disabled after manual move of extent.
Crosshair is sticked with GPS marker while z coord recording is enabled.

closes #286 