### PR TITLE
Fix invalid layer loading - postgis

### DIFF
--- a/app/loader.cpp
+++ b/app/loader.cpp
@@ -147,7 +147,7 @@ void Loader::setMapSettingsLayers() const
     if ( nodeLayer->isVisible() )
     {
       QgsMapLayer *layer = nodeLayer->layer();
-      if ( layer->isValid() )
+      if ( layer && layer->isValid() )
       {
         allLayers << layer;
       }


### PR DESCRIPTION
Invalid layer from postgis provider (and potentially other providers as well) returns null, not invalid layer. We did not check it. 

Closes #877 