### PR TITLE
Fix of GPS autopanning

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -370,7 +370,7 @@ ApplicationWindow {
       simulatePositionLongLatRad: __use_simulated_position ? [-2.9207148, 51.3624998, 0.05] : []
 
       onScreenPositionChanged: {
-        if ((digitizing.useGpsPoint && stateManager.state === "record")|| (__appSettings.autoCenterMapChecked && isPositionOutOfExtent(mainPanel.height))) {
+        if ((digitizing.useGpsPoint && stateManager.state !== "view")|| (stateManager.state === "view" && __appSettings.autoCenterMapChecked && isPositionOutOfExtent(mainPanel.height))) {
             var useGpsPoint = digitizing.useGpsPoint
             mapCanvas.mapSettings.setCenter(positionKit.projectedPosition);
             // sets previous useGpsPoint value, because setCenter triggers extentChanged signal which changes this property

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -370,7 +370,7 @@ ApplicationWindow {
       simulatePositionLongLatRad: __use_simulated_position ? [-2.9207148, 51.3624998, 0.05] : []
 
       onScreenPositionChanged: {
-        if (digitizing.useGpsPoint || (__appSettings.autoCenterMapChecked && isPositionOutOfExtent(mainPanel.height))) {
+        if ((digitizing.useGpsPoint && stateManager.state === "record")|| (__appSettings.autoCenterMapChecked && isPositionOutOfExtent(mainPanel.height))) {
             var useGpsPoint = digitizing.useGpsPoint
             mapCanvas.mapSettings.setCenter(positionKit.projectedPosition);
             // sets previous useGpsPoint value, because setCenter triggers extentChanged signal which changes this property


### PR DESCRIPTION
Autopan only in record/edit mode. Otherwise updates screen center point according gps position only single time on gpc button clicked.
Autocenter allowed only for viewing
closes #847 
closes #499 