### PR TITLE
Attr table - add/edit features in no geometry layers

### DIFF
--- a/app/digitizingcontroller.cpp
+++ b/app/digitizingcontroller.cpp
@@ -294,6 +294,11 @@ QgsQuickFeatureLayerPair DigitizingController::lineOrPolygonFeature()
   return createFeatureLayerPair( geom );
 }
 
+QgsQuickFeatureLayerPair DigitizingController::featureWithoutGeometry()
+{
+  return createFeatureLayerPair( QgsGeometry() );
+}
+
 QgsPoint DigitizingController::pointFeatureMapCoordinates( QgsQuickFeatureLayerPair pair )
 {
   if ( !pair.layer() )

--- a/app/digitizingcontroller.h
+++ b/app/digitizingcontroller.h
@@ -57,6 +57,8 @@ class DigitizingController : public QObject
     Q_INVOKABLE QgsQuickFeatureLayerPair pointFeatureFromPoint( const QgsPoint &point, bool isGpsPoint );
     //! Creates a new QgsFeature with line/polygon geometry from the points stored since the start of recording
     Q_INVOKABLE QgsQuickFeatureLayerPair lineOrPolygonFeature();
+    //! Creates a new QgsFeature without geometry
+    Q_INVOKABLE QgsQuickFeatureLayerPair featureWithoutGeometry();
     //! Returns (point geom) featurePair coords in map coordinates.
     Q_INVOKABLE QgsPoint pointFeatureMapCoordinates( QgsQuickFeatureLayerPair pair );
     //! Changes point geometry of given pair according given point.

--- a/app/featuresmodel.cpp
+++ b/app/featuresmodel.cpp
@@ -65,7 +65,9 @@ QVariant FeaturesModel::data( const QModelIndex &index, int role ) const
         case QgsWkbTypes::GeometryType::PointGeometry: return QVariant( "mIconPointLayer.svg" );
         case QgsWkbTypes::GeometryType::LineGeometry: return QVariant( "mIconLineLayer.svg" );
         case QgsWkbTypes::GeometryType::PolygonGeometry: return QVariant( "mIconPolygonLayer.svg" );
-        default: return QVariant( "" );
+
+        case QgsWkbTypes::GeometryType::NullGeometry: // fall through
+        case QgsWkbTypes::GeometryType::UnknownGeometry: return QVariant("mIconTableLayer.svg");
       }
     default: return QVariant();
   }
@@ -76,7 +78,7 @@ void FeaturesModel::reloadDataFromLayer( QgsVectorLayer *layer )
   beginResetModel();
   mFeatures.clear();
 
-  const int FEATURES_LIMIT = 100;
+  const int FEATURES_LIMIT = 10000;
 
   if ( layer )
   {
@@ -90,6 +92,11 @@ void FeaturesModel::reloadDataFromLayer( QgsVectorLayer *layer )
     while ( it.nextFeature( f ) )
     {
       mFeatures << QgsQuickFeatureLayerPair( f, layer );
+    }
+
+    if ( layer->featureCount() > FEATURES_LIMIT )
+    {
+      emit tooManyFeaturesInLayer( FEATURES_LIMIT );
     }
   }
 
@@ -122,7 +129,6 @@ QHash<int, QByteArray> FeaturesModel::roleNames() const
   roleNames[FeatureTitle] = QStringLiteral( "FeatureTitle" ).toLatin1();
   roleNames[FeatureId] = QStringLiteral( "FeatureId" ).toLatin1();
   roleNames[Description] = QStringLiteral( "Description" ).toLatin1();
-  roleNames[GeometryType] = QStringLiteral( "GeometryType" ).toLatin1();
   roleNames[IconSource] = QStringLiteral( "IconSource" ).toLatin1();
   return roleNames;
 }

--- a/app/featuresmodel.cpp
+++ b/app/featuresmodel.cpp
@@ -100,6 +100,7 @@ void FeaturesModel::reloadDataFromLayer( QgsVectorLayer *layer )
     }
   }
 
+  emit featuresCountChanged( mFeatures.count() );
   endResetModel();
 }
 
@@ -119,6 +120,8 @@ void FeaturesModel::emptyData()
   beginResetModel();
 
   mFeatures.clear();
+
+  emit featuresCountChanged( mFeatures.size() );
 
   endResetModel();
 }
@@ -149,4 +152,9 @@ Qt::ItemFlags FeaturesModel::flags( const QModelIndex &index ) const
     return Qt::NoItemFlags;
 
   return Qt::ItemIsEditable;
+}
+
+int FeaturesModel::featuresCount() const
+{
+  return mFeatures.size();
 }

--- a/app/featuresmodel.cpp
+++ b/app/featuresmodel.cpp
@@ -155,7 +155,7 @@ int FeaturesModel::featuresCount() const
   return mFeaturesCount;
 }
 
-void FeaturesModel::setFeaturesCount(int count)
+void FeaturesModel::setFeaturesCount( int count )
 {
   mFeaturesCount = count;
 

--- a/app/featuresmodel.cpp
+++ b/app/featuresmodel.cpp
@@ -121,7 +121,7 @@ void FeaturesModel::emptyData()
 
   mFeatures.clear();
 
-  emit featuresCountChanged( mFeatures.size() );
+  emit featuresCountChanged( 0 );
 
   endResetModel();
 }

--- a/app/featuresmodel.cpp
+++ b/app/featuresmodel.cpp
@@ -12,7 +12,8 @@
 
 FeaturesModel::FeaturesModel( Loader &loader, QObject *parent )
   : QAbstractListModel( parent ),
-    mLoader( loader )
+    mLoader( loader ),
+    mFeaturesCount( 0 )
 {
 }
 
@@ -75,10 +76,9 @@ QVariant FeaturesModel::data( const QModelIndex &index, int role ) const
 
 void FeaturesModel::reloadDataFromLayer( QgsVectorLayer *layer )
 {
-  beginResetModel();
-  mFeatures.clear();
+  emptyData();
 
-  const int FEATURES_LIMIT = 10000;
+  beginResetModel();
 
   if ( layer )
   {
@@ -94,13 +94,9 @@ void FeaturesModel::reloadDataFromLayer( QgsVectorLayer *layer )
       mFeatures << QgsQuickFeatureLayerPair( f, layer );
     }
 
-    if ( layer->featureCount() > FEATURES_LIMIT )
-    {
-      emit tooManyFeaturesInLayer( FEATURES_LIMIT );
-    }
+    setFeaturesCount( layer->featureCount() );
   }
 
-  emit featuresCountChanged( mFeatures.count() );
   endResetModel();
 }
 
@@ -121,7 +117,7 @@ void FeaturesModel::emptyData()
 
   mFeatures.clear();
 
-  emit featuresCountChanged( 0 );
+  setFeaturesCount( 0 );
 
   endResetModel();
 }
@@ -156,5 +152,15 @@ Qt::ItemFlags FeaturesModel::flags( const QModelIndex &index ) const
 
 int FeaturesModel::featuresCount() const
 {
-  return mFeatures.size();
+  return mFeaturesCount;
+}
+
+void FeaturesModel::setFeaturesCount(int count)
+{
+  mFeaturesCount = count;
+
+  if ( mFeaturesCount > FEATURES_LIMIT )
+    emit tooManyFeaturesInLayer( FEATURES_LIMIT );
+
+  emit featuresCountChanged( mFeaturesCount );
 }

--- a/app/featuresmodel.cpp
+++ b/app/featuresmodel.cpp
@@ -67,7 +67,7 @@ QVariant FeaturesModel::data( const QModelIndex &index, int role ) const
         case QgsWkbTypes::GeometryType::PolygonGeometry: return QVariant( "mIconPolygonLayer.svg" );
 
         case QgsWkbTypes::GeometryType::NullGeometry: // fall through
-        case QgsWkbTypes::GeometryType::UnknownGeometry: return QVariant("mIconTableLayer.svg");
+        case QgsWkbTypes::GeometryType::UnknownGeometry: return QVariant( "mIconTableLayer.svg" );
       }
     default: return QVariant();
   }

--- a/app/featuresmodel.h
+++ b/app/featuresmodel.h
@@ -74,7 +74,6 @@ class FeaturesModel : public QAbstractListModel
 
     QList<QgsQuickFeatureLayerPair> mFeatures;
     Loader &mLoader;
-    int m_featuresCount;
 };
 
 #endif // FEATURESMODEL_H

--- a/app/featuresmodel.h
+++ b/app/featuresmodel.h
@@ -28,6 +28,8 @@ class FeaturesModel : public QAbstractListModel
 {
     Q_OBJECT
 
+    Q_PROPERTY( int featuresCount READ featuresCount NOTIFY featuresCountChanged )
+
     enum roleNames
     {
       FeatureTitle = Qt::UserRole + 1,
@@ -44,17 +46,20 @@ class FeaturesModel : public QAbstractListModel
     //! Function to get QgsQuickFeatureLayerPair by feature id
     Q_INVOKABLE QgsQuickFeatureLayerPair featureLayerPair( const int &featureId );
 
+    int featuresCount() const;
     int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
     QHash<int, QByteArray> roleNames() const override;
-
 
     bool setData( const QModelIndex &index, const QVariant &value,
                   int role = Qt::EditRole ) override;
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
 
+
   signals:
     void tooManyFeaturesInLayer( int limitCount );
+
+    void featuresCountChanged( int featuresCount );
 
   public slots:
     void reloadDataFromLayer( QgsVectorLayer *layer );
@@ -69,6 +74,7 @@ class FeaturesModel : public QAbstractListModel
 
     QList<QgsQuickFeatureLayerPair> mFeatures;
     Loader &mLoader;
+    int m_featuresCount;
 };
 
 #endif // FEATURESMODEL_H

--- a/app/featuresmodel.h
+++ b/app/featuresmodel.h
@@ -33,7 +33,7 @@ class FeaturesModel : public QAbstractListModel
       FeatureTitle = Qt::UserRole + 1,
       FeatureId,
       Description, // secondary text in list view
-      GeometryType, // type of geometry (point, line, ..)
+      GeometryType,
       IconSource
     };
 
@@ -52,6 +52,9 @@ class FeaturesModel : public QAbstractListModel
     bool setData( const QModelIndex &index, const QVariant &value,
                   int role = Qt::EditRole ) override;
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
+
+signals:
+    void tooManyFeaturesInLayer( int limitCount );
 
   public slots:
     void reloadDataFromLayer( QgsVectorLayer *layer );

--- a/app/featuresmodel.h
+++ b/app/featuresmodel.h
@@ -46,7 +46,6 @@ class FeaturesModel : public QAbstractListModel
     //! Function to get QgsQuickFeatureLayerPair by feature id
     Q_INVOKABLE QgsQuickFeatureLayerPair featureLayerPair( const int &featureId );
 
-    int featuresCount() const;
     int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
     QHash<int, QByteArray> roleNames() const override;
@@ -55,6 +54,9 @@ class FeaturesModel : public QAbstractListModel
                   int role = Qt::EditRole ) override;
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
 
+    //! Features count represents real number of features in layer being browsed
+    int featuresCount() const;
+    void setFeaturesCount( int count );
 
   signals:
     void tooManyFeaturesInLayer( int limitCount );
@@ -74,6 +76,9 @@ class FeaturesModel : public QAbstractListModel
 
     QList<QgsQuickFeatureLayerPair> mFeatures;
     Loader &mLoader;
+    int mFeaturesCount;
+
+    const int FEATURES_LIMIT = 10000;
 };
 
 #endif // FEATURESMODEL_H

--- a/app/featuresmodel.h
+++ b/app/featuresmodel.h
@@ -53,7 +53,7 @@ class FeaturesModel : public QAbstractListModel
                   int role = Qt::EditRole ) override;
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
 
-signals:
+  signals:
     void tooManyFeaturesInLayer( int limitCount );
 
   public slots:

--- a/app/img/mIconTableLayer.svg
+++ b/app/img/mIconTableLayer.svg
@@ -1,0 +1,18 @@
+<svg height="16" width="16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<linearGradient id="a" gradientUnits="userSpaceOnUse" x1="4.5" x2="9.5" y1="2.5" y2="14.5">
+<stop offset="0" stop-color="#f1f1f1"/>
+<stop offset="1" stop-color="#d6d6d6"/>
+</linearGradient>
+<g fill-rule="evenodd" stroke="#888a85" stroke-linecap="round" stroke-linejoin="round" transform="translate(0 -16)">
+<rect fill="url(#a)" height="15" overflow="visible" rx="1" transform="translate(0 16)" width="13" x="1.5" y=".5"/>
+<path d="m1.5 4.5l13 0" fill="#eeeeec" overflow="visible" transform="translate(0 16)"/>
+<path d="m3.5 23.5l2 0" fill="#eeeeec" overflow="visible"/>
+<path d="m3.5 26.5l2 0" fill="#eeeeec" overflow="visible"/>
+<path d="m3.5 29.5l2 0" fill="#eeeeec" overflow="visible"/>
+<path d="m8.5 23.5l4 0" fill="#eeeeec" overflow="visible"/>
+<path d="m8.4378776 26.458275l4.0621224.041725" fill="#eeeeec" overflow="visible"/>
+<path d="m8.5 29.5l4 0" fill="#eeeeec" overflow="visible"/>
+<path d="m3.5710868 2.5057164l1.9289132-.0057164" fill="#eeeeec" overflow="visible" transform="translate(0 16)"/>
+<path d="m8.5 2.5l4 0" fill="#eeeeec" overflow="visible" transform="translate(0 16)"/>
+</g>
+</svg>

--- a/app/img/pics.qrc
+++ b/app/img/pics.qrc
@@ -48,5 +48,6 @@
         <file>database-solid.svg</file>
         <file>ic_today.svg</file>
         <file>exclamation-triangle-solid.svg</file>
+        <file>mIconTableLayer.svg</file>
     </qresource>
 </RCC>

--- a/app/layersmodel.cpp
+++ b/app/layersmodel.cpp
@@ -32,6 +32,7 @@ QVariant LayersModel::data( const QModelIndex &index, int role ) const
   {
     case LayerNameRole: return layer->name();
     case VectorLayerRole: return vectorLayer ? QVariant::fromValue<QgsVectorLayer *>( vectorLayer ) : QVariant();
+    case HasGeometryRole: return vectorLayer ? vectorLayer->wkbType() != QgsWkbTypes::NoGeometry && vectorLayer->wkbType() != QgsWkbTypes::Type::Unknown : QVariant();
     case IconSourceRole:
     {
       if ( vectorLayer )
@@ -42,8 +43,9 @@ QVariant LayersModel::data( const QModelIndex &index, int role ) const
           case QgsWkbTypes::GeometryType::PointGeometry: return "mIconPointLayer.svg";
           case QgsWkbTypes::GeometryType::LineGeometry: return "mIconLineLayer.svg";
           case QgsWkbTypes::GeometryType::PolygonGeometry: return "mIconPolygonLayer.svg";
-          case QgsWkbTypes::GeometryType::UnknownGeometry: return "";
-          case QgsWkbTypes::GeometryType::NullGeometry: return "";
+
+          case QgsWkbTypes::GeometryType::UnknownGeometry: // fall through
+          case QgsWkbTypes::GeometryType::NullGeometry: return "mIconTableLayer.svg";
         }
         return QVariant();
       }
@@ -58,6 +60,7 @@ QHash<int, QByteArray> LayersModel::roleNames() const
   QHash<int, QByteArray> roles = QgsMapLayerModel::roleNames();
   roles[LayerNameRole] = QStringLiteral( "layerName" ).toLatin1();
   roles[IconSourceRole] = QStringLiteral( "iconSource" ).toLatin1();
+  roles[HasGeometryRole] = QStringLiteral( "hasGeometry" ).toLatin1();
   roles[VectorLayerRole] = QStringLiteral( "vectorLayer" ).toLatin1();
   return roles;
 }

--- a/app/layersmodel.h
+++ b/app/layersmodel.h
@@ -29,6 +29,7 @@ class LayersModel : public QgsMapLayerModel
     {
       LayerNameRole = Qt::UserRole + 100, //! Reserved for QgsMapLayerModel roles
       VectorLayerRole,
+      HasGeometryRole,
       IconSourceRole
     };
     Q_ENUMS( LayerRoles )

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -746,7 +746,9 @@ void MerginApi::authorizeFinished()
       mUserAuth->setFromJson( docObj );
       mUserInfo->setFromJson( docObj );
       emit authChanged();
-    } else {
+    }
+    else
+    {
       mUserAuth->setUsername( QString() );
       mUserAuth->setPassword( QString() );
       mUserAuth->clearTokenData();

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -745,8 +745,15 @@ void MerginApi::authorizeFinished()
       QJsonObject docObj = doc.object();
       mUserAuth->setFromJson( docObj );
       mUserInfo->setFromJson( docObj );
+      emit authChanged();
+    } else {
+      mUserAuth->setUsername( QString() );
+      mUserAuth->setPassword( QString() );
+      mUserAuth->clearTokenData();
+      emit authFailed();
+      InputUtils::log( "auth", QStringLiteral( "FAILED - invalid JSON response" ) );
+      emit notify( "Internal server error during authorization" );
     }
-    emit authChanged();
   }
   else
   {

--- a/app/qml/BrowseDataFeaturesPanel.qml
+++ b/app/qml/BrowseDataFeaturesPanel.qml
@@ -1,3 +1,12 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 import QtQuick 2.0
 import QtQuick.Controls 2.12
 
@@ -10,7 +19,7 @@ Item {
 
   property bool layerHasGeometry: true
   property string layerName: ""
-  property int featuresCount: 0
+  property int featuresCount: __featuresModel.featuresCount
 
   Page {
     id: featuresPage

--- a/app/qml/BrowseDataFeaturesPanel.qml
+++ b/app/qml/BrowseDataFeaturesPanel.qml
@@ -6,7 +6,12 @@ Item {
 
   signal backButtonClicked()
   signal featureClicked( var featureId )
-  
+  signal addFeatureClicked()
+
+  property bool layerHasGeometry: true
+  property string layerName: ""
+  property int featuresCount: 0
+
   Page {
     id: featuresPage
     anchors.fill: parent
@@ -17,7 +22,7 @@ Item {
       width: parent.width
       color: InputStyle.clrPanelMain
       rowHeight: InputStyle.rowHeightHeader
-      titleText: qsTr("Features")
+      titleText: layerName + " (" + featuresCount + ")"
       
       onBack: root.backButtonClicked()
       withBackButton: true
@@ -29,6 +34,11 @@ Item {
       height: parent.height
 
       onFeatureClicked: root.featureClicked( featureId )
+    }
+
+    footer: BrowseDataToolbar {
+      visible: !layerHasGeometry
+      onAddButtonClicked: addFeatureClicked()
     }
   }
 }

--- a/app/qml/BrowseDataLayersPanel.qml
+++ b/app/qml/BrowseDataLayersPanel.qml
@@ -1,3 +1,12 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 import QtQuick 2.0
 import QtQuick.Controls 2.12
 import QgsQuick 0.1 as QgsQuick

--- a/app/qml/BrowseDataPanel.qml
+++ b/app/qml/BrowseDataPanel.qml
@@ -41,13 +41,6 @@ Item {
     browseDataLayout.push( browseDataFeaturesPanel, { layerHasGeometry: hasGeometry, layerName: layerName, featuresCount: featuresCount } )
   }
 
-  function pushFeaturesPanelWithParams( index ) {
-    let modelIndex = __browseDataLayersModel.index( index, 0 )
-    let hasGeometry = __browseDataLayersModel.data( modelIndex, LayersModel.HasGeometryRole )
-
-    browseDataLayout.push( browseDataFeaturesPanel, { layerHasGeometry: hasGeometry } )
-  }
-
   StackView {
     id: browseDataLayout
     initialItem: browseDataLayersPanel

--- a/app/qml/BrowseDataPanel.qml
+++ b/app/qml/BrowseDataPanel.qml
@@ -1,3 +1,12 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 import QtQuick 2.0
 import QtQuick.Controls 2.12
 import lc 1.0
@@ -38,7 +47,7 @@ Item {
     let layerName = __browseDataLayersModel.data( modelIndex, LayersModel.LayerNameRole )
     let featuresCount = __featuresModel.rowCount()
 
-    browseDataLayout.push( browseDataFeaturesPanel, { layerHasGeometry: hasGeometry, layerName: layerName, featuresCount: featuresCount } )
+    browseDataLayout.push( browseDataFeaturesPanel, { layerHasGeometry: hasGeometry, layerName: layerName } )
   }
 
   StackView {
@@ -80,7 +89,7 @@ Item {
   Connections {
     target: __featuresModel
     onTooManyFeaturesInLayer: {
-      __inputUtils.showNotification( qsTr( "Too many features in layer, showing first " ) + limitCount )
+      __inputUtils.showNotification( qsTr( "Too many features in layer, showing first %1" ).arg( limitCount ) )
     }
   }
 }

--- a/app/qml/BrowseDataToolbar.qml
+++ b/app/qml/BrowseDataToolbar.qml
@@ -1,3 +1,12 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 import QtQuick 2.0
 import QtQuick.Layouts 1.3
 

--- a/app/qml/BrowseDataToolbar.qml
+++ b/app/qml/BrowseDataToolbar.qml
@@ -1,0 +1,45 @@
+import QtQuick 2.0
+import QtQuick.Layouts 1.3
+
+
+Item {
+
+  signal addButtonClicked()
+  id: root
+
+  height: InputStyle.rowHeightHeader
+  width: parent.width
+  y: parent.height - height
+
+  Rectangle {
+    anchors.fill: parent
+    color: InputStyle.clrPanelBackground
+    opacity: InputStyle.panelOpacity
+
+    MouseArea {
+      anchors.fill: parent
+      onClicked: {} // do nothing but do not let click propagate
+    }
+
+    RowLayout {
+      height: parent.height
+      width: parent.width
+      anchors.bottom: parent.bottom
+
+      Item {
+        height: parent.height
+        Layout.fillWidth: true
+
+        MainPanelButton {
+          id: addButton
+          width: root.height * 0.8
+          text: qsTr("Add Feature")
+          imageSource: "plus.svg"
+          onActivated: {
+            addButtonClicked()
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/qml/BrowseDataView.qml
+++ b/app/qml/BrowseDataView.qml
@@ -1,3 +1,12 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 import QtQuick 2.0
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -22,6 +22,7 @@ Drawer {
     property bool isReadOnly
 
     signal editGeometryClicked()
+    signal featureSaved( var feature )
 
     property alias formState: featureForm.state
     property alias feature: attributeModel.featureLayerPair
@@ -236,6 +237,7 @@ Drawer {
 
             project: featurePanel.project
             onSaved: {
+                featurePanel.featureSaved( featurePanel.feature )
                 featurePanel.visible = false
             }
             onCanceled: featurePanel.visible = false

--- a/app/qml/Notification.qml
+++ b/app/qml/Notification.qml
@@ -33,6 +33,7 @@ Popup {
         color: InputStyle.fontColor
         verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.Wrap
     }
 
     Timer {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -62,6 +62,7 @@ ApplicationWindow {
                 recordToolbar.focus = true
                 recordToolbar.extraPanelVisible = true
                 recordToolbar.gpsSwitchClicked()
+                digitizing.layer = recordToolbar.activeVectorLayer
             }
             else if (stateManager.state === "edit") {
                 recordToolbar.focus = true
@@ -74,6 +75,8 @@ ApplicationWindow {
 
                 var screenPos = digitizing.pointFeatureMapCoordinates( featurePanel.feature )
                 mapCanvas.mapSettings.setCenter(screenPos);
+
+                browseDataPanel.clearStackAndClose()
             }
         }
     }
@@ -86,17 +89,23 @@ ApplicationWindow {
                 )
     }
 
-    function saveRecordedFeature(pair) {
-        if (digitizing.isPairValid(pair)) {
-            digitizingHighlight.featureLayerPair = pair
-            digitizingHighlight.visible = true
-            featurePanel.show_panel(pair, "Add", "form")
-        } else {
-            popup.text = qsTr("Recording feature is not valid")
-            popup.open()
+    function saveRecordedFeature( pair, hasGeometry = true ) {
+
+      if ( !digitizing.isPairValid( pair ) && hasGeometry ) { // TODO: add check for no geometry pair validity
+        popup.text = qsTr( "Recording feature is not valid" )
+        popup.open()
+      }
+      else {
+        if ( hasGeometry ) {
+          digitizingHighlight.featureLayerPair = pair
+          digitizingHighlight.visible = true
         }
-        stateManager.state = "view"
-        digitizing.useGpsPoint = false
+
+        featurePanel.show_panel( pair, "Add", "form" )
+      }
+
+      stateManager.state = "view"
+      digitizing.useGpsPoint = false
     }
 
 
@@ -130,16 +139,25 @@ ApplicationWindow {
         }
     }
 
-    function recordFeature() {
-      var recordedPoint = getRecordedPoint()
-      if ( digitizing.hasPointGeometry( __activeLayer.layer ) ) {
+    function recordFeature( hasGeometry = true ) {
+      if ( hasGeometry )
+      {
+        var recordedPoint = getRecordedPoint()
+
+        if ( digitizing.hasPointGeometry( __activeLayer.layer ) ) {
           var pair = digitizing.pointFeatureFromPoint( recordedPoint, digitizing.useGpsPoint )
           saveRecordedFeature( pair )
-      } else {
-          if ( !digitizing.recording ) {
-              digitizing.startRecording()
-          }
+        }
+        else {
+          if ( !digitizing.recording )
+            digitizing.startRecording()
+
           digitizing.addRecordPoint( recordedPoint, digitizing.useGpsPoint )
+        }
+      }
+      else
+      {
+        saveRecordedFeature( digitizing.featureWithoutGeometry(), hasGeometry )
       }
     }
 
@@ -169,23 +187,35 @@ ApplicationWindow {
 
       activeLayerPanel.activeIndex = __recordingLayersModel.indexFromLayer( __activeLayer.layer )
       recordToolbar.activeVectorLayer = __activeLayer.vectorLayer
-
+      digitizing.layer = recordToolbar.activeVectorLayer
+      
       if ( !recordToolbar.activeVectorLayer ) // nothing to do with no active layer
         return
 
       recordToolbar.pointLayerSelected = digitizing.hasPointGeometry( recordToolbar.activeVectorLayer )
     }
 
-    function selectFeature( feature, shouldUpdateExtent ) {
-      highlight.featureLayerPair = feature
+    function updateBrowseDataPanel( layer )
+    {
+      if ( browseDataPanel.visible )
+        browseDataPanel.selectedLayer = layer
+    }
 
-      if ( shouldUpdateExtent ) // update extent to fit feature above preview panel
-      {
+    function selectFeature( feature, shouldUpdateExtent, hasGeometry = true ) {
+
+      // update extent to fit feature above preview panel
+      if ( shouldUpdateExtent ) {
           let panelOffsetRatio = featurePanel.previewHeight/window.height
           __inputUtils.setExtentToFeature( feature, mapCanvas.mapSettings, panelOffsetRatio )
       }
-      highlight.visible = true
-      featurePanel.show_panel( feature, "ReadOnly", "preview" )
+
+      if ( hasGeometry ) {
+        highlight.featureLayerPair = feature
+        highlight.visible = true
+        featurePanel.show_panel( feature, "ReadOnly", "preview" )
+      }
+      else
+        featurePanel.show_panel( feature, "ReadOnly", "form" )
     }
 
     Component.onCompleted: {
@@ -577,9 +607,15 @@ ApplicationWindow {
       z: zPanel   // make sure items from here are on top of the Z-order
 
       onFeatureSelectRequested: {
-        let pair = __featuresModel.featureLayerPair( featureId )
         if ( pair.valid )
           selectFeature( pair, true )
+        else if ( pair.feature.geometry.isNull )
+          selectFeature( pair, false, false )
+      }
+
+      onCreateFeatureRequested: {
+        digitizing.layer = selectedLayer
+        recordFeature( false )
       }
     }
 
@@ -662,6 +698,10 @@ ApplicationWindow {
 
         onEditGeometryClicked: {
             stateManager.state = "edit"
+        }
+
+        onFeatureSaved: {
+          updateBrowseDataPanel( feature.layer )
         }
     }
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -91,8 +91,9 @@ ApplicationWindow {
 
     function saveRecordedFeature( pair, hasGeometry = true ) {
 
-      if ( !digitizing.isPairValid( pair ) && hasGeometry ) { // TODO: add check for no geometry pair validity
-        popup.text = qsTr( "Recording feature is not valid" )
+      if ( !digitizing.isPairValid( pair ) && hasGeometry ||
+            !pair.layer && !hasGeometry ) {
+        popup.text = qsTr( "Recorded feature is not valid" )
         popup.open()
       }
       else {

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -46,5 +46,6 @@
         <file>SubscribePage.qml</file>
         <file>TextWithIcon.qml</file>
         <file>CircularProgressBar.qml</file>
+        <file>BrowseDataToolbar.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Added possibility to `add` and `edit` features without geometry.

When user selects layer in `browse data` (attribute table), there are three possible screens:

<table>
  <tr>
    <th>Features with geometry</th>
    <th>Features without geometry</th>
    <th>Features without geometry <br> (over limit *)</th>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/22449698/88152297-1a377900-cc04-11ea-8d0e-9e194a2aa597.png" width="300"/></td>
    <td><img src="https://user-images.githubusercontent.com/22449698/88152301-1b68a600-cc04-11ea-8197-45e4ddd79adc.png"  width="300"/></td>
    <td><img src="https://user-images.githubusercontent.com/22449698/88152666-a47fdd00-cc04-11ea-8ebf-5886914037bc.png"  width="300"/></td>
  </tr>
 </table>

***limit** is set to 10.000 ~ Input queries first 10.000 features from a layer and informs user when layer has more than this limit.

 + I used the same icon for no geometry features as in Qgis.
 + Clicking on `Add Feature` button opens classic feature form and saving/closing the form moves back to this view
 + Clicking on feature (without geo) opens fullscreen feature form  and saving/closing again leads back to this view
 + Toolbar to add feature is visible only for layers without geometry

Closes #794 