### PR TITLE
Fixed subscription URL

### DIFF
--- a/app/ios/iospurchasing.h
+++ b/app/ios/iospurchasing.h
@@ -101,7 +101,7 @@ class IosPurchasingBackend: public PurchasingBackend
     void createTransaction( QSharedPointer<PurchasingPlan> plan ) override;
     void restore() override;
 
-    QString subscriptionManageUrl() override {return "https://apps.apple.com/account/subscription"; }
+    QString subscriptionManageUrl() override {return "https://apps.apple.com/account/subscriptions"; }
     QString subscriptionBillingUrl() override {return "https://apps.apple.com/account/billing"; }
     MerginSubscriptionType::SubscriptionType provider() const override { return MerginSubscriptionType::AppleSubscriptionType; }
     bool userCanMakePayments() const override;


### PR DESCRIPTION
Issue reported by @saberraz that `manage subscription` button always comes out with an error message instead of opening AppStore/Subscriptions.

Tested on local iOS build and desktop

Source: https://developer.apple.com/documentation/storekit/in-app_purchase/subscriptions_and_offers/handling_subscriptions_billing