### PR TITLE
Fix of infinite projectList reloading due to always expired auth.

### DIFF
--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -744,6 +744,7 @@ void MerginApi::authorizeFinished()
     {
       QJsonObject docObj = doc.object();
       mUserAuth->setFromJson( docObj );
+      mUserInfo->setFromJson( docObj );
       emit authChanged();
     }
     else

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -744,7 +744,6 @@ void MerginApi::authorizeFinished()
     {
       QJsonObject docObj = doc.object();
       mUserAuth->setFromJson( docObj );
-      mUserInfo->setFromJson( docObj );
       emit authChanged();
     }
     else
@@ -1964,7 +1963,6 @@ void MerginApi::getUserInfoFinished()
     if ( doc.isObject() )
     {
       QJsonObject docObj = doc.object();
-      mUserAuth->setFromJson( docObj );
       mUserInfo->setFromJson( docObj );
     }
   }


### PR DESCRIPTION
Auth has been updated always when a user info was called. That caused wiping out the expiration token data which resulted into infinite authorization loop.

closes #814 