### PR TITLE
Add logs to the app

### DIFF
--- a/app/loader.cpp
+++ b/app/loader.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "loader.h"
+#include "inpututils.h"
 #include "qgsvectorlayer.h"
 #include "qgslayertree.h"
 #include "qgslayertreelayer.h"
@@ -305,6 +306,15 @@ void Loader::setActiveMapTheme( int index )
 
 void Loader::appStateChanged( Qt::ApplicationState state )
 {
+  QString msg;
+
+  // Instatiate QDebug with QString to redirect output to string
+  // It is used to convert enum to string
+  QDebug logHelper( &msg );
+
+  logHelper << "Application changed state to: " << state;
+  InputUtils::log( "Input", msg );
+
   if ( !mRecording && mPositionKit )
   {
     if ( state == Qt::ApplicationActive )
@@ -316,6 +326,11 @@ void Loader::appStateChanged( Qt::ApplicationState state )
       mPositionKit->source()->stopUpdates();
     }
   }
+}
+
+void Loader::appAboutToQuit()
+{
+  InputUtils::log( "Input", "Application has quit" );
 }
 
 QList<QgsExpressionContextScope *> Loader::globalProjectLayerScopes( QgsMapLayer *layer )

--- a/app/loader.h
+++ b/app/loader.h
@@ -115,6 +115,7 @@ class Loader: public QObject
     void appStateChanged( Qt::ApplicationState state );
     // Reloads project if current project path matches given path (its the same project)
     bool reloadProject( QString projectDir );
+    void appAboutToQuit();
 
   private:
     QString iconFromGeometry( const QgsWkbTypes::GeometryType &geometry );

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -387,6 +387,7 @@ int main( int argc, char *argv[] )
 
   // Connections
   QObject::connect( &app, &QGuiApplication::applicationStateChanged, &loader, &Loader::appStateChanged );
+  QObject::connect( &app, &QCoreApplication::aboutToQuit, &loader, &Loader::appAboutToQuit );
   QObject::connect( ma.get(), &MerginApi::syncProjectFinished, &pm, &ProjectModel::syncedProjectFinished );
   QObject::connect( ma.get(), &MerginApi::listProjectsFinished, &mpm, &MerginProjectModel::resetProjects );
   QObject::connect( ma.get(), &MerginApi::syncProjectStatusChanged, &mpm, &MerginProjectModel::syncProjectStatusChanged );

--- a/app/qml/TextHyperlink.qml
+++ b/app/qml/TextHyperlink.qml
@@ -13,7 +13,7 @@ import "."  // import InputStyle singleton
 
 Text {
     width: parent.width
-    height: paren.height
+    height: parent.height
     color: InputStyle.fontColor
     onLinkActivated: Qt.openUrlExternally(link)
     textFormat: Text.StyledText


### PR DESCRIPTION
Added logs for state change of the application:
 - **minimizing** and **maximizing** 
 - **quit**
 - **start**
 - **lock and unlock** 

> Note: lock and unlock logs are the same as minimizing and maximizing logs due to the same state in Qt:ApplicationState

States: https://doc.qt.io/qt-5/qt.html#ApplicationState-enum

Closes #894 

**EDIT:**
There was bug with wrongly typed variable name in `TextHyperlink.qml`, `paren` instead of `parent` so I added it here

![image](https://user-images.githubusercontent.com/22449698/94431673-e180c680-0195-11eb-9e0e-1356d63d62e3.png)
