### PR TITLE
Fix: Previous geometry used bug

### DIFF
--- a/app/digitizingcontroller.cpp
+++ b/app/digitizingcontroller.cpp
@@ -233,6 +233,7 @@ void DigitizingController::startRecording()
 void DigitizingController::stopRecording()
 {
   mRecording = false;
+  mRecordedPoints.clear();
   emit recordingChanged();
 }
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -55,6 +55,7 @@ ApplicationWindow {
             if (stateManager.state === "view") {
                 recordToolbar.visible = false
                 mainPanel.focus = true
+                digitizing.stopRecording();
             }
             else if (stateManager.state === "record") {
                 updateRecordToolbar()
@@ -497,7 +498,6 @@ ApplicationWindow {
                 featurePanel.show_panel(featurePanel.feature, "Edit", "form")
             }
             stateManager.state = "view"
-            digitizing.stopRecording();
             digitizingHighlight.visible = false
         }
 
@@ -506,7 +506,6 @@ ApplicationWindow {
         }
 
          onStopRecordingClicked: {
-             digitizing.stopRecording()
              var pair = digitizing.lineOrPolygonFeature();
              saveRecordedFeature(pair)
              stateManager.state = "view"


### PR DESCRIPTION
We forgot to clean array of recorded points in `digitizing controller` when recording mode stops.

![ezgif com-resize](https://user-images.githubusercontent.com/22449698/94122712-300b2980-fe53-11ea-9874-ae72aa9d403b.gif)

Closes #883 