### PR TITLE
Fix unfinished download files 

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -268,6 +268,16 @@ QString InputUtils::logFilename()
   return sLogFile;
 }
 
+bool InputUtils::createFile( const QString &filePath )
+{
+  QFile newFile( filePath );
+  if ( !newFile.open( QIODevice::WriteOnly ) )
+    return false;
+
+  newFile.close();
+  return true;
+}
+
 QString InputUtils::filesToString( QList<MerginFile> files )
 {
   QStringList resultList;
@@ -446,6 +456,12 @@ QString InputUtils::renameWithDateTime( const QString &srcPath, const QDateTime 
   }
 
   return QString();
+}
+
+QString InputUtils::downloadInProgressFilePath( const QString &projectDir )
+{
+  // Use first 11 characters of sha-256 of text "Input" to create unique file name
+  return projectDir + "/.mergin/.project-36ecb4f8669.downloading";
 }
 
 void InputUtils::showNotification( const QString &message )

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -268,7 +268,7 @@ QString InputUtils::logFilename()
   return sLogFile;
 }
 
-bool InputUtils::createFile( const QString &filePath )
+bool InputUtils::createEmptyFile( const QString &filePath )
 {
   QFile newFile( filePath );
   if ( !newFile.open( QIODevice::WriteOnly ) )
@@ -460,8 +460,7 @@ QString InputUtils::renameWithDateTime( const QString &srcPath, const QDateTime 
 
 QString InputUtils::downloadInProgressFilePath( const QString &projectDir )
 {
-  // Use first 11 characters of sha-256 of text "Input" to create unique file name
-  return projectDir + "/.mergin/.project-36ecb4f8669.downloading";
+  return projectDir + "/.mergin/.project.downloading";
 }
 
 void InputUtils::showNotification( const QString &message )

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -113,7 +113,7 @@ class InputUtils: public QObject
 
     static QString logFilename();
 
-    static bool createFile( const QString &filePath );
+    static bool createEmptyFile( const QString &filePath );
 
     static QString filesToString( QList<MerginFile> files );
 

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -70,6 +70,12 @@ class InputUtils: public QObject
      */
     Q_INVOKABLE static QString renameWithDateTime( const QString &srcPath, const QDateTime &dateTime = QDateTime() );
 
+    /**
+     * Returns name of temporary file indicating first time download of project is in progress
+     * \param projectName
+     */
+    static QString downloadInProgressFilePath( const QString &projectDir );
+
     Q_INVOKABLE void showNotification( const QString &message );
 
     /**
@@ -106,6 +112,8 @@ class InputUtils: public QObject
     static void setLogFilename( const QString &value );
 
     static QString logFilename();
+
+    static bool createFile( const QString &filePath );
 
     static QString filesToString( QList<MerginFile> files );
 

--- a/app/localprojectsmanager.cpp
+++ b/app/localprojectsmanager.cpp
@@ -11,6 +11,7 @@
 
 #include "merginapi.h"
 #include "merginprojectmetadata.h"
+#include "inpututils.h"
 
 #include <QDir>
 #include <QDirIterator>
@@ -184,12 +185,21 @@ QString LocalProjectsManager::findQgisProjectFile( const QString &projectDir, QS
 {
   QList<QString> foundProjectFiles;
   QDirIterator it( projectDir, QStringList() << QStringLiteral( "*.qgs" ) << QStringLiteral( "*.qgz" ), QDir::Files, QDirIterator::Subdirectories );
+
   while ( it.hasNext() )
   {
     it.next();
     foundProjectFiles << it.filePath();
   }
-  if ( foundProjectFiles.count() == 1 )
+
+  if ( QFile::exists( InputUtils::downloadInProgressFilePath( projectDir ) ) )
+  {
+    // if this is a mergin project and file indicating download in progress is still there
+    // download failed or copying from .temp to project dir failed (app was probably closed meanwhile)
+
+    err = tr( "Download failed, remove and download project again" );
+  }
+  else if ( foundProjectFiles.count() == 1 )
   {
     return foundProjectFiles.first();
   }
@@ -198,11 +208,12 @@ QString LocalProjectsManager::findQgisProjectFile( const QString &projectDir, QS
     // error: multiple project files found
     err = tr( "Found multiple QGIS project files" );
   }
-  else
+  else if ( foundProjectFiles.count() < 1 )
   {
     // no projects
     err = tr( "Failed to find a QGIS project file" );
   }
+
   return QString();
 }
 

--- a/app/localprojectsmanager.cpp
+++ b/app/localprojectsmanager.cpp
@@ -183,6 +183,15 @@ void LocalProjectsManager::updateProjectErrors( const QString &projectDir, const
 
 QString LocalProjectsManager::findQgisProjectFile( const QString &projectDir, QString &err )
 {
+  if ( QFile::exists( InputUtils::downloadInProgressFilePath( projectDir ) ) )
+  {
+    // if this is a mergin project and file indicating download in progress is still there
+    // download failed or copying from .temp to project dir failed (app was probably closed meanwhile)
+
+    err = tr( "Download failed, remove and download project again" );
+    return QString();
+  }
+
   QList<QString> foundProjectFiles;
   QDirIterator it( projectDir, QStringList() << QStringLiteral( "*.qgs" ) << QStringLiteral( "*.qgz" ), QDir::Files, QDirIterator::Subdirectories );
 
@@ -192,14 +201,7 @@ QString LocalProjectsManager::findQgisProjectFile( const QString &projectDir, QS
     foundProjectFiles << it.filePath();
   }
 
-  if ( QFile::exists( InputUtils::downloadInProgressFilePath( projectDir ) ) )
-  {
-    // if this is a mergin project and file indicating download in progress is still there
-    // download failed or copying from .temp to project dir failed (app was probably closed meanwhile)
-
-    err = tr( "Download failed, remove and download project again" );
-  }
-  else if ( foundProjectFiles.count() == 1 )
+  if ( foundProjectFiles.count() == 1 )
   {
     return foundProjectFiles.first();
   }

--- a/app/localprojectsmanager.cpp
+++ b/app/localprojectsmanager.cpp
@@ -188,7 +188,7 @@ QString LocalProjectsManager::findQgisProjectFile( const QString &projectDir, QS
     // if this is a mergin project and file indicating download in progress is still there
     // download failed or copying from .temp to project dir failed (app was probably closed meanwhile)
 
-    err = tr( "Download failed, remove and download project again" );
+    err = tr( "Download failed, remove and retry" );
     return QString();
   }
 

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -145,6 +145,15 @@ void MerginApi::downloadNextItem( const QString &projectFullName )
                    ( !range.isEmpty() ? " Range: " + range : QString() ) );
 }
 
+void MerginApi::removeProjectsTempFolder( const QString &projectNamespace, const QString &projectName )
+{
+  if ( projectNamespace.isEmpty() || projectName.isEmpty() )
+    return; // otherwise we could remove enitre users temp or entire .temp
+
+  QString path = getTempProjectDir( getFullProjectName( projectNamespace, projectName ) );
+  QDir( path ).removeRecursively();
+}
+
 QNetworkRequest MerginApi::getDefaultRequest( bool withAuth )
 {
   QNetworkRequest request;
@@ -855,7 +864,6 @@ void MerginApi::pingMerginReplyFinished()
   r->deleteLater();
   emit pingMerginFinished( apiVersion, serverSupportsSubscriptions, serverMsg );
 }
-
 
 QNetworkReply *MerginApi::getProjectInfo( const QString &projectFullName, bool withoutAuth )
 {
@@ -1594,6 +1602,9 @@ void MerginApi::startProjectUpdate( const QString &projectFullName, const QByteA
     QString projectNamespace;
     QString projectName;
     extractProjectName( projectFullName, projectNamespace, projectName );
+
+    // remove any leftover temp files that could be created from previous unsuccessful download
+    removeProjectsTempFolder( projectNamespace, projectName );
 
     // project has not been downloaded yet - we need to create a directory for it
     transaction.projectDir = createUniqueProjectDirectory( projectName );

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -1407,6 +1407,11 @@ void MerginApi::finalizeProjectUpdate( const QString &projectFullName )
   {
     QString projectNamespace, projectName;
     extractProjectName( projectFullName, projectNamespace, projectName );
+
+    // remove download in progress file
+    if ( !QFile::remove( InputUtils::downloadInProgressFilePath( transaction.projectDir ) ) )
+      InputUtils::log( "sync " + projectFullName, QStringLiteral( "Failed to remove download in progress file for project name %1" ).arg( projectName ) );
+
     mLocalProjects.addMerginProject( projectDir, projectNamespace, projectName );
   }
 
@@ -2276,13 +2281,6 @@ void MerginApi::finishProjectSync( const QString &projectFullName, bool syncSucc
     // update info of local projects
     mLocalProjects.updateMerginLocalVersion( transaction.projectDir, transaction.version );
     mLocalProjects.updateMerginServerVersion( transaction.projectDir, transaction.version );
-
-    QString projectName, projectNamespace;
-    extractProjectName( projectFullName, projectNamespace, projectName );
-
-    // remove download in progress file
-    if ( !QFile::remove( InputUtils::downloadInProgressFilePath( transaction.projectDir ) ) )
-      InputUtils::log( "sync " + projectFullName, QStringLiteral( "Failed to remove download in progress file for project name %1" ).arg( projectName ) );
 
     InputUtils::log( "sync " + projectFullName, QStringLiteral( "### Finished ###  New project version: %1\n" ).arg( transaction.version ) );
   }

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -1594,6 +1594,11 @@ void MerginApi::startProjectUpdate( const QString &projectFullName, const QByteA
     transaction.projectDir = createUniqueProjectDirectory( projectName );
     transaction.firstTimeDownload = true;
 
+    // create file indicating first time download in progress
+    QString downloadInProgressFilePath = InputUtils::downloadInProgressFilePath( transaction.projectDir );
+    createPathIfNotExists( downloadInProgressFilePath );
+    InputUtils::createFile( downloadInProgressFilePath );
+
     InputUtils::log( "pull " + projectFullName, QStringLiteral( "First time download - new directory: " ) + transaction.projectDir );
   }
 
@@ -2270,6 +2275,13 @@ void MerginApi::finishProjectSync( const QString &projectFullName, bool syncSucc
     // update info of local projects
     mLocalProjects.updateMerginLocalVersion( transaction.projectDir, transaction.version );
     mLocalProjects.updateMerginServerVersion( transaction.projectDir, transaction.version );
+
+    QString projectName, projectNamespace;
+    extractProjectName( projectFullName, projectNamespace, projectName );
+
+    // remove download in progress file
+    if ( !QFile::remove( InputUtils::downloadInProgressFilePath( transaction.projectDir ) ) )
+      InputUtils::log( "sync " + projectFullName, QStringLiteral( "Failed to remove download in progress file for project name %1" ).arg( projectName ) );
 
     InputUtils::log( "sync " + projectFullName, QStringLiteral( "### Finished ###  New project version: %1\n" ).arg( transaction.version ) );
   }

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -1418,7 +1418,7 @@ void MerginApi::finalizeProjectUpdate( const QString &projectFullName )
 
     // remove download in progress file
     if ( !QFile::remove( InputUtils::downloadInProgressFilePath( transaction.projectDir ) ) )
-      InputUtils::log( "sync " + projectFullName, QStringLiteral( "Failed to remove download in progress file for project name %1" ).arg( projectName ) );
+      InputUtils::log( QStringLiteral( "sync %1" ).arg( projectFullName ), QStringLiteral( "Failed to remove download in progress file for project name %1" ).arg( projectName ) );
 
     mLocalProjects.addMerginProject( projectDir, projectNamespace, projectName );
   }
@@ -1613,8 +1613,8 @@ void MerginApi::startProjectUpdate( const QString &projectFullName, const QByteA
     // create file indicating first time download in progress
     QString downloadInProgressFilePath = InputUtils::downloadInProgressFilePath( transaction.projectDir );
     createPathIfNotExists( downloadInProgressFilePath );
-    InputUtils::createFile( downloadInProgressFilePath );
-    Q_ASSERT( QFile::exists( downloadInProgressFilePath ) );
+    if ( !InputUtils::createEmptyFile( downloadInProgressFilePath ) )
+      InputUtils::log( QStringLiteral( "pull %1" ).arg( projectFullName ), "Unable to create temporary download in progress file" );
 
     InputUtils::log( "pull " + projectFullName, QStringLiteral( "First time download - new directory: " ) + transaction.projectDir );
   }

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -1598,6 +1598,7 @@ void MerginApi::startProjectUpdate( const QString &projectFullName, const QByteA
     QString downloadInProgressFilePath = InputUtils::downloadInProgressFilePath( transaction.projectDir );
     createPathIfNotExists( downloadInProgressFilePath );
     InputUtils::createFile( downloadInProgressFilePath );
+    Q_ASSERT( QFile::exists( downloadInProgressFilePath ) );
 
     InputUtils::log( "pull " + projectFullName, QStringLiteral( "First time download - new directory: " ) + transaction.projectDir );
   }

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -523,6 +523,9 @@ class MerginApi: public QObject
     //! Starts download request of another item
     void downloadNextItem( const QString &projectFullName );
 
+    //! Removes temp folder for project
+    void removeProjectsTempFolder( const QString &projectNamespace, const QString &projectName );
+
     QNetworkRequest getDefaultRequest( bool withAuth = true );
 
     bool projectFileHasBeenUpdated( const ProjectDiff &diff );

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -170,6 +170,9 @@ void TestMerginApi::testDownloadProject()
   // there should be something in the directory
   QStringList projectDirEntries = QDir( project.projectDir ).entryList( QDir::AllEntries | QDir::NoDotAndDotDot );
   QCOMPARE( projectDirEntries.count(), 2 );
+
+  // verify that download in progress file is erased
+  QVERIFY( !QFile::exists( InputUtils::downloadInProgressFilePath( mTestDataPath + "/" + TEST_PROJECT_NAME ) ) );
 }
 
 void TestMerginApi::createRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName, const QString &sourcePath )


### PR DESCRIPTION
What has changed:

- Added temp file to `.mergin` folder to indicate (first time) download in progress
- File is removed once the project is successfully downloaded, but is kept within the project if application was closed during download ~ unsuccessful download
- If this file is found during startup check, given project is considered invalid
- Also we now clear the temp folder of given project when it should be downloaded for the first time in case there was previous unsuccessful attempt to download and some chunks were left here

Closes #884