### PR TITLE
Forwarding logs from geodiff

### DIFF
--- a/app/geodiffutils.cpp
+++ b/app/geodiffutils.cpp
@@ -109,3 +109,17 @@ bool GeodiffUtils::applyDiffs( const QString &src, const QStringList &diffFiles 
   }
   return true;
 }
+
+void GeodiffUtils::log( GEODIFF_LoggerLevel level, const char *msg )
+{
+  QString prefix;
+  switch ( level )
+  {
+    case LevelError: prefix = "GEODIFF error: "; break;
+    case LevelWarning: prefix = "GEODIFF warning: "; break;
+    case LevelInfo: prefix = "GEODIFF info: "; break;
+    case LevelDebug: prefix = "GEODIFF debug: "; break;
+    default: break;
+  }
+  InputUtils::log( prefix, msg );
+}

--- a/app/geodiffutils.cpp
+++ b/app/geodiffutils.cpp
@@ -115,10 +115,10 @@ void GeodiffUtils::log( GEODIFF_LoggerLevel level, const char *msg )
   QString prefix;
   switch ( level )
   {
-    case LevelError: prefix = "GEODIFF error: "; break;
-    case LevelWarning: prefix = "GEODIFF warning: "; break;
-    case LevelInfo: prefix = "GEODIFF info: "; break;
-    case LevelDebug: prefix = "GEODIFF debug: "; break;
+    case LevelError: prefix = "GEODIFF error"; break;
+    case LevelWarning: prefix = "GEODIFF warning"; break;
+    case LevelInfo: prefix = "GEODIFF info"; break;
+    case LevelDebug: prefix = "GEODIFF debug"; break;
     default: break;
   }
   InputUtils::log( prefix, msg );

--- a/app/geodiffutils.h
+++ b/app/geodiffutils.h
@@ -13,6 +13,7 @@
 #include <QMap>
 #include <QString>
 
+#include <geodiff.h>
 
 /**
  * Utility functions for working with geodiff library
@@ -53,6 +54,9 @@ class GeodiffUtils
 
     //! Takes "src" file and applies a sequence of changesets for the list in "diffFiles"
     static bool applyDiffs( const QString &src, const QStringList &diffFiles );
+
+    //! Geodiff logger callback function used to forward logs to Input.
+    static void log( GEODIFF_LoggerLevel level, const char *msg );
 };
 
 #endif // GEODIFFUTILS_H

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -54,7 +54,7 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
   loadAuthData();
   GEODIFF_init();
   GEODIFF_setLoggerCallback( &GeodiffUtils::log );
-  GEODIFF_setMaximumLoggerLevel( GEODIFF_LoggerLevel::LevelInfo );
+  GEODIFF_setMaximumLoggerLevel( GEODIFF_LoggerLevel::LevelDebug );
 }
 
 MerginUserAuth *MerginApi::userAuth() const

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -53,6 +53,8 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
 
   loadAuthData();
   GEODIFF_init();
+  GEODIFF_setLoggerCallback( &GeodiffUtils::log );
+  GEODIFF_setMaximumLoggerLevel( GEODIFF_LoggerLevel::LevelInfo );
 }
 
 MerginUserAuth *MerginApi::userAuth() const


### PR DESCRIPTION
Currently set logging level to `info`. 
Just an idea: it might be useful to set log level according type of build (production, dev, debug,..)
closes #688 