### PR TITLE
Zoom to WMS Extent

### DIFF
--- a/app/loader.cpp
+++ b/app/loader.cpp
@@ -111,17 +111,32 @@ void Loader::zoomToProject( QgsQuickMapSettings *mapSettings )
 {
   if ( !mapSettings )
   {
-    qDebug() << "Cannot zoom to layers extent, mapSettings is not defined";
+    qDebug() << "Cannot zoom to extent, mapSettings is not defined";
     return;
   }
-
-  const QVector<QgsMapLayer *> layers = mProject->layers<QgsMapLayer *>();
   QgsRectangle extent;
-  for ( const QgsMapLayer *layer : layers )
+
+  // Check if WMSExtent is set in project
+  bool hasWMS;
+  QStringList WMSExtent = mProject->readListEntry( "WMSExtent", QStringLiteral( "/" ), QStringList(), &hasWMS );
+
+  if ( hasWMS && ( WMSExtent.length() == 4 ) )
   {
-    QgsRectangle layerExtent = mapSettings->mapSettings().layerExtentToOutputExtent( layer, layer->extent() );
-    extent.combineExtentWith( layerExtent );
+    extent.setXMinimum(WMSExtent[0].toDouble());
+    extent.setYMinimum(WMSExtent[1].toDouble());
+    extent.setXMaximum(WMSExtent[2].toDouble());
+    extent.setYMaximum(WMSExtent[3].toDouble());
   }
+  else // set layers extent
+  {
+    const QVector<QgsMapLayer *> layers = mProject->layers<QgsMapLayer *>();
+    for ( const QgsMapLayer *layer : layers )
+    {
+      QgsRectangle layerExtent = mapSettings->mapSettings().layerExtentToOutputExtent( layer, layer->extent() );
+      extent.combineExtentWith( layerExtent );
+    }
+  }
+
   if ( extent.isEmpty() )
   {
     extent.grow( mProject->crs().isGeographic() ? 0.01 : 1000.0 );

--- a/app/loader.cpp
+++ b/app/loader.cpp
@@ -122,10 +122,7 @@ void Loader::zoomToProject( QgsQuickMapSettings *mapSettings )
 
   if ( hasWMS && ( WMSExtent.length() == 4 ) )
   {
-    extent.setXMinimum(WMSExtent[0].toDouble());
-    extent.setYMinimum(WMSExtent[1].toDouble());
-    extent.setXMaximum(WMSExtent[2].toDouble());
-    extent.setYMaximum(WMSExtent[3].toDouble());
+    extent.set( WMSExtent[0].toDouble(), WMSExtent[1].toDouble(), WMSExtent[2].toDouble(), WMSExtent[3].toDouble() );
   }
   else // set layers extent
   {

--- a/docs/users/project_config.md
+++ b/docs/users/project_config.md
@@ -24,6 +24,11 @@ If you are using a vector layer for background layer:
 
 -   All vector layers not intended to be used as survey layers, have to be set as read-only. To make a vector layer read-only in QGIS, from the main menu select Project \> Properties. Within the window, select Data Source tab and select the Read-only option for the layers you do not want to be used as survey layer in Input.
 
+## Project extent
+In Input app, there is an option to zoom to the project extent. If not set, Input zooms to all visible layers. This is not particularly convenient when you have a layer with a large/global extent (e.g. Open Street Map).
+
+To set the project extent: from **Project** > **Properties**, select **QGIS Server** (not the most obvious location!). Under **WMS capabilities** select the option for **Advertised extent** and either enter the coordinate extent of your project bounding box or use the canvas extent.
+
 ## Survey layer
 
 Vector layers can be used as survey layer


### PR DESCRIPTION
#577

If user specifies WMS Extent inside QGIS, `Zoom to project` in input automatically zooms to this extent, no longer to the entire project. If WMS Extent is not provided, behaviour stays the same - zoom to entire project.

Can be tested with this project: https://public.cloudmergin.com/projects/tomas/SlovakiaTrees/tree

![ezgif com-optimize](https://user-images.githubusercontent.com/22449698/82909826-15d74280-9f6a-11ea-9587-5b7cd4733b0e.gif)
