### PR TITLE
Position fix of notice text for Subscribe page

### DIFF
--- a/app/qml/SubscribePage.qml
+++ b/app/qml/SubscribePage.qml
@@ -156,7 +156,9 @@ Rectangle {
   TextHyperlink {
     id: textNotice
     width: parent.width
+    height: InputStyle.rowHeightHeader
     anchors.bottom: parent.bottom
+    anchors.bottomMargin: InputStyle.rowHeightHeader/2
     text: qsTr("Your Mergin subscription plan will renew automatically. You can cancel or change it at any time. %1Learn More%2")
               .arg("<a href='" + __inputHelp.merginSubscriptionDetailsLink + "'>")
               .arg("</a>")


### PR DESCRIPTION
Defined height and bottom margin.
Note that it is still not optimised for super small screens - it can be wrapped in ScrallView. Should work on the most screens though.

<img width="326" alt="Screenshot 2020-09-29 at 16 29 39" src="https://user-images.githubusercontent.com/6735606/94572849-c4b9c100-0271-11eb-8b1b-efba1a0489d1.png">

closes #899 
