### PR TITLE
Fix android back button on startup with active project

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -243,6 +243,7 @@ ApplicationWindow {
         __loader.recording = digitizing.recording
         __loader.mapSettings = mapCanvas.mapSettings
 
+        mainPanel.forceActiveFocus()
         console.log("Completed Running!")
     }
 


### PR DESCRIPTION
Android back button did not work when app was opened with active project.

Solution ~> force focus on start to `MainPanel` component

Closes #876