### PR TITLE
Cascade value relations and Multiple selections

### DIFF
--- a/app/qml/BrowseDataFeaturesPanel.qml
+++ b/app/qml/BrowseDataFeaturesPanel.qml
@@ -14,11 +14,12 @@ Item {
   id: root
 
   signal backButtonClicked()
-  signal featureClicked( var featureIdx )
+  signal featureClicked( var featureIds )
   signal addFeatureClicked()
   signal searchTextChanged( string text )
 
   property bool layerHasGeometry: true
+  property bool allowMultiselect: false
   property string layerName: ""
   property var featuresModel: null
   property int featuresCount: featuresModel ? featuresModel.featuresCount : 0
@@ -88,14 +89,19 @@ Item {
       clip: true
       showAdditionalInfo: root.state == "search"
       featuresModel: root.featuresModel
+      allowMultiselect: root.allowMultiselect
 
-      onFeatureClicked: root.featureClicked( featureIdx )
+      onFeatureClicked: root.featureClicked( featureId )
     }
 
     footer: BrowseDataToolbar {
       id: browseDataToolbar
-      visible: !layerHasGeometry
+      visible: !layerHasGeometry || allowMultiselect
+      addButtonVisible: !layerHasGeometry
+      doneButtonVisible: allowMultiselect
+
       onAddButtonClicked: addFeatureClicked()
+      onDoneButtonClicked: root.featureClicked( browseDataView.selectedIds )
     }
   }
 }

--- a/app/qml/BrowseDataFeaturesPanel.qml
+++ b/app/qml/BrowseDataFeaturesPanel.qml
@@ -25,10 +25,24 @@ Item {
   property int featuresCount: featuresModel ? featuresModel.featuresCount : 0
   property int featuresLimit: featuresModel ? featuresModel.featuresLimit : 0
   property string pageTitle: layerName + " (" + featuresCount + ")"
-  property var preSelectedFeatures: []
+  property var selectedFeatures: []
 
   property var deactivateSearch: function deactivateSearch() {
     searchBar.deactivate()
+  }
+
+  function featureToggled( featureId, toggleState ) {
+    if ( !Array.isArray( selectedFeatures ) )
+      selectedFeatures = []
+    if ( toggleState === Qt.Checked )
+    {
+      selectedFeatures.push( featureId )
+    }
+    else if ( toggleState === Qt.Unchecked )
+    {
+      selectedFeatures = selectedFeatures.filter( _id => _id !== featureId )
+    }
+    browseDataView.preSelectedIds = selectedFeatures // update checkboxes when search changes
   }
 
   states: [
@@ -91,9 +105,10 @@ Item {
       showAdditionalInfo: root.state == "search"
       featuresModel: root.featuresModel
       allowMultiselect: root.allowMultiselect
-      preSelectedIds: preSelectedFeatures
+      preSelectedIds: selectedFeatures
 
       onFeatureClicked: root.featureClicked( featureId )
+      onFeatureToggled: root.featureToggled( featureId, toggleState )
     }
 
     footer: BrowseDataToolbar {
@@ -103,7 +118,7 @@ Item {
       doneButtonVisible: allowMultiselect
 
       onAddButtonClicked: addFeatureClicked()
-      onDoneButtonClicked: root.featureClicked( browseDataView.selectedIds )
+      onDoneButtonClicked: root.featureClicked( root.selectedFeatures )
     }
   }
 }

--- a/app/qml/BrowseDataFeaturesPanel.qml
+++ b/app/qml/BrowseDataFeaturesPanel.qml
@@ -25,6 +25,7 @@ Item {
   property int featuresCount: featuresModel ? featuresModel.featuresCount : 0
   property int featuresLimit: featuresModel ? featuresModel.featuresLimit : 0
   property string pageTitle: layerName + " (" + featuresCount + ")"
+  property var preSelectedFeatures: []
 
   property var deactivateSearch: function deactivateSearch() {
     searchBar.deactivate()
@@ -90,6 +91,7 @@ Item {
       showAdditionalInfo: root.state == "search"
       featuresModel: root.featuresModel
       allowMultiselect: root.allowMultiselect
+      preSelectedIds: preSelectedFeatures
 
       onFeatureClicked: root.featureClicked( featureId )
     }

--- a/app/qml/BrowseDataPanel.qml
+++ b/app/qml/BrowseDataPanel.qml
@@ -70,7 +70,7 @@ Item {
   }
 
   function searchTextEdited( text ) {
-    featuresListModel.filterExpression = text
+    featuresListModel.searchExpression = text
   }
 
   StackView {
@@ -111,7 +111,7 @@ Item {
       id: dataFeaturesPanel
       onBackButtonClicked: popOnePageOrClose()
       onFeatureClicked: {
-        let featurePair = featuresListModel.featureLayerPair( featureIdx )
+        let featurePair = featuresListModel.featureLayerPair( featureIds )
 
         if ( !featurePair.feature.geometry.isNull ) {
           clearStackAndClose() // close view if feature has geometry

--- a/app/qml/BrowseDataToolbar.qml
+++ b/app/qml/BrowseDataToolbar.qml
@@ -14,6 +14,11 @@ import QtQuick.Layouts 1.3
 Item {
 
   signal addButtonClicked()
+  signal doneButtonClicked()
+
+  property bool addButtonVisible: false
+  property bool doneButtonVisible: false
+
   id: root
 
   height: InputStyle.rowHeightHeader
@@ -38,6 +43,7 @@ Item {
       Item {
         height: parent.height
         Layout.fillWidth: true
+        visible: addButtonVisible
 
         MainPanelButton {
           id: addButton
@@ -46,6 +52,22 @@ Item {
           imageSource: "plus.svg"
           onActivated: {
             addButtonClicked()
+          }
+        }
+      }
+
+      Item {
+        height: parent.height
+        Layout.fillWidth: true
+        visible: doneButtonVisible
+
+        MainPanelButton {
+          id: doneButton
+          width: root.height * 0.8
+          text: qsTr("Done")
+          imageSource: "check.svg"
+          onActivated: {
+            doneButtonClicked()
           }
         }
       }

--- a/app/qml/BrowseDataView.qml
+++ b/app/qml/BrowseDataView.qml
@@ -18,18 +18,12 @@ Item {
   id: root
 
   signal featureClicked( var featureId )
+  signal featureToggled( var featureId, var toggleState )
 
   property bool showAdditionalInfo: false
   property bool allowMultiselect: false
   property var featuresModel: null
-  property var selectedIds: []
   property var preSelectedIds: []
-
-  onVisibleChanged: {
-    if ( visible ) {
-      selectedIds.length = 0 // clear the array without copying it
-    }
-  }
 
   ListView {
     topMargin: 10 * QgsQuick.Utils.dp
@@ -46,28 +40,22 @@ Item {
 
       MouseArea {
         anchors.fill: parent
+        propagateComposedEvents: false
         onClicked: {
+
           if ( allowMultiselect ) {
             checkboxItem.toggle()
+            root.featureToggled( model.FeatureId, checkboxItem.checkState )
+          }
+          else root.featureClicked( model.FeatureId )
 
-            if ( checkboxItem.checkState === Qt.Checked )
-              selectedIds.push(model.FeatureId)
-            else if ( checkboxItem.checkState === Qt.Unchecked )
-              selectedIds = selectedIds.filter( _id => _id !== model.FeatureId )
-          }
-          else {
-            root.featureClicked( model.FeatureId )
-          }
         }
       }
 
       Component.onCompleted: { // mark all preselected features
-        if ( Array.isArray(preSelectedIds) ) {
-          preSelectedIds = preSelectedIds.map( id => Number(id) ) // ids can be of string type, convert them to number
-
+        if ( Array.isArray( preSelectedIds ) ) {
           if ( preSelectedIds.includes( model.FeatureId ) ) {
-            checkboxItem.toggle()
-            selectedIds.push(model.FeatureId)
+            checkboxItem.checkState = Qt.Checked
           }
         }
       }
@@ -89,6 +77,8 @@ Item {
             baseColor: InputStyle.panelBackgroundDarker
             height: 40 * QgsQuick.Utils.dp
             width: 40 * QgsQuick.Utils.dp
+
+            onCheckboxClicked: root.featureToggled( model.FeatureId, buttonState )
           }
         }
 

--- a/app/qml/BrowseDataView.qml
+++ b/app/qml/BrowseDataView.qml
@@ -17,10 +17,18 @@ import QgsQuick 0.1 as QgsQuick
 Item {
   id: root
 
-  signal featureClicked( var featureIdx )
+  signal featureClicked( var featureId )
 
   property bool showAdditionalInfo: false
+  property bool allowMultiselect: false
   property var featuresModel: null
+  property var selectedIds: []
+
+  onVisibleChanged: {
+    if ( visible ) {
+      selectedIds.length = 0 // clear the array without copying it
+    }
+  }
 
   ListView {
     topMargin: 10 * QgsQuick.Utils.dp
@@ -38,7 +46,17 @@ Item {
       MouseArea {
         anchors.fill: parent
         onClicked: {
-          root.featureClicked( model.FeatureId )
+          if ( allowMultiselect ) {
+            checkboxItem.toggle()
+
+            if ( checkboxItem.checkState === Qt.Checked )
+              selectedIds.push(model.FeatureId)
+            else if ( checkboxItem.checkState === Qt.Unchecked )
+              selectedIds = selectedIds.filter( _id => _id !== model.FeatureId )
+          }
+          else {
+            root.featureClicked( model.FeatureId )
+          }
         }
       }
 
@@ -94,6 +112,24 @@ Item {
             horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignTop
             elide: Text.ElideRight
+          }
+        }
+
+        Item {
+          id: checkboxContainer
+          visible: allowMultiselect
+          height: itemContainer.height
+          Layout.fillWidth: true
+          Layout.minimumWidth: 60 * QgsQuick.Utils.dp
+          Layout.maximumWidth: 40 * QgsQuick.Utils.dp
+
+          LeftCheckBox {
+            id: checkboxItem
+            anchors.margins: (parent.height / 4)
+            anchors.centerIn: parent
+            baseColor: InputStyle.panelBackgroundDarker
+            height: 40 * QgsQuick.Utils.dp
+            width: 40 * QgsQuick.Utils.dp
           }
         }
       }

--- a/app/qml/BrowseDataView.qml
+++ b/app/qml/BrowseDataView.qml
@@ -23,6 +23,7 @@ Item {
   property bool allowMultiselect: false
   property var featuresModel: null
   property var selectedIds: []
+  property var preSelectedIds: []
 
   onVisibleChanged: {
     if ( visible ) {
@@ -60,14 +61,41 @@ Item {
         }
       }
 
+      Component.onCompleted: { // mark all preselected features
+        if ( Array.isArray(preSelectedIds) ) {
+          preSelectedIds = preSelectedIds.map( id => Number(id) ) // ids can be of string type, convert them to number
+
+          if ( preSelectedIds.includes( model.FeatureId ) ) {
+            checkboxItem.toggle()
+            selectedIds.push(model.FeatureId)
+          }
+        }
+      }
+
       RowLayout {
         id: layout
         anchors.fill: parent
 
         Item {
+          id: checkboxContainer
+          visible: allowMultiselect
+          height: itemContainer.height
+          width: 40 * QgsQuick.Utils.dp
+
+          LeftCheckBox {
+            id: checkboxItem
+            anchors.margins: (parent.height / 4)
+            anchors.centerIn: parent
+            baseColor: InputStyle.panelBackgroundDarker
+            height: 40 * QgsQuick.Utils.dp
+            width: 40 * QgsQuick.Utils.dp
+          }
+        }
+
+        Item {
           id: iconContainer
           height: itemContainer.height
-          width: 60 * QgsQuick.Utils.dp
+          width: checkboxContainer.visible ? 30 * QgsQuick.Utils.dp : 60 * QgsQuick.Utils.dp
 
           Image {
             id: icon
@@ -112,24 +140,6 @@ Item {
             horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignTop
             elide: Text.ElideRight
-          }
-        }
-
-        Item {
-          id: checkboxContainer
-          visible: allowMultiselect
-          height: itemContainer.height
-          Layout.fillWidth: true
-          Layout.minimumWidth: 60 * QgsQuick.Utils.dp
-          Layout.maximumWidth: 40 * QgsQuick.Utils.dp
-
-          LeftCheckBox {
-            id: checkboxItem
-            anchors.margins: (parent.height / 4)
-            anchors.centerIn: parent
-            baseColor: InputStyle.panelBackgroundDarker
-            height: 40 * QgsQuick.Utils.dp
-            width: 40 * QgsQuick.Utils.dp
           }
         }
       }

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -203,6 +203,7 @@ Drawer {
                 property QtObject toolbutton: QtObject {
                   property color backgroundColor: "transparent"
                   property color backgroundColorInvalid: "#bdc3c7"
+                  property color activeButtonColor: InputStyle.panelBackgroundDarker
                   property real size: 80 * QgsQuick.Utils.dp
                 }
 

--- a/app/qml/LeftCheckBox.qml
+++ b/app/qml/LeftCheckBox.qml
@@ -17,6 +17,8 @@ import QtQuick.Templates 2.1 as T
 T.CheckBox {
     id: control
 
+    signal checkboxClicked( var buttonState )
+
     property var spaceWidth: height / 4.0
     property var baseSize: height / 5.5
     property var baseColor: InputStyle.panelBackgroundDarker
@@ -28,6 +30,8 @@ T.CheckBox {
                                                    indicator ? indicator.implicitHeight : 0) + topPadding + bottomPadding)
 
     leftPadding: spaceWidth
+
+    onClicked: control.checkboxClicked( control.checkState )
 
     indicator: Rectangle {
         id: checkboxHandle

--- a/app/qml/SearchBar.qml
+++ b/app/qml/SearchBar.qml
@@ -39,6 +39,7 @@ Rectangle {
   function deactivate() {
     searchField.text = ""
     searchField.focus = false
+    searchTextChanged("")
   }
 
   Timer {

--- a/app/qml/ValueRelationWidget.qml
+++ b/app/qml/ValueRelationWidget.qml
@@ -21,11 +21,16 @@ Item {
     property var valueRelationOpened: function valueRelationOpened( widget, valueRelationModel ) {
       itemWidget = widget
 
+      let selectedFeatures = itemWidget.getCurrentValueAsFeatureId()
+      if ( Array.isArray( selectedFeatures ) ) {
+        selectedFeatures = selectedFeatures.map( id => Number(id) ) // ids can be of string type, convert them to number
+      }
+
       valueRelationLayoutStack.push(componentValueRelationPage, {
                                       featuresModel: valueRelationModel,
                                       pageTitle: itemWidget.fieldName,
                                       allowMultiselect: itemWidget.allowMultipleValues,
-                                      preSelectedFeatures: itemWidget.getCurrentValueAsFeatureId()
+                                      selectedFeatures: selectedFeatures
                                     })
     }
 

--- a/app/qml/ValueRelationWidget.qml
+++ b/app/qml/ValueRelationWidget.qml
@@ -54,7 +54,7 @@ Item {
     }
 
     onSearchTextChanged: {
-      featuresModel.filterExpression = text
+      featuresModel.searchExpression = text
     }
 
     Keys.onReleased: {

--- a/app/qml/ValueRelationWidget.qml
+++ b/app/qml/ValueRelationWidget.qml
@@ -14,11 +14,13 @@ Item {
 
     property var valueRelationOpened: function valueRelationOpened( widget, valueRelationModel ) {
       itemWidget = widget
-      if ( valueRelationModel.featuresCount > 4 ) {
+
+      if ( valueRelationModel.featuresCount > 4 || itemWidget.allowMultipleValues ) {
         valueRelationPage.visible = true
         valueRelationPage.featuresModel = valueRelationModel
         valueRelationPage.pageTitle = itemWidget.fieldName
         valueRelationPage.forceActiveFocus()
+        valueRelationPage.allowMultiselect = itemWidget.allowMultipleValues
       }
       else {
         itemWidget.openCombobox()
@@ -49,7 +51,11 @@ Item {
     }
 
     onFeatureClicked: {
-      valueRelationHandler.featureSelected( featureIdx )
+      if ( typeof featureIds === "object" )
+        featureIds = Object.values( featureIds )
+
+      console.log( featureIds )
+//      valueRelationHandler.featureSelected( featureIds )
       closeValueRelationPage()
     }
 

--- a/app/qml/ValueRelationWidget.qml
+++ b/app/qml/ValueRelationWidget.qml
@@ -15,58 +15,69 @@ Item {
     property var valueRelationOpened: function valueRelationOpened( widget, valueRelationModel ) {
       itemWidget = widget
 
-      if ( valueRelationModel.featuresCount > 4 || itemWidget.allowMultipleValues ) {
-        valueRelationPage.visible = true
-        valueRelationPage.featuresModel = valueRelationModel
-        valueRelationPage.pageTitle = itemWidget.fieldName
-        valueRelationPage.forceActiveFocus()
-        valueRelationPage.allowMultiselect = itemWidget.allowMultipleValues
-      }
-      else {
-        itemWidget.openCombobox()
-      }
+      valueRelationLayoutStack.push(componentValueRelationPage, {
+                                      featuresModel: valueRelationModel,
+                                      pageTitle: itemWidget.fieldName,
+                                      allowMultiselect: itemWidget.allowMultipleValues,
+                                      preSelectedFeatures: itemWidget.getCurrentValueAsFeatureId()
+                                    })
     }
 
-    function featureSelected( index ) {
-      itemWidget.itemSelected( index )
+    function featureSelected( featureIds ) {
+      itemWidget.setValue( featureIds )
+    }
+  }
+
+  StackView {
+    // this stackview can be moved to FeatureForm when we will create multiple instances of feature form
+    id: valueRelationLayoutStack
+    anchors.fill: parent
+    focus: true
+
+    Keys.onReleased: {
+      if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+        event.accepted = true;
+        closeValueRelationPage()
+      }
     }
   }
 
   function closeValueRelationPage() {
-    valueRelationPage.visible = false
-    valueRelationPage.deactivateSearch()
     valueRelationWidget.widgetClosed()
+    valueRelationLayoutStack.clear()
   }
 
   id: valueRelationWidget
   anchors.fill: parent
 
-  BrowseDataFeaturesPanel {
-    id: valueRelationPage
-    visible: false
-    anchors.fill: parent
+  Component {
+    id: componentValueRelationPage
 
-    onBackButtonClicked: {
-      closeValueRelationPage()
-    }
+    BrowseDataFeaturesPanel {
+      id: valueRelationPage
+      anchors.fill: parent
 
-    onFeatureClicked: {
-      if ( typeof featureIds === "object" )
-        featureIds = Object.values( featureIds )
-
-      console.log( featureIds )
-//      valueRelationHandler.featureSelected( featureIds )
-      closeValueRelationPage()
-    }
-
-    onSearchTextChanged: {
-      featuresModel.searchExpression = text
-    }
-
-    Keys.onReleased: {
-      if ( valueRelationPage.visible && ( event.key === Qt.Key_Back || event.key === Qt.Key_Escape ) ) {
-        event.accepted = true;
+      onBackButtonClicked: {
+        deactivateSearch()
         closeValueRelationPage()
+      }
+
+      onFeatureClicked: {
+        valueRelationHandler.featureSelected( featureIds )
+        deactivateSearch()
+        closeValueRelationPage()
+      }
+
+      onSearchTextChanged: {
+        featuresModel.searchExpression = text
+      }
+
+      Keys.onReleased: {
+        if ( event.key === Qt.Key_Back || event.key === Qt.Key_Escape ) {
+          event.accepted = true;
+          deactivateSearch()
+          closeValueRelationPage()
+        }
       }
     }
   }

--- a/app/qml/ValueRelationWidget.qml
+++ b/app/qml/ValueRelationWidget.qml
@@ -12,6 +12,12 @@ Item {
     // pointer to widget from qgis feature form
     property var itemWidget: null
 
+    property var getTypeOfWidget: function getTypeOfWidget( widget, valueRelationModel ) {
+      if ( widget.allowMultipleValues || valueRelationModel.featuresCount > 4 )
+        return "textfield"
+      return "combobox"
+    }
+
     property var valueRelationOpened: function valueRelationOpened( widget, valueRelationModel ) {
       itemWidget = widget
 


### PR DESCRIPTION
Added possibility to select multiple values in value relation field and also filtering values in value relation based on filter expression.

Example:
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/22449698/98811806-b2f73c00-2421-11eb-8f25-c72679abce18.gif)

Relates heavily on https://github.com/qgis/QGIS/pull/39959

Closes #740 and closes #741 