### PR TITLE
Add guide lines and polygons when recording new features

### DIFF
--- a/app/qml/Highlight.qml
+++ b/app/qml/Highlight.qml
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -31,7 +31,7 @@ Item {
   property color outlineColor: "black"
 
   property string markerType: "circle"   // "circle" or "image"
-  property color markerColor: "red"
+  property color markerColor: "grey"
   property real markerWidth: 30 * QgsQuick.Utils.dp
   property real markerHeight: 30 * QgsQuick.Utils.dp
   property real markerAnchorX: markerWidth/2
@@ -50,7 +50,7 @@ Item {
   // internal properties not meant to be modified from outside
   //
   property real markerOffsetY: 14 * QgsQuick.Utils.dp // for circle marker type to be aligned with crosshair
-  property real markerCircleSize: 20 * QgsQuick.Utils.dp
+  property real markerCircleSize: 15 * QgsQuick.Utils.dp
 
   // transform used by line/path
   property QgsQuick.MapTransform mapTransform: QgsQuick.MapTransform {
@@ -78,6 +78,7 @@ Item {
     let newMarkerItems = []
     let newLineElements = []
     let newPolygonElements = []
+    let newHelperLineElements = []
 
     let typeIdx = 0
     let dataStartIndex = ( data[ typeIdx ] === 0 ? 1 : 2 ) // point data starts from index 1, others from index 2
@@ -116,10 +117,11 @@ Item {
 
         // place temp line to center of screen for visual feedback
         if ( isRecording ) {
+          newHelperLineElements.push( componentMoveTo.createObject( tempLinePath, { "x": elems[ elems.length - 1 ].x, "y": elems[ elems.length - 1 ].y } ) )
 
           let crosshairCoord = Qt.point( mapCanvas.width/2, mapCanvas.height/2 )
           crosshairCoord = mapCanvas.mapSettings.screenToCoordinate( crosshairCoord )  // map CRS
-          elems.push( componentLineTo.createObject( tempLinePath, { "x": crosshairCoord.x, "y": crosshairCoord.y } ) )
+          newHelperLineElements.push( componentLineTo.createObject( tempLinePath, { "x": crosshairCoord.x, "y": crosshairCoord.y } ) )
         }
       }
     }
@@ -136,7 +138,8 @@ Item {
       newPolygonElements.push(componentMoveTo.createObject(polygonShapePath))
     polygonShapePath.pathElements = newPolygonElements
 
-//    tempLinePath.pathElements = newLineElements
+    tempLinePath.pathElements = newHelperLineElements
+
     // TODO: change
     updateTempLine = true
   }
@@ -146,7 +149,7 @@ Item {
       return
 
     // TODO: check if recording line or polygon (by actual featureLayerPair)
-    let elements = Object.values(lineOutlineShapePath.pathElements)
+    let elements = Object.values( tempLinePath.pathElements )
 
     // if we have not yet added any point, do not draw a line
     if ( elements.length === 1 && elements[0].x === 0 && elements[0].y === 0 )
@@ -154,14 +157,15 @@ Item {
 
     let tmp = elements.pop()
 
-    if (elements.length === 0)
-      elements.push( componentMoveTo.createObject( lineShapePath, { "x": tmp.x, "y": tmp.y } ) )
+//    if (elements.length === 0)
+//      elements.push( componentMoveTo.createObject( tempLinePath, { "x": tmp.x, "y": tmp.y } ) )
 
     let crosshairCoord = Qt.point( mapCanvas.width/2, mapCanvas.height/2 )
     crosshairCoord = mapCanvas.mapSettings.screenToCoordinate( crosshairCoord )  // map CRS
+
     elements.push( componentLineTo.createObject( tempLinePath, { "x": crosshairCoord.x, "y": crosshairCoord.y } ) )
-    lineOutlineShapePath.pathElements = elements
-//    tempLinePath.pathElements = elements
+//    lineOutlineShapePath.pathElements = elements
+    tempLinePath.pathElements = elements
   }
 
   // keeps list of currently displayed marker items (an internal property)
@@ -239,7 +243,7 @@ Item {
     ShapePath {
       id: tempLinePath
       fillColor: "transparent"
-      strokeColor: "blue"
+      strokeColor: "grey"
       capStyle: ShapePath.RoundCap
     }
   }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -387,6 +387,7 @@ ApplicationWindow {
             // sets previous useGpsPoint value, because setCenter triggers extentChanged signal which changes this property
             digitizing.useGpsPoint = useGpsPoint
         }
+
         digitizingHighlight.positionChanged()
       }
     }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -249,6 +249,11 @@ ApplicationWindow {
         if ( __appSettings.activeProject )
           mainPanel.forceActiveFocus()
 
+        window.width = 423
+        window.height = 601
+        window.x = 1100
+        window.y = 266
+
         console.log("Completed Running!")
     }
 
@@ -336,6 +341,7 @@ ApplicationWindow {
       markerWidth: highlight.markerWidth
       markerHeight: highlight.markerHeight
       markerAnchorY: highlight.markerAnchorY
+      isRecording: digitizing.recording
 
       // enable anti-aliasing to make the higlight look nicer
       // https://stackoverflow.com/questions/48895449/how-do-i-enable-antialiasing-on-qml-shapes
@@ -381,6 +387,7 @@ ApplicationWindow {
             // sets previous useGpsPoint value, because setCenter triggers extentChanged signal which changes this property
             digitizing.useGpsPoint = useGpsPoint
         }
+        digitizingHighlight.positionChanged()
       }
     }
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -337,6 +337,7 @@ ApplicationWindow {
       markerHeight: highlight.markerHeight
       markerAnchorY: highlight.markerAnchorY
       recordingInProgress: digitizing.recording
+      guideLineAllowed: digitizing.manualRecording && stateManager.state === "record"
 
       // enable anti-aliasing to make the higlight look nicer
       // https://stackoverflow.com/questions/48895449/how-do-i-enable-antialiasing-on-qml-shapes

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -249,11 +249,6 @@ ApplicationWindow {
         if ( __appSettings.activeProject )
           mainPanel.forceActiveFocus()
 
-        window.width = 423
-        window.height = 601
-        window.x = 1100
-        window.y = 266
-
         console.log("Completed Running!")
     }
 
@@ -324,7 +319,7 @@ ApplicationWindow {
       id: digitizingHighlight
       anchors.fill: mapCanvas
 
-      property bool hasPolygon: featureLayerPair !== null ? digitizing.hasPolygonGeometry(featureLayerPair.layer) : false
+      hasPolygon: featureLayerPair !== null ? digitizing.hasPolygonGeometry(featureLayerPair.layer) : false
 
       mapSettings: mapCanvas.mapSettings
 
@@ -341,7 +336,7 @@ ApplicationWindow {
       markerWidth: highlight.markerWidth
       markerHeight: highlight.markerHeight
       markerAnchorY: highlight.markerAnchorY
-      isRecording: digitizing.recording
+      recordingInProgress: digitizing.recording
 
       // enable anti-aliasing to make the higlight look nicer
       // https://stackoverflow.com/questions/48895449/how-do-i-enable-antialiasing-on-qml-shapes


### PR DESCRIPTION
Enriches UI/UX experience while recording new linestrings and polygons by adding leading line / polygon as can be seen below:

<table>
  <tr>
    <th>Capturing Linestring</th>
    <th>Capturing Polygon</th>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/22449698/97553792-2d619e00-19d6-11eb-9868-18debcc8e9ea.gif" width="300"/></td>
    <td><img src="https://user-images.githubusercontent.com/22449698/97553892-4d915d00-19d6-11eb-996e-be558789595c.gif"  width="300"/></td>
  </tr>
 </table>

Closes #309 