### PR TITLE
Fix of wrong prefix path in the final value of selected/captured image.

### DIFF
--- a/app/qml/ExternalResourceBundle.qml
+++ b/app/qml/ExternalResourceBundle.qml
@@ -103,18 +103,14 @@ Item {
         }
 
         /**
-         * Called when an image is selected from a gallery. If the image doesn't exist in a folder
-         * set in widget's config, it is copied to the destination and value is set according a new copy.
+         * Called when an image is either selected from a gallery or captured by native camera. If the image doesn't exist in a folder
+         * set in widget's config, it is copied to the destination and value is set according a new copy (only when chosen from gallery).
          * \param imagePath Absolute path to a selected image
          */
         property var imageSelected: function imageSelected(imagePath) {
-          // if prefixToRelativePath is empty (widget is using absolute path), then use targetDir
-          var prefix = (externalResourceHandler.itemWidget.prefixToRelativePath) ?
-                externalResourceHandler.itemWidget.prefixToRelativePath:
-                externalResourceHandler.itemWidget.targetDir
-
           var filename = __inputUtils.getFileName(imagePath)
-          var absolutePath  = externalResourceHandler.itemWidget.getAbsolutePath(prefix, filename)
+          //! final absolute location of an image.
+          var absolutePath  = externalResourceHandler.itemWidget.getAbsolutePath(externalResourceHandler.itemWidget.targetDir, filename)
 
           if (!QgsQuick.Utils.fileExists(absolutePath)) {
             var success = __inputUtils.copyFile(imagePath, absolutePath)
@@ -123,8 +119,7 @@ Item {
                 console.log("error: Unable to copy file " + imagePath + " to the project directory")
             }
           }
-
-          externalResourceHandler.confirmImage(externalResourceHandler.itemWidget, prefix, absolutePath)
+          externalResourceHandler.confirmImage(externalResourceHandler.itemWidget, externalResourceHandler.itemWidget.prefixToRelativePath, absolutePath)
         }
 
         /**


### PR DESCRIPTION
When an image has been captured or chosen from a gallery, wrong prefixPath has been used to extract relative path. TargetDir (actual final location of the image) and prefixDir (to which dir has to be value relative to) were mixed up.

This fixes also duplicating captured photos that occurrs when default path is different from project path.

Tested with following settings with project_folder `./lutra/mergin/projects_mergin/image_paths` :
<img width="556" alt="Screenshot 2020-09-08 at 19 01 23" src="https://user-images.githubusercontent.com/6735606/92506525-e2ad7c00-f205-11ea-9ce7-ed2e74288d83.png">
value: `JPEG_20200908_184942_1945163542.jpg`<br/>
actual location: `./lutra/mergin/projects_mergin/image_paths/JPEG_20200908_184942_1945163542.jpg`. 

<img width="564" alt="Screenshot 2020-09-08 at 19 01 17" src="https://user-images.githubusercontent.com/6735606/92506531-e4773f80-f205-11ea-8a93-f3c5d4548004.png">
value: `JPEG_20200908_184937_271523668.jpg` <br/>

actual location: `./lutra/mergin/projects_mergin/image_paths/photos/JPEG_20200908_184937_271523668.jpg`. 

<img width="558" alt="Screenshot 2020-09-08 at 19 01 08" src="https://user-images.githubusercontent.com/6735606/92506532-e50fd600-f205-11ea-929f-33e4ce34d94c.png">
value: `photos/JPEG_20200908_184511_1010381118.jpg`<br/>

actual location: `./lutra/mergin/projects_mergin/image_paths/photos/JPEG_20200908_184511_1010381118.jpg`. 
<br/>

NOTE: Further test configuration done on viktor/image_paths test project - I can make it shared or public on request.

closes #655 closes #848 