### PR TITLE
Fix of twice called slots for Feature delete dialog

### DIFF
--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -273,6 +273,7 @@ Drawer {
           icon: StandardIcon.Warning
           standardButtons: StandardButton.Ok | StandardButton.Cancel
 
+          //! Using onButtonClicked instead of onAccepted,onRejected which have been called twice
           onButtonClicked: {
               if (clickedButton === StandardButton.Ok) {
                 featureForm.model.attributeModel.deleteFeature()

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -272,13 +272,16 @@ Drawer {
           text: qsTr( "Really delete this feature?" )
           icon: StandardIcon.Warning
           standardButtons: StandardButton.Ok | StandardButton.Cancel
-          onAccepted: {
-            featureForm.model.attributeModel.deleteFeature()
-            visible = false
-            featureForm.canceled()
-          }
-          onRejected: {
-            visible = false
+
+          onButtonClicked: {
+              if (clickedButton === StandardButton.Ok) {
+                featureForm.model.attributeModel.deleteFeature()
+                visible = false
+                featureForm.canceled()
+              }
+              else if (clickedButton === StandardButton.Cancel) {
+                visible = false
+              }
           }
         }
     }

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -686,21 +686,25 @@ Item {
     text: qsTr( "Do you really want to delete project?" )
     icon: StandardIcon.Warning
     standardButtons: StandardButton.Ok | StandardButton.Cancel
-    onAccepted: {
-      if (relatedProjectIndex < 0) {
-          return;
-      }
-      __projectsModel.deleteProject(relatedProjectIndex)
-      if (projectsPanel.activeProjectIndex === relatedProjectIndex) {
-        __loader.load("")
-        projectsPanel.activeProjectIndex = -1
-      }
-      deleteDialog.relatedProjectIndex = -1
-      visible = false
-    }
-    onRejected: {
-      deleteDialog.relatedProjectIndex = -1
-      visible = false
+
+    //! Using onButtonClicked instead of onAccepted,onRejected which have been called twice
+    onButtonClicked: {
+        if (clickedButton === StandardButton.Ok) {
+          if (relatedProjectIndex < 0) {
+              return;
+          }
+          __projectsModel.deleteProject(relatedProjectIndex)
+          if (projectsPanel.activeProjectIndex === relatedProjectIndex) {
+            __loader.load("")
+            projectsPanel.activeProjectIndex = -1
+          }
+          deleteDialog.relatedProjectIndex = -1
+          visible = false
+        }
+        else if (clickedButton === StandardButton.Cancel) {
+          deleteDialog.relatedProjectIndex = -1
+          visible = false
+        }
     }
   }
 


### PR DESCRIPTION
There is a bug in Qt Dialog (seems to affect v1.1 - v1.3) with sending same signal twice
[https://bugreports.qt.io/browse/QTBUG-40613](https://bugreports.qt.io/browse/QTBUG-40613?jql=project%20%3D%20QTBUG%20AND%20component%20%3D%20%22Quick%3A%20Dialogs%22%20AND%20text%20~%20%22twice%22)

Tested and confirmed that `onAccept` and `onRejected` have been called twice. Handling only buttons signal fixes the issue.

TODO: `mFeatureLayerPair` in `QgsQuickAttributeModel` is after calling `QgsQuickAttributeModel::deleteFeature` not reseted - PR in QGIS:


closes #786 - a real issue was due to combination of ogr data provider and shapefile.