### PR TITLE
Update: Android back button #916

### DIFF
--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -118,28 +118,28 @@ Item {
 
   Keys.onReleased: {
     if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
-      if (!projectsPanel.visible || !activeProjectPath)
-      {
-        return; // Closes app - no project is opened or mergin panel has focus in map view
-      }
-      else if (authPanel.visible) // back to project view
+      if ( authPanel.visible ) // back to project view
       {
         authPanel.visible = false;
         projectsPanel.forceActiveFocus();
         homeBtn.activated();
         event.accepted = true;
       }
-      else if (accountPanel.visible) // back to project view
+      else if ( accountPanel.visible ) // back to project view
       {
         accountPanel.visible = false;
         event.accepted = true;
       }
-      else if (statusPanel.visible) // back to project view
+      else if ( statusPanel.visible ) // back to project view
       {
         event.accepted = true;
         statusPanel.close();
       }
-      else if (projectsPanel.visible) // back to map
+      else if ( projectsPanel.visible && !activeProjectPath ) // Closes app - no active project
+      {
+        return;
+      }
+      else if ( projectsPanel.visible ) // back to map
       {
         event.accepted = true;
         projectsPanel.visible = false;

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -37,6 +37,9 @@ Page {
         if (aboutPanel.visible) { // hide about panel
           aboutPanel.visible = false;
         }
+        else if (logPanel.visible) {
+          logPanel.visible = false
+        }
         else if (settingsPanel.visible) {
           settingsPanel.visible = false;
         }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -244,7 +244,10 @@ ApplicationWindow {
         __loader.recording = digitizing.recording
         __loader.mapSettings = mapCanvas.mapSettings
 
-        mainPanel.forceActiveFocus()
+        // get focus when any project is active, otherwise let focus to merginprojectpanel
+        if ( __appSettings.activeProject )
+          mainPanel.forceActiveFocus()
+
         console.log("Completed Running!")
     }
 
@@ -570,10 +573,10 @@ ApplicationWindow {
 
         onVisibleChanged: {
           if (openProjectPanel.visible)
-            openProjectPanel.focus = true
+            openProjectPanel.forceActiveFocus()
           else
           {
-            mainPanel.focus = true
+            mainPanel.forceActiveFocus()
           }
         }
 


### PR DESCRIPTION
While working on #916 I found 2 other issues that this PR addresses, original bug should be fixed by refactoring in #917. 

**One with log panel**: Hitting back on android in log panel was not consistent with back button in header. (android back leaded immediately to map view while in-app back led to settings panel)

**Second issue**: Wrong component received focus when application started without active project.

These changes should not conflict with #917 