### PR TITLE
Fix issue with recoring layer selection

### DIFF
--- a/app/layersmodel.cpp
+++ b/app/layersmodel.cpp
@@ -51,6 +51,7 @@ QVariant LayersModel::data( const QModelIndex &index, int role ) const
       }
       else return "mIconRaster.svg";
     }
+    case LayerIdRole: return layer->id();
   }
   return QVariant();
 }
@@ -62,5 +63,6 @@ QHash<int, QByteArray> LayersModel::roleNames() const
   roles[IconSourceRole] = QStringLiteral( "iconSource" ).toLatin1();
   roles[HasGeometryRole] = QStringLiteral( "hasGeometry" ).toLatin1();
   roles[VectorLayerRole] = QStringLiteral( "vectorLayer" ).toLatin1();
+  roles[LayerIdRole] = QStringLiteral( "layerId" ).toLatin1();
   return roles;
 }

--- a/app/layersmodel.h
+++ b/app/layersmodel.h
@@ -30,7 +30,8 @@ class LayersModel : public QgsMapLayerModel
       LayerNameRole = Qt::UserRole + 100, //! Reserved for QgsMapLayerModel roles
       VectorLayerRole,
       HasGeometryRole,
-      IconSourceRole
+      IconSourceRole,
+      LayerIdRole
     };
     Q_ENUMS( LayerRoles )
 

--- a/app/layersproxymodel.cpp
+++ b/app/layersproxymodel.cpp
@@ -86,12 +86,12 @@ bool LayersProxyModel::layerVisible( QgsMapLayer *layer ) const
 
 QList<QgsMapLayer *> LayersProxyModel::layers() const
 {
-  QList<QgsMapLayer *> allLayers = mModel->layers();
   QList<QgsMapLayer *> filteredLayers;
 
   if ( !mModel )
     return filteredLayers;
 
+  QList<QgsMapLayer *> allLayers = mModel->layers();
   int layersCount = allLayers.size();
 
   for ( int i = 0; i < layersCount; i++ )
@@ -119,28 +119,33 @@ QgsMapLayer *LayersProxyModel::firstUsableLayer() const
   return nullptr;
 }
 
-int LayersProxyModel::indexFromLayer( QgsMapLayer *layer ) const
+QModelIndex LayersProxyModel::indexFromLayerId( QString layerId ) const
 {
-  if ( !layer )
-    return -1;
+  if ( layerId.isEmpty() )
+    return QModelIndex();
 
+  QgsVectorLayer *layer = layerFromLayerId( layerId );
+
+  return mModel->indexFromLayer( layer ); // return source model index to skip converting indexes in proxy model
+}
+
+QgsVectorLayer *LayersProxyModel::layerFromLayerId( QString layerId ) const
+{
   QList<QgsMapLayer *> filteredLayers = layers();
 
   for ( int i = 0; i < filteredLayers.count(); i++ )
   {
-    if ( filteredLayers.at( i )->id() == layer->id() )
-      return i;
+    if ( filteredLayers.at( i )->id() == layerId )
+    {
+      QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( filteredLayers.at( i ) );
+      if ( layer )
+        return layer;
+    }
   }
-
-  return -1;
+  return nullptr;
 }
 
-QgsMapLayer *LayersProxyModel::layerFromIndex( int index ) const
+QVariant LayersProxyModel::getData( QModelIndex index, int role ) const
 {
-  QList<QgsMapLayer *> filteredLayers = layers();
-
-  if ( index >= 0 && index < filteredLayers.size() )
-    return filteredLayers.at( index );
-
-  return nullptr;
+  return sourceModel()->data( index, role );
 }

--- a/app/layersproxymodel.h
+++ b/app/layersproxymodel.h
@@ -35,8 +35,11 @@ class LayersProxyModel : public QgsMapLayerProxyModel
     bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
 
     //! Helper methods that convert layer to/from index/name
-    Q_INVOKABLE QgsMapLayer *layerFromIndex( int index ) const;
-    Q_INVOKABLE int indexFromLayer( QgsMapLayer *layer ) const;
+    Q_INVOKABLE QModelIndex indexFromLayerId( QString layerId ) const;
+    Q_INVOKABLE QgsVectorLayer *layerFromLayerId( QString layerId ) const;
+
+    //! Helper method to get data from source model to skip converting indexes
+    Q_INVOKABLE QVariant getData( QModelIndex index, int role ) const;
 
     //! Returns first layer from proxy model's layers list (filtered with filter function)
     Q_INVOKABLE QgsMapLayer *firstUsableLayer() const;

--- a/app/qml/ActiveLayerPanel.qml
+++ b/app/qml/ActiveLayerPanel.qml
@@ -15,9 +15,9 @@ import "."  // import InputStyle singleton
 
 Drawer {
     property string title: qsTr("Survey Layer")
-    property int activeIndex: __recordingLayersModel.indexFromLayer( __activeLayer.layer )
+    property string activeLayerId: __activeLayer.layerId
 
-    signal activeLayerChangeRequested( var index )
+    signal activeLayerChangeRequested( var layerId )
 
     function openPanel() {
         layerPanel.visible = true
@@ -61,14 +61,14 @@ Drawer {
         width: parent.width
         y: header.height
         model: __recordingLayersModel
-        activeIndex: layerPanel.activeIndex
+        activeLayerId: layerPanel.activeLayerId
 
         cellWidth: width
         cellHeight: InputStyle.rowHeight
         borderWidth: 1
 
         onListItemClicked: {
-          activeLayerChangeRequested( index )
+          activeLayerChangeRequested( layerId )
           layerPanel.visible = false
         }
     }

--- a/app/qml/BrowseDataLayersPanel.qml
+++ b/app/qml/BrowseDataLayersPanel.qml
@@ -16,7 +16,7 @@ Item {
   id: root
 
   signal backButtonClicked()
-  signal layerClicked( var index )
+  signal layerClicked( var layerId )
 
   Page {
     id: layersListPage
@@ -46,7 +46,7 @@ Item {
         noLayersText: qsTr("No identifiable layers in the project!")
 
         onListItemClicked: {
-          layerClicked( index )
+          layerClicked( layerId )
         }
     }
   }

--- a/app/qml/BrowseDataPanel.qml
+++ b/app/qml/BrowseDataPanel.qml
@@ -51,17 +51,16 @@ Item {
     else clearStackAndClose()
   }
 
-  function loadFeaturesFromLayerIndex( index ) {
-    let modelIndex = __browseDataLayersModel.index( index, 0 )
-    let layer = __browseDataLayersModel.data( modelIndex, LayersModel.VectorLayerRole )
+  function loadFeaturesFromLayerIndex( layerId ) {
+    let layer = __browseDataLayersModel.layerFromLayerId( layerId )
 
     selectedLayer = layer
   }
 
-  function pushFeaturesPanelWithParams( index ) {
-    let modelIndex = __browseDataLayersModel.index( index, 0 )
-    let hasGeometry = __browseDataLayersModel.data( modelIndex, LayersModel.HasGeometryRole )
-    let layerName = __browseDataLayersModel.data( modelIndex, LayersModel.LayerNameRole )
+  function pushFeaturesPanelWithParams( layerId ) {
+    let modelIndex = __browseDataLayersModel.indexFromLayerId( layerId )
+    let hasGeometry = __browseDataLayersModel.getData( modelIndex, LayersModel.HasGeometryRole )
+    let layerName = __browseDataLayersModel.getData( modelIndex, LayersModel.LayerNameRole )
 
     browseDataLayout.push( browseDataFeaturesPanel, {
                             layerHasGeometry: hasGeometry,
@@ -99,8 +98,8 @@ Item {
     BrowseDataLayersPanel {
       onBackButtonClicked: popOnePageOrClose()
       onLayerClicked: {
-        loadFeaturesFromLayerIndex( index )
-        pushFeaturesPanelWithParams( index )
+        loadFeaturesFromLayerIndex( layerId )
+        pushFeaturesPanelWithParams( layerId )
       }
     }
   }

--- a/app/qml/LayerList.qml
+++ b/app/qml/LayerList.qml
@@ -10,9 +10,10 @@ ListView {
   property int borderWidth: 1
   property bool highlightingAllowed: true
   property string noLayersText: qsTr("No editable layers in the project!")
+  property string activeLayerId: ""
   property int activeIndex: -1
 
-  signal listItemClicked( var index )
+  signal listItemClicked( var layerId )
 
     id: listView
     implicitWidth: parent.width
@@ -36,7 +37,7 @@ ListView {
         MouseArea {
           anchors.fill: parent
           onClicked: {
-            listItemClicked( index )
+            listItemClicked( model.layerId )
           }
         }
 
@@ -47,7 +48,7 @@ ListView {
             contentText: layerName ? layerName : ""
             imageSource: iconSource ? iconSource : ""
             overlayImage: false
-            highlight: highlightingAllowed && activeIndex === index
+            highlight: highlightingAllowed && layerId === activeLayerId
             showBorder: highlightingAllowed ? !__appSettings.defaultLayer || activeIndex - 1 !== index : true
         }
     }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -186,7 +186,6 @@ ApplicationWindow {
       if ( !__activeLayer.layer )
         __loader.setActiveLayer( __recordingLayersModel.firstUsableLayer() )
 
-      activeLayerPanel.activeIndex = __recordingLayersModel.indexFromLayer( __activeLayer.layer )
       recordToolbar.activeVectorLayer = __activeLayer.vectorLayer
       digitizing.layer = recordToolbar.activeVectorLayer
       
@@ -597,7 +596,7 @@ ApplicationWindow {
         z: zPanel
 
         onActiveLayerChangeRequested: {
-          __loader.setActiveLayer( __recordingLayersModel.layerFromIndex( index ) )
+          __loader.setActiveLayer( __recordingLayersModel.layerFromLayerId( layerId ) )
         }
     }
 


### PR DESCRIPTION
Indexes from listview (and possibly other views) were used for communication with BE models. Solution replaces these with featureIds.

<table>
    <td><img src="https://user-images.githubusercontent.com/22449698/92963790-50121480-f473-11ea-87a9-153421ae4ca7.png" width="400"/></td>
    <td><img src="https://user-images.githubusercontent.com/22449698/92963812-56a08c00-f473-11ea-8143-2ea3e019e0fa.png"  width="400"/></td>
  </tr>
 </table>

Closes #845 