### PR TITLE
Register form adjusted for smaller screens or virtual keyboard

### DIFF
--- a/app/qml/AuthPanel.qml
+++ b/app/qml/AuthPanel.qml
@@ -93,16 +93,8 @@ Item {
     LoginForm {
       id: loginForm
       visible: !warningMsgContainer.visible
+      height: Qt.inputMethod.visible ? parent.height + staticPane.height - Qt.inputMethod.keyboardRectangle.height : parent.height - staticPane.height
       width: parent.width
-      height: parent.height - staticPane.height
-      anchors.bottom: staticPane.top
-      anchors.bottomMargin: {
-        Math.max(
-              Qt.inputMethod.keyboardRectangle.height ? Qt.inputMethod.keyboardRectangle.height
-                                                        - (staticPane.height + toolbarHeight
-                                                           + panelMargin) : 0,
-              0)
-      }
 
       onRegistrationRequested: {
         registrationForm.clean()

--- a/app/qml/AuthPanel.qml
+++ b/app/qml/AuthPanel.qml
@@ -113,16 +113,8 @@ Item {
     RegistrationForm {
       id: registrationForm
       visible: false
+      height: Qt.inputMethod.visible ? parent.height + staticPane.height - Qt.inputMethod.keyboardRectangle.height : parent.height - staticPane.height
       width: parent.width
-      height: parent.height - staticPane.height
-      anchors.bottom: staticPane.top
-      anchors.bottomMargin: {
-        Math.max(
-              Qt.inputMethod.keyboardRectangle.height ? Qt.inputMethod.keyboardRectangle.height
-                                                        - (staticPane.height + toolbarHeight
-                                                           + panelMargin) : 0,
-              0)
-      }
     }
 
     // Mergin check

--- a/app/qml/LoginForm.qml
+++ b/app/qml/LoginForm.qml
@@ -25,16 +25,7 @@ Rectangle {
   signal registrationRequested()
 
   id: loginForm
-  width: parent.width
-  height: parent.height - staticPane.height
   color: root.bgColor
-  anchors.bottom: staticPane.top
-  anchors.bottomMargin: {
-    Math.max(
-          Qt.inputMethod.keyboardRectangle.height ? Qt.inputMethod.keyboardRectangle.height
-                                                    - (staticPane.height + toolbarHeight
-                                                       + panelMargin) : 0, 0)
-  }
 
   function clean() {
     password.text = ""

--- a/app/qml/RegistrationForm.qml
+++ b/app/qml/RegistrationForm.qml
@@ -10,7 +10,7 @@
  ***************************************************************************/
 import QtQuick.Templates 2.1 as T
 import QtQuick 2.7
-import QtQuick.Controls 2.0
+import QtQuick.Controls 2.7
 import QtQuick.Layouts 1.3
 import QtQuick.Dialogs 1.2
 import QtGraphicalEffects 1.0
@@ -23,16 +23,7 @@ import "." // import InputStyle singleton
   */
 Rectangle {
   id: registerForm
-  width: parent.width
-  height: parent.height - staticPane.height
   color: root.bgColor
-  anchors.bottom: staticPane.top
-  anchors.bottomMargin: {
-    Math.max(
-          Qt.inputMethod.keyboardRectangle.height ? Qt.inputMethod.keyboardRectangle.height
-                                                    - (staticPane.height + toolbarHeight
-                                                       + panelMargin) : 0, 0)
-  }
 
   function clean() {
     registerName.text = ""
@@ -41,6 +32,10 @@ Rectangle {
     passwordConfirm.text = ""
     acceptTOC.checked = false
   }
+
+  ScrollView {
+    width: registerForm.width
+    height: registerForm.height
 
   Column {
     id: columnLayout
@@ -358,6 +353,7 @@ Rectangle {
         verticalAlignment: Text.AlignVCenter
         elide: Text.ElideRight
       }
+    }
     }
   }
 }


### PR DESCRIPTION
Added scroll view and simplified calculation of height/margins of the register form. The height of Qt.InputMethod and keyboard rectangle was used using implicit changed signal to change form's height/margins. However, after init of the virtual keyboard, its size wasnt being changed anyway. More promising way is to use visible property.
 
Fixed resizing of the login form with same pattern - the whole form was lifted when keyboard was shown, but it wasnt put back afterwards.
closes #863 