### PR TITLE
Added initial state for stateManger

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -36,6 +36,7 @@ ApplicationWindow {
 
     Item {
         id: stateManager
+        state: "view"
         states: [
             // Default state - when none of state below
             State {


### PR DESCRIPTION
Auto-centering option was "ignored" due to not initialised state of stateManger.
The condition with empty state was not satisfied, so even though auto-center was on, nothing happen.
Related code (condition): https://github.com/lutraconsulting/input/blob/master/app/qml/main.qml#L377

closes #927 