### PR TITLE
Enlarged button for download/sync project at the expense of the right…

### DIFF
--- a/app/qml/ProjectDelegateItem.qml
+++ b/app/qml/ProjectDelegateItem.qml
@@ -56,7 +56,6 @@ Rectangle {
         RowLayout {
             id: row
             anchors.fill: parent
-            anchors.rightMargin: itemContainer.itemMargin
             anchors.leftMargin: itemContainer.itemMargin
             spacing: InputStyle.panelMargin
 
@@ -159,7 +158,7 @@ Rectangle {
             Item {
                 id: statusContainer
                 height: itemContainer.cellHeight
-                width: itemContainer.iconSize
+                width: height
                 y: 0
 
                 MouseArea {


### PR DESCRIPTION
Button was way narrow and sometimes it was. difficult to click on it on small screen.
Before (red is just for visualisation of button size):
<img width="279" alt="Screenshot 2020-09-11 at 14 15 54" src="https://user-images.githubusercontent.com/6735606/92924981-15d85100-f43a-11ea-9c67-7e7dadf5e814.png">
After:
<img width="281" alt="Screenshot 2020-09-11 at 14 16 54" src="https://user-images.githubusercontent.com/6735606/92924983-17097e00-f43a-11ea-94cb-8550b14d3049.png">
