### PR TITLE
Fix/map theme from project

### DIFF
--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -18,7 +18,6 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
   settings.beginGroup( mGroupName );
   QString path = settings.value( "defaultProject", "" ).toString();
   QString layer = settings.value( "defaultLayer/"  + path, "" ).toString();
-  QString mapTheme = settings.value( "defaultMapTheme/"  + path, "" ).toString();
   bool autoCenter = settings.value( "autoCenter", false ).toBool();
   int gpsTolerance = settings.value( "gpsTolerance", 10 ).toInt();
   int lineRecordingInterval = settings.value( "lineRecordingInterval", 3 ).toInt();
@@ -27,7 +26,6 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
   setDefaultProject( path );
   setActiveProject( path );
   setDefaultLayer( layer );
-  setDefaultMapTheme( mapTheme );
   setAutoCenterMapChecked( autoCenter );
   setGpsAccuracyTolerance( gpsTolerance );
   setLineRecordingInterval( lineRecordingInterval );
@@ -152,23 +150,5 @@ void AppSettings::setLineRecordingInterval( int value )
     settings.endGroup();
 
     emit lineRecordingIntervalChanged();
-  }
-}
-
-QString AppSettings::defaultMapTheme() const
-{
-  return mDefaultMapTheme.value( mActiveProject );
-}
-
-void AppSettings::setDefaultMapTheme( const QString &value )
-{
-  if ( defaultMapTheme() != value )
-  {
-    QSettings settings;
-    settings.beginGroup( mGroupName );
-    settings.setValue( "defaultMapTheme/" + mActiveProject, value );
-    settings.endGroup();
-    mDefaultMapTheme.insert( mActiveProject, value );
-    emit defaultMapThemeChanged();
   }
 }

--- a/app/appsettings.h
+++ b/app/appsettings.h
@@ -20,7 +20,6 @@ class AppSettings: public QObject
     Q_PROPERTY( QString activeProject READ activeProject WRITE setActiveProject NOTIFY activeProjectChanged )
     Q_PROPERTY( QString defaultProjectName READ defaultProjectName NOTIFY defaultProjectChanged )
     Q_PROPERTY( QString defaultLayer READ defaultLayer WRITE setDefaultLayer NOTIFY defaultLayerChanged )
-    Q_PROPERTY( QString defaultMapTheme READ defaultMapTheme WRITE setDefaultMapTheme NOTIFY defaultMapThemeChanged )
     Q_PROPERTY( bool autoCenterMapChecked READ autoCenterMapChecked WRITE setAutoCenterMapChecked NOTIFY autoCenterMapCheckedChanged )
     Q_PROPERTY( int lineRecordingInterval READ lineRecordingInterval WRITE setLineRecordingInterval NOTIFY lineRecordingIntervalChanged )
     Q_PROPERTY( int gpsAccuracyTolerance READ gpsAccuracyTolerance WRITE setGpsAccuracyTolerance NOTIFY gpsAccuracyToleranceChanged )
@@ -48,14 +47,10 @@ class AppSettings: public QObject
     int lineRecordingInterval() const;
     void setLineRecordingInterval( int lineRecordingInterval );
 
-    QString defaultMapTheme() const;
-    void setDefaultMapTheme( const QString &value );
-
   signals:
     void defaultProjectChanged();
     void activeProjectChanged();
     void defaultLayerChanged();
-    void defaultMapThemeChanged();
     void autoCenterMapCheckedChanged();
     void gpsAccuracyToleranceChanged();
     void lineRecordingIntervalChanged();
@@ -74,9 +69,6 @@ class AppSettings: public QObject
 
     // Projects path -> defaultLayer name
     QHash<QString, QString> mDefaultLayers;
-
-    // Projects path -> defaultMapTheme name
-    QHash<QString, QString> mDefaultMapTheme;
 
     const QString mGroupName = QString( "inputApp" );
 

--- a/app/loader.cpp
+++ b/app/loader.cpp
@@ -94,26 +94,6 @@ bool Loader::forceLoad( const QString &filePath, bool force )
     res = mProject->read( filePath );
 
     mMapThemeModel.reloadMapThemes( mProject );
-    QgsLayerTree *root = mProject->layerTreeRoot();
-    QgsLayerTreeModel model( root );
-    QgsMapThemeCollection::MapThemeRecord rec = mProject->mapThemeCollection()->createThemeFromCurrentState( root, &model );
-
-    QString defaultThemeName = mAppSettings.defaultMapTheme();
-    if ( !defaultThemeName.isEmpty() && rec == QgsProject::instance()->mapThemeCollection()->mapThemeState( defaultThemeName ) )
-    {
-      mMapThemeModel.updateMapTheme( mAppSettings.defaultMapTheme() );
-    }
-    else
-    {
-      const auto constMapThemes = QgsProject::instance()->mapThemeCollection()->mapThemes();
-      for ( const QString &themeName : constMapThemes )
-      {
-        if ( rec == QgsProject::instance()->mapThemeCollection()->mapThemeState( themeName ) )
-        {
-          mMapThemeModel.updateMapTheme( themeName );
-        }
-      }
-    }
 
     mLayersModel.reloadLayers( mProject );
     mLayersModel.updateActiveLayer( mAppSettings.defaultLayer() );
@@ -249,8 +229,6 @@ QStringList Loader::mapTipFields( QgsQuickFeatureLayerPair pair )
 void Loader::setActiveMapTheme( int index )
 {
   QString name = mMapThemeModel.setActiveThemeIndex( index );
-  mAppSettings.setDefaultMapTheme( name );
-
   mLayersModel.reloadLayers( mProject );
   mLayersModel.updateActiveLayer( mAppSettings.defaultLayer() );
 }

--- a/app/mapthemesmodel.h
+++ b/app/mapthemesmodel.h
@@ -77,6 +77,12 @@ class MapThemesModel : public QAbstractListModel
     QgsProject *mProject = nullptr;
     QList<QString> mMapThemes;
     int mActiveThemeIndex = -1;
+
+    /**
+    * Updates map theme (sets active index in the model) with the first match from project's theme collection.
+    * Precondition is to have model up-to-date with Project's theme collection.
+    */
+    void updateMapThemeByProject();
 };
 
 #endif // MapThemesModel_H


### PR DESCRIPTION
Changed behaviour of selecting active map theme. Now it is changed according project. If a current project theme is not found either in project's collection or ThemeModel, active index is set to -1.

Updating active index has to be done after any map theme reloading - even if a model hasn't really changed (use case - having two same projects with very same themes. One project differs with the other with selected theme, so active index has to be changed after project loading even if themes in model haven't changed).

closes #789 