### PR TITLE
Add different text for multiple projects

### DIFF
--- a/app/localprojectsmanager.cpp
+++ b/app/localprojectsmanager.cpp
@@ -31,12 +31,12 @@ static QString findQgisProjectFile( const QString &projectDir, QString &err )
   else if ( foundProjectFiles.count() > 1 )
   {
     // error: multiple project files found
-    err = QString( "ERR_MULTIPLE_PROJECTS" );
+    err = QObject::tr( "Error: Multiple QGIS project files" );
   }
   else
   {
     // no projects
-    err = QString( "ERR_NO_PROJECTS" );
+    err = QObject::tr( "Error: Missing QGIS project file" );
   }
   return QString();
 }
@@ -49,11 +49,8 @@ LocalProjectsManager::LocalProjectsManager( const QString &dataDir )
   for ( QString folderName : entryList )
   {
     LocalProjectInfo info;
-    QString err;
     info.projectDir = mDataDir + "/" + folderName;
-    info.qgisProjectFilePath = findQgisProjectFile( info.projectDir, err );
-    if ( !err.isEmpty() )
-      info.setprojectFileError( err );
+    info.qgisProjectFilePath = findQgisProjectFile( info.projectDir, info.qgisProjectError );
 
     MerginProjectMetadata metadata = MerginProjectMetadata::fromCachedJson( info.projectDir + "/" + MerginApi::sMetadataFile );
     if ( metadata.isValid() )
@@ -122,11 +119,8 @@ void LocalProjectsManager::updateProjectStatus( const QString &projectDir )
 void LocalProjectsManager::addMerginProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName )
 {
   LocalProjectInfo project;
-  QString err;
   project.projectDir = projectDir;
-  project.qgisProjectFilePath = findQgisProjectFile( projectDir, err );
-  if ( !err.isEmpty() )
-    project.setprojectFileError( err );
+  project.qgisProjectFilePath = findQgisProjectFile( projectDir, project.qgisProjectError );
   project.projectNamespace = projectNamespace;
   project.projectName = projectName;
   // version info and status should be updated afterwards

--- a/app/localprojectsmanager.cpp
+++ b/app/localprojectsmanager.cpp
@@ -29,9 +29,9 @@ static QString findQgisProjectFile( const QString &projectDir )
     return foundProjectFiles.first();
   }
   else if ( foundProjectFiles.count() > 1 ) // multiple projects
-    return QString( "ERR:-2" );
+    return QString( "ERR_MULTIPLE_PROJECTS" );
   else // no projects
-    return QString( "ERR:-1" );
+    return QString( "ERR_NO_PROJECTS" );
 }
 
 

--- a/app/localprojectsmanager.cpp
+++ b/app/localprojectsmanager.cpp
@@ -28,7 +28,10 @@ static QString findQgisProjectFile( const QString &projectDir )
   {
     return foundProjectFiles.first();
   }
-  return QString();
+  else if ( foundProjectFiles.count() > 1 ) // multiple projects
+    return QString( "ERR:-2" );
+  else // no projects
+    return QString( "ERR:-1" );
 }
 
 

--- a/app/localprojectsmanager.h
+++ b/app/localprojectsmanager.h
@@ -28,9 +28,16 @@ struct LocalProjectInfo
 {
   bool isValid() const { return !projectDir.isEmpty(); }
 
+  void setprojectFileError( const QString error ) { projectError = error; }
+
+  bool isShowable() const { return projectError.isEmpty(); }
+
   QString projectDir;  //!< full path to the project directory
 
   QString qgisProjectFilePath;  //!< path to the .qgs/.qgz file (or empty if not have exactly one such file)
+
+  QString projectError; //!< If project is invalid, projectError carry more information why
+  // TODO: reset when project is synchronized
 
   //
   // mergin-specific project info (may be empty)

--- a/app/localprojectsmanager.h
+++ b/app/localprojectsmanager.h
@@ -28,15 +28,13 @@ struct LocalProjectInfo
 {
   bool isValid() const { return !projectDir.isEmpty(); }
 
-  void setprojectFileError( const QString error ) { projectError = error; }
-
-  bool isShowable() const { return projectError.isEmpty(); }
+  bool isShowable() const { return qgisProjectError.isEmpty(); }
 
   QString projectDir;  //!< full path to the project directory
 
   QString qgisProjectFilePath;  //!< path to the .qgs/.qgz file (or empty if not have exactly one such file)
 
-  QString projectError; //!< If project is invalid, projectError carry more information why
+  QString qgisProjectError; //!< If project is invalid, projectError carry more information why
   // TODO: reset when project is synchronized
 
   //

--- a/app/positiondirection.h
+++ b/app/positiondirection.h
@@ -19,7 +19,7 @@
 
 
 /**
- * Utility class containing infortmation about the direction. Note that depends on availibility of sensors and their data.
+ * Utility class containing information about the direction. Note that depends on availibility of sensors and their data.
  *
  * Updates direction periodicly according timer while filtering small difference values between old and new direction angle.
  * Uses ground speed (in m/s) to select which direction source will be used - compass for smaller speed whereas positionKit direction

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -60,7 +60,7 @@ void ProjectModel::findProjectFiles()
       else if ( project.projectError.contains( "ERR_MULTIPLE_PROJECTS" ) )
         projectFile.info = tr( "Error: Multiple QGIS project files" );
       else
-        projectFile.info = tr("Invalid project");
+        projectFile.info = tr( "Invalid project" );
     }
     mProjectFiles << projectFile;
   }

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -47,20 +47,20 @@ void ProjectModel::findProjectFiles()
     projectFile.folderName = dir.dirName();
     projectFile.projectName = project.projectName;
     projectFile.projectNamespace = project.projectNamespace;
+    projectFile.isValid = project.isShowable();
     QDateTime created = fi.created().toUTC();   // TODO: why UTC ???
-    if ( !project.qgisProjectFilePath.startsWith( "ERR" ) )
+    if ( projectFile.isValid )
     {
       projectFile.info = QString( created.toString() );
-      projectFile.isValid = true;
     }
     else
     {
-      if ( project.qgisProjectFilePath.contains( "ERR_NO_PROJECTS" ) )
+      if ( project.projectError.contains( "ERR_NO_PROJECTS" ) )
         projectFile.info = tr( "Error: Missing QGIS project file" );
-      else if ( project.qgisProjectFilePath.contains( "ERR_MULTIPLE_PROJECTS" ) )
+      else if ( project.projectError.contains( "ERR_MULTIPLE_PROJECTS" ) )
         projectFile.info = tr( "Error: Multiple QGIS project files" );
-
-      projectFile.isValid = false;
+      else
+        projectFile.info = tr("Invalid project");
     }
     mProjectFiles << projectFile;
   }

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -55,9 +55,9 @@ void ProjectModel::findProjectFiles()
     }
     else
     {
-      if ( project.qgisProjectFilePath.contains( "-1" ) )
+      if ( project.qgisProjectFilePath.contains( "ERR_NO_PROJECTS" ) )
         projectFile.info = tr( "Error: Missing QGIS project file" );
-      else if ( project.qgisProjectFilePath.contains( "-2" ) )
+      else if ( project.qgisProjectFilePath.contains( "ERR_MULTIPLE_PROJECTS" ) )
         projectFile.info = tr( "Error: Multiple QGIS project files" );
 
       projectFile.isValid = false;

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -56,7 +56,7 @@ void ProjectModel::findProjectFiles()
     else
     {
       if ( project.qgisProjectFilePath.contains( "-1" ) )
-        projectFile.info = tr( "Missing QGIS project file" );
+        projectFile.info = tr( "Error: Missing QGIS project file" );
       else if ( project.qgisProjectFilePath.contains( "-2" ) )
         projectFile.info = tr( "Error: Multiple QGIS project files" );
 

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -48,14 +48,18 @@ void ProjectModel::findProjectFiles()
     projectFile.projectName = project.projectName;
     projectFile.projectNamespace = project.projectNamespace;
     QDateTime created = fi.created().toUTC();   // TODO: why UTC ???
-    if ( !project.qgisProjectFilePath.isEmpty() )
+    if ( !project.qgisProjectFilePath.startsWith( "ERR" ) )
     {
       projectFile.info = QString( created.toString() );
       projectFile.isValid = true;
     }
     else
     {
-      projectFile.info = tr( "Missing QGIS project file" );
+      if ( project.qgisProjectFilePath.contains( "-1" ) )
+        projectFile.info = tr( "Missing QGIS project file" );
+      else if ( project.qgisProjectFilePath.contains( "-2" ) )
+        projectFile.info = tr( "Error: Multiple QGIS project files" );
+
       projectFile.isValid = false;
     }
     mProjectFiles << projectFile;

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -55,12 +55,7 @@ void ProjectModel::findProjectFiles()
     }
     else
     {
-      if ( project.projectError.contains( "ERR_NO_PROJECTS" ) )
-        projectFile.info = tr( "Error: Missing QGIS project file" );
-      else if ( project.projectError.contains( "ERR_MULTIPLE_PROJECTS" ) )
-        projectFile.info = tr( "Error: Multiple QGIS project files" );
-      else
-        projectFile.info = tr( "Invalid project" );
+      projectFile.info = project.qgisProjectError;
     }
     mProjectFiles << projectFile;
   }


### PR DESCRIPTION
An option to make error messages more readable, not only: _invalid project_

![image](https://user-images.githubusercontent.com/22449698/82927098-77a2a700-9f80-11ea-89a6-4aa73eebd37d.png)
