### PR TITLE
Fix of stuck context menu at the bottom [iOS]

### DIFF
--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -441,8 +441,7 @@ Item {
         id: contextMenu
         height: (projectNamespace && projectName) ? menuItemHeight * 2 : menuItemHeight
         width:Math.min( parent.width, 300 * QgsQuick.Utils.dp )
-        modal: true
-        dim: false
+        leftMargin: Math.max(parent.width - (width + projectsPanel.rowHeight), 0)
 
         MenuItem {
           height:  (projectNamespace && projectName) ? contextMenu.menuItemHeight : 0
@@ -481,7 +480,7 @@ Item {
         projectsPanel.visible = false
       }
 
-      onMenuClicked:contextMenu.popup()
+      onMenuClicked:contextMenu.open()
     }
   }
 

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -441,7 +441,16 @@ Item {
         id: contextMenu
         height: (projectNamespace && projectName) ? menuItemHeight * 2 : menuItemHeight
         width:Math.min( parent.width, 300 * QgsQuick.Utils.dp )
-        leftMargin: Math.max(parent.width - (width + projectsPanel.rowHeight), 0)
+        leftMargin: Math.max(parent.width - width, 0)
+
+        //! sets y-offset either above or below related item according relative position to end of the list
+        onAboutToShow: {
+          var itemRelativeY = parent.y - grid.contentY
+          if (itemRelativeY + contextMenu.height >= grid.height)
+            contextMenu.y = -contextMenu.height
+          else
+            contextMenu.y = parent.height
+        }
 
         MenuItem {
           height:  (projectNamespace && projectName) ? contextMenu.menuItemHeight : 0


### PR DESCRIPTION
Sets y-offset of context menu. Takes into consideration relative y value of the parent item to show it either below or above the related item if there is no space.

Tested on iOS and Android with long project list.
closes #540 

Examples of context menu related to `gallery_test`. 
![IMG_0023](https://user-images.githubusercontent.com/6735606/80498429-fef20000-896b-11ea-832a-b714eb4686ac.PNG)
![IMG_0024](https://user-images.githubusercontent.com/6735606/80498437-01ecf080-896c-11ea-90b8-5987e9befdf8.PNG)



