### PR TITLE
Added link to reset password

### DIFF
--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -642,6 +642,16 @@ void MerginApi::resetApiRoot()
   settings.endGroup();
 }
 
+QString MerginApi::resetPasswordURl()
+{
+  if ( !mApiRoot.isEmpty() )
+  {
+    QUrl base( mApiRoot );
+    return base.resolved( QUrl( "login/reset" ) ).toString();
+  }
+  return QString( "" );
+}
+
 void MerginApi::createProject( const QString &projectNamespace, const QString &projectName )
 {
   if ( !validateAuthAndContinute() || mApiVersionStatus != MerginApiStatus::OK )

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -642,14 +642,14 @@ void MerginApi::resetApiRoot()
   settings.endGroup();
 }
 
-QString MerginApi::resetPasswordURl()
+QString MerginApi::resetPasswordUrl()
 {
   if ( !mApiRoot.isEmpty() )
   {
     QUrl base( mApiRoot );
     return base.resolved( QUrl( "login/reset" ) ).toString();
   }
-  return QString( "" );
+  return QString();
 }
 
 void MerginApi::createProject( const QString &projectNamespace, const QString &projectName )

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -269,6 +269,7 @@ class MerginApi: public QObject
     Q_INVOKABLE void getUserInfo();
     Q_INVOKABLE void clearAuth();
     Q_INVOKABLE void resetApiRoot();
+    Q_INVOKABLE QString resetPasswordURl();
 
     /**
     * Registers new user to Mergin service.

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -269,7 +269,7 @@ class MerginApi: public QObject
     Q_INVOKABLE void getUserInfo();
     Q_INVOKABLE void clearAuth();
     Q_INVOKABLE void resetApiRoot();
-    Q_INVOKABLE QString resetPasswordURl();
+    Q_INVOKABLE QString resetPasswordUrl();
 
     /**
     * Registers new user to Mergin service.

--- a/app/qml/LoginForm.qml
+++ b/app/qml/LoginForm.qml
@@ -223,10 +223,10 @@ Rectangle {
         id: resetPasswordButton
         width: loginForm.width - 2 * root.panelMargin
         height: fieldHeight * 0.7
-        text: qsTr("Reset password")
+        text: qsTr("Forgot password?")
         font.pixelSize: InputStyle.fontPixelSizeSmall
         anchors.horizontalCenter: parent.horizontalCenter
-        onClicked: Qt.openUrlExternally(__merginApi.resetPasswordURl());
+        onClicked: Qt.openUrlExternally(__merginApi.resetPasswordUrl());
         background: Rectangle {
           color: root.bgColor
         }

--- a/app/qml/LoginForm.qml
+++ b/app/qml/LoginForm.qml
@@ -215,5 +215,31 @@ Rectangle {
         }
       }
     }
+
+    Column {
+      spacing: root.panelMargin / 2
+
+      Button {
+        id: resetPasswordButton
+        width: loginForm.width - 2 * root.panelMargin
+        height: fieldHeight * 0.7
+        text: qsTr("Reset password")
+        font.pixelSize: InputStyle.fontPixelSizeSmall
+        anchors.horizontalCenter: parent.horizontalCenter
+        onClicked: Qt.openUrlExternally(__merginApi.resetPasswordURl());
+        background: Rectangle {
+          color: root.bgColor
+        }
+
+        contentItem: Text {
+          text: resetPasswordButton.text
+          font: resetPasswordButton.font
+          color: InputStyle.highlightColor
+          horizontalAlignment: Text.AlignHCenter
+          verticalAlignment: Text.AlignVCenter
+          elide: Text.ElideRight
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Simple link to forward to mergin web.
Questions/suggestions: Shall the reset password link be located next to the `Sign up` button with backslash delimiter?

![Screenshot_20201109-120733](https://user-images.githubusercontent.com/6735606/98539731-1d2aa800-228d-11eb-81bb-16ca17ffd66f.png)


closes #914 