### PR TITLE
Value relation page - android problems

### DIFF
--- a/app/qml/BrowseDataFeaturesPanel.qml
+++ b/app/qml/BrowseDataFeaturesPanel.qml
@@ -45,6 +45,11 @@ Item {
       __inputUtils.showNotification( qsTr( "Showing only the first %1 features" ).arg( featuresLimit ) )
   }
 
+  onVisibleChanged: {
+    if ( !visible && __androidUtils.isAndroid )
+      searchBar.deactivate()
+  }
+
   Page {
     id: featuresPage
     anchors.fill: parent

--- a/app/qml/BrowseDataFeaturesPanel.qml
+++ b/app/qml/BrowseDataFeaturesPanel.qml
@@ -46,6 +46,7 @@ Item {
   }
 
   onVisibleChanged: {
+    // On Android, due to a Qt bug, we need to call deactivate again on page close to clear text search
     if ( !visible && __androidUtils.isAndroid )
       searchBar.deactivate()
   }

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -299,5 +299,7 @@ Drawer {
 
     ValueRelationWidget {
       id: valueRelationWidget
+
+      onWidgetClosed: backHandler.forceActiveFocus()
     }
 }

--- a/app/qml/ValueRelationWidget.qml
+++ b/app/qml/ValueRelationWidget.qml
@@ -2,6 +2,7 @@ import QtQuick 2.0
 import QtQuick.Controls 2.12
 
 Item {
+  signal widgetClosed()
 
   property alias handler: valueRelationHandler
 
@@ -17,6 +18,7 @@ Item {
         valueRelationPage.visible = true
         valueRelationPage.featuresModel = valueRelationModel
         valueRelationPage.pageTitle = itemWidget.fieldName
+        valueRelationPage.forceActiveFocus()
       }
       else {
         itemWidget.openCombobox()
@@ -28,6 +30,12 @@ Item {
     }
   }
 
+  function closeValueRelationPage() {
+    valueRelationPage.visible = false
+    valueRelationPage.deactivateSearch()
+    valueRelationWidget.widgetClosed()
+  }
+
   id: valueRelationWidget
   anchors.fill: parent
 
@@ -37,18 +45,23 @@ Item {
     anchors.fill: parent
 
     onBackButtonClicked: {
-      valueRelationPage.visible = false
-      valueRelationPage.deactivateSearch()
+      closeValueRelationPage()
     }
 
     onFeatureClicked: {
       valueRelationHandler.featureSelected( featureIdx )
-      valueRelationPage.visible = false
-      valueRelationPage.deactivateSearch()
+      closeValueRelationPage()
     }
 
     onSearchTextChanged: {
       featuresModel.filterExpression = text
+    }
+
+    Keys.onReleased: {
+      if ( valueRelationPage.visible && ( event.key === Qt.Key_Back || event.key === Qt.Key_Escape ) ) {
+        event.accepted = true;
+        closeValueRelationPage()
+      }
     }
   }
 }


### PR DESCRIPTION
PR fixes 2 bugs with value relation page:
 - search text were not being cleared on Android. We read `displaytext` property and looks like it is not being updated immediately
 - back button now working

Fixes #952 