### PR TITLE
change condition for widget loading

### DIFF
--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -442,7 +442,7 @@ Item {
           active: widget !== 'Hidden'
 
           source: {
-            if ( widget )
+            if ( widget !== undefined )
                return form.loadWidgetFn(widget.toLowerCase())
             else return ''
           }


### PR DESCRIPTION
Reason: Sometimes config do not provide field type (passes empty string). In these scenarios we were showing textfield by default. However, in recent changes we have introduced check for undefined widget type (due to another bug), but empty string was resolved as false in condition too and field would not get generated.

<img src="https://user-images.githubusercontent.com/22449698/99959203-de1b4d00-2d8a-11eb-8864-afce21228b00.png" width=300>
