### PR TITLE
Added busyIndicator for the SubscribePage

### DIFF
--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -112,6 +112,15 @@ Item {
     onRegistrationFailed: authPanel.pending = false
   }
 
+  Connections {
+    target: __purchasing
+    onRecommendedPlanChanged: {
+      if (!subscribePanel.isBusy && subscribePanel.visible) {
+        busyIndicator.running = false
+      }
+    }
+  }
+
   id: projectsPanel
   visible: false
   focus: true
@@ -674,6 +683,10 @@ Item {
       __purchasing.purchase( __purchasing.recommendedPlan.id )
       accountPanel.visible = true
       subscribePanel.visible = false
+    }
+
+    onVisibleChanged: {
+      busyIndicator.running = subscribePanel.visible && subscribePanel.isBusy
     }
   }
 

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -112,15 +112,6 @@ Item {
     onRegistrationFailed: authPanel.pending = false
   }
 
-  Connections {
-    target: __purchasing
-    onRecommendedPlanChanged: {
-      if (!subscribePanel.isBusy && subscribePanel.visible) {
-        busyIndicator.running = false
-      }
-    }
-  }
-
   id: projectsPanel
   visible: false
   focus: true
@@ -683,10 +674,6 @@ Item {
       __purchasing.purchase( __purchasing.recommendedPlan.id )
       accountPanel.visible = true
       subscribePanel.visible = false
-    }
-
-    onVisibleChanged: {
-      busyIndicator.running = subscribePanel.visible && subscribePanel.isBusy
     }
   }
 

--- a/app/qml/SubscribePage.qml
+++ b/app/qml/SubscribePage.qml
@@ -19,8 +19,32 @@ Rectangle {
   signal backClicked
   signal subscribeClicked
 
-  //! If true and component is visible, busy indicator suppose to be on. Currently only for pending recommendedPlan
+  //! If true and component is visible, busy indicator suppose to be on. Currently used only while fetching a recommendedPlan
   property bool isBusy: __purchasing.recommendedPlan.id === ""
+
+  onVisibleChanged: {
+    subscribeBusyIndicator.running = root.visible && root.isBusy
+  }
+
+  Connections {
+    target: __purchasing
+    onRecommendedPlanChanged: {
+      if (!root.isBusy && root.visible) {
+        subscribeBusyIndicator.running = false
+      }
+    }
+  }
+
+
+  BusyIndicator {
+    id: subscribeBusyIndicator
+    width: root.width/8
+    height: width
+    running: false
+    visible: running
+    anchors.centerIn: root
+    z: root.z + 1
+  }
 
   // header
   PanelHeader {

--- a/app/qml/SubscribePage.qml
+++ b/app/qml/SubscribePage.qml
@@ -19,6 +19,9 @@ Rectangle {
   signal backClicked
   signal subscribeClicked
 
+  //! If true and component is visible, busy indicator suppose to be on. Currently only for pending recommendedPlan
+  property bool isBusy: __purchasing.recommendedPlan.id === ""
+
   // header
   PanelHeader {
     id: header

--- a/app/qml/SubscribePage.qml
+++ b/app/qml/SubscribePage.qml
@@ -101,6 +101,7 @@ Rectangle {
 
       height: InputStyle.rowHeightHeader
       text: __merginApi.userInfo.ownsActiveSubscription ? qsTr("Manage") : __purchasing.recommendedPlan.price
+      enabled: text !== ''
       font.pixelSize: subscribeButton.height / 2
 
       background: Rectangle {


### PR DESCRIPTION
Note: Would be good to have a single improved Busy Indicator for Input. Currently we use one for several screens where loadings may interfere to each other.

closes #805 