### PR TITLE
Paging project list

### DIFF
--- a/app/localprojectsmanager.h
+++ b/app/localprojectsmanager.h
@@ -18,7 +18,8 @@ enum ProjectStatus
   NoVersion,  //!< the project is not available locally
   UpToDate,   //!< both server and local copy are in sync with no extra modifications
   OutOfDate,  //!< server has newer version than what is available locally (but the project is not modified locally)
-  Modified    //!< there are some local modifications in the project that need to be pushed (note: also server may have newer version)
+  Modified,    //!< there are some local modifications in the project that need to be pushed (note: also server may have newer version)
+  Invalid
 };
 Q_ENUMS( ProjectStatus )
 

--- a/app/localprojectsmanager.h
+++ b/app/localprojectsmanager.h
@@ -19,7 +19,7 @@ enum ProjectStatus
   UpToDate,   //!< both server and local copy are in sync with no extra modifications
   OutOfDate,  //!< server has newer version than what is available locally (but the project is not modified locally)
   Modified,    //!< there are some local modifications in the project that need to be pushed (note: also server may have newer version)
-  Invalid      //!< only for mock projects, acts like a hook to enable extra functionality for models working with projects .
+  NonProjectItem      //!< only for mock projects, acts like a hook to enable extra functionality for models working with projects .
 };
 Q_ENUMS( ProjectStatus )
 

--- a/app/localprojectsmanager.h
+++ b/app/localprojectsmanager.h
@@ -19,7 +19,7 @@ enum ProjectStatus
   UpToDate,   //!< both server and local copy are in sync with no extra modifications
   OutOfDate,  //!< server has newer version than what is available locally (but the project is not modified locally)
   Modified,    //!< there are some local modifications in the project that need to be pushed (note: also server may have newer version)
-  Invalid
+  Invalid      //!< only for mock projects, acts like a hook to enable extra functionality for models working with projects .
 };
 Q_ENUMS( ProjectStatus )
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -401,7 +401,7 @@ int main( int argc, char *argv[] )
   QObject::connect( &app, &QGuiApplication::applicationStateChanged, &loader, &Loader::appStateChanged );
   QObject::connect( &app, &QCoreApplication::aboutToQuit, &loader, &Loader::appAboutToQuit );
   QObject::connect( ma.get(), &MerginApi::syncProjectFinished, &pm, &ProjectModel::syncedProjectFinished );
-  QObject::connect( ma.get(), &MerginApi::listProjectsFinished, &mpm, &MerginProjectModel::resetProjects );
+  QObject::connect( ma.get(), &MerginApi::listProjectsFinished, &mpm, &MerginProjectModel::updateModel );
   QObject::connect( ma.get(), &MerginApi::syncProjectStatusChanged, &mpm, &MerginProjectModel::syncProjectStatusChanged );
   QObject::connect( ma.get(), &MerginApi::reloadProject, &loader, &Loader::reloadProject );
   QObject::connect( &mtm, &MapThemesModel::mapThemeChanged, &recordingLpm, &LayersProxyModel::onMapThemeChanged );

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -89,7 +89,7 @@ void MerginApi::listProjects( const QString &searchExpression, const QString &fl
     query.addQueryItem( "flag", flag );
   }
   // Required query parameters
-  query.addQueryItem( "page", QString::number( page ) ); // TODO
+  query.addQueryItem( "page", QString::number( page ) );
   query.addQueryItem( "per_page", QString::number( PROJECT_PER_PAGE ) );
 
   QUrl url( mApiRoot + QStringLiteral( "/v1/project/paginated" ) );

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -82,12 +82,13 @@ void MerginApi::listProjects( const QString &searchExpression, const QString &fl
   }
   if ( !searchExpression.isEmpty() )
   {
-    query.addQueryItem( "q", searchExpression );
+    query.addQueryItem( "name", searchExpression );
   }
   if ( !flag.isEmpty() )
   {
     query.addQueryItem( "flag", flag );
   }
+  query.addQueryItem( "order_by", QStringLiteral( "name" ) );
   // Required query parameters
   query.addQueryItem( "page", QString::number( page ) );
   query.addQueryItem( "per_page", QString::number( PROJECT_PER_PAGE ) );

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -67,42 +67,7 @@ MerginUserInfo *MerginApi::userInfo() const
   return mUserInfo;
 }
 
-void MerginApi::listProjects( const QString &searchExpression,
-                              const QString &flag, const QString &filterTag )
-{
-
-  bool authorize = !flag.isEmpty();
-  if ( ( authorize && !validateAuthAndContinute() ) || mApiVersionStatus != MerginApiStatus::OK )
-  {
-    return;
-  }
-
-  QUrlQuery query;
-  if ( !filterTag.isEmpty() )
-  {
-    query.addQueryItem( "tags", filterTag );
-  }
-  if ( !searchExpression.isEmpty() )
-  {
-    query.addQueryItem( "q", searchExpression );
-  }
-  if ( !flag.isEmpty() )
-  {
-    query.addQueryItem( "flag", flag );
-  }
-  QUrl url( mApiRoot + QStringLiteral( "/v1/project" ) );
-  url.setQuery( query );
-
-  // Even if the authorization is not required, it can be include to fetch more results
-  QNetworkRequest request = getDefaultRequest( mUserAuth->hasAuthData() );
-  request.setUrl( url );
-
-  QNetworkReply *reply = mManager.get( request );
-  InputUtils::log( "list projects", QStringLiteral( "Requesting: " ) + url.toString() );
-  connect( reply, &QNetworkReply::finished, this, &MerginApi::listProjectsReplyFinished );
-}
-
-void MerginApi::fetchProjectList( const QString &searchExpression, const QString &flag, const QString &filterTag, const int page )
+void MerginApi::listProjects( const QString &searchExpression, const QString &flag, const QString &filterTag, const int page )
 {
   bool authorize = !flag.isEmpty();
   if ( ( authorize && !validateAuthAndContinute() ) || mApiVersionStatus != MerginApiStatus::OK )
@@ -136,16 +101,8 @@ void MerginApi::fetchProjectList( const QString &searchExpression, const QString
 
   QNetworkReply *reply = mManager.get( request );
   InputUtils::log( "list projects", QStringLiteral( "Requesting: " ) + url.toString() );
-  connect( reply, &QNetworkReply::finished, this, &MerginApi::listProjectsPaginatedReplyFinished );
+  connect( reply, &QNetworkReply::finished, this, &MerginApi::listProjectsReplyFinished );
 }
-
-void MerginApi::listProjectsPaginated( const QString &searchExpression,
-                                       const QString &flag, const QString &filterTag )
-{
-  // Always fetch first page
-  fetchProjectList( searchExpression, flag, filterTag, 1 );
-}
-
 
 void MerginApi::downloadNextItem( const QString &projectFullName )
 {
@@ -1209,44 +1166,6 @@ void MerginApi::listProjectsReplyFinished()
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
 
-  if ( r->error() == QNetworkReply::NoError )
-  {
-    QByteArray data = r->readAll();
-    mRemoteProjects = parseListProjectsMetadata( data );
-
-    // for any local projects we can update the latest server version
-    for ( MerginProjectListEntry project : mRemoteProjects )
-    {
-      QString fullProjectName = getFullProjectName( project.projectNamespace, project.projectName );
-      LocalProjectInfo localProject = mLocalProjects.projectFromMerginName( fullProjectName );
-      if ( localProject.isValid() )
-      {
-        mLocalProjects.updateMerginServerVersion( localProject.projectDir, project.version );
-      }
-    }
-
-    InputUtils::log( "list projects", QStringLiteral( "Success - got %1 projects" ).arg( mRemoteProjects.count() ) );
-  }
-  else
-  {
-    QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "listProjects" ), r->errorString(), serverMsg );
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: listProjects" ) );
-    InputUtils::log( "list projects", QStringLiteral( "FAILED - %1" ).arg( message ) );
-    mRemoteProjects.clear();
-
-    emit listProjectsFailed();
-  }
-
-  r->deleteLater();
-  emit listProjectsFinished( mRemoteProjects, mTransactionalStatus );
-}
-
-void MerginApi::listProjectsPaginatedReplyFinished()
-{
-  QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
-  Q_ASSERT( r );
-
   int projectCount = -1;
   int requestedPage = 1;
 
@@ -1269,8 +1188,6 @@ void MerginApi::listProjectsPaginatedReplyFinished()
       mRemoteProjects.clear();
     }
 
-    //mRemoteProjects = parseListProjectsMetadata( data );
-
     // for any local projects we can update the latest server version
     for ( MerginProjectListEntry project : mRemoteProjects )
     {
@@ -1296,7 +1213,7 @@ void MerginApi::listProjectsPaginatedReplyFinished()
   }
 
   r->deleteLater();
-  emit listProjectsFinished( mRemoteProjects, mTransactionalStatus, projectCount, requestedPage == 1 );
+  emit listProjectsFinished( mRemoteProjects, mTransactionalStatus, projectCount, requestedPage );
 }
 
 

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -216,17 +216,11 @@ class MerginApi: public QObject
      * Eventually emits listProjectsFinished on which ProjectPanel (qml component) updates content.
      * \param searchExpression Search filter on projects name.
      * \param flag If defined, it is used to filter out projects tagged as 'created' or 'shared' with a authorized user
-     * \param filterTag .// TODO
+     * \param filterTag Name of tag that fetched projects have to have..
+     * \param page Requested page of projects
      */
     Q_INVOKABLE void listProjects( const QString &searchExpression = QStringLiteral(),
-                                   const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral() );
-
-    Q_INVOKABLE void fetchProjectList( const QString &searchExpression = QStringLiteral(),
-                                       const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral(), const int page = 1 );
-
-    Q_INVOKABLE void listProjectsPaginated( const QString &searchExpression = QStringLiteral(),
-                                            const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral() );
-
+                                   const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral(), const int page = 1 );
 
     /**
      * Sends non-blocking POST request to the server to download/update a project with a given name. On downloadProjectReplyFinished,
@@ -382,7 +376,7 @@ class MerginApi: public QObject
   signals:
     void apiSupportsSubscriptionsChanged();
 
-    void listProjectsFinished( const MerginProjectList &merginProjects, Transactions pendingProjects, int requestedProjectCount = -1, bool isFirstPage = true );
+    void listProjectsFinished( const MerginProjectList &merginProjects, Transactions pendingProjects, int projectCount, int page );
     void listProjectsFailed();
     void syncProjectFinished( const QString &projectDir, const QString &projectFullName, bool successfully = true );
     /**
@@ -415,7 +409,6 @@ class MerginApi: public QObject
 
   private slots:
     void listProjectsReplyFinished();
-    void listProjectsPaginatedReplyFinished();
 
     // Pull slots
     void updateInfoReplyFinished();
@@ -565,7 +558,7 @@ class MerginApi: public QObject
 
     static const int CHUNK_SIZE = 65536;
     static const int UPLOAD_CHUNK_SIZE;
-    const int PROJECT_PER_PAGE = 5; // TODO 50
+    const int PROJECT_PER_PAGE = 50;
     const QString TEMP_FOLDER = QStringLiteral( ".temp/" );
 
     static QList<DownloadQueueItem> itemsForFileChunks( const MerginFile &file, int version );

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -216,8 +216,8 @@ class MerginApi: public QObject
      * Eventually emits listProjectsFinished on which ProjectPanel (qml component) updates content.
      * \param searchExpression Search filter on projects name.
      * \param flag If defined, it is used to filter out projects tagged as 'created' or 'shared' with a authorized user
-     * \param filterTag Name of tag that fetched projects have to have..
-     * \param page Requested page of projects
+     * \param filterTag Name of tag that fetched projects have to have.
+     * \param page Requested page of projects.
      */
     Q_INVOKABLE void listProjects( const QString &searchExpression = QStringLiteral(),
                                    const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral(), const int page = 1 );

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -216,10 +216,17 @@ class MerginApi: public QObject
      * Eventually emits listProjectsFinished on which ProjectPanel (qml component) updates content.
      * \param searchExpression Search filter on projects name.
      * \param flag If defined, it is used to filter out projects tagged as 'created' or 'shared' with a authorized user
-     * \param withFilter If true, applies "input" tag in request.
+     * \param filterTag .// TODO
      */
     Q_INVOKABLE void listProjects( const QString &searchExpression = QStringLiteral(),
                                    const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral() );
+
+    Q_INVOKABLE void fetchProjectList( const QString &searchExpression = QStringLiteral(),
+                                       const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral(), const int page = 1 );
+
+    Q_INVOKABLE void listProjectsPaginated( const QString &searchExpression = QStringLiteral(),
+                                            const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral() );
+
 
     /**
      * Sends non-blocking POST request to the server to download/update a project with a given name. On downloadProjectReplyFinished,
@@ -375,7 +382,7 @@ class MerginApi: public QObject
   signals:
     void apiSupportsSubscriptionsChanged();
 
-    void listProjectsFinished( const MerginProjectList &merginProjects, Transactions pendingProjects );
+    void listProjectsFinished( const MerginProjectList &merginProjects, Transactions pendingProjects, int requestedProjectCount = -1, bool isFirstPage = true );
     void listProjectsFailed();
     void syncProjectFinished( const QString &projectDir, const QString &projectFullName, bool successfully = true );
     /**
@@ -408,6 +415,7 @@ class MerginApi: public QObject
 
   private slots:
     void listProjectsReplyFinished();
+    void listProjectsPaginatedReplyFinished();
 
     // Pull slots
     void updateInfoReplyFinished();
@@ -430,6 +438,7 @@ class MerginApi: public QObject
 
   private:
     MerginProjectList parseListProjectsMetadata( const QByteArray &data );
+    MerginProjectList parseProjectJsonArray( const QJsonArray &vArray );
     static QStringList generateChunkIdsForSize( qint64 fileSize );
     QJsonArray prepareUploadChangesJSON( const QList<MerginFile> &files );
     static QString getApiKey( const QString &serverName );
@@ -556,6 +565,7 @@ class MerginApi: public QObject
 
     static const int CHUNK_SIZE = 65536;
     static const int UPLOAD_CHUNK_SIZE;
+    const int PROJECT_PER_PAGE = 5; // TODO 50
     const QString TEMP_FOLDER = QStringLiteral( ".temp/" );
 
     static QList<DownloadQueueItem> itemsForFileChunks( const MerginFile &file, int version );

--- a/app/merginprojectmodel.cpp
+++ b/app/merginprojectmodel.cpp
@@ -19,7 +19,7 @@ MerginProjectModel::MerginProjectModel( LocalProjectsManager &localProjects, QOb
   QObject::connect( &mLocalProjects, &LocalProjectsManager::localProjectAdded, this, &MerginProjectModel::onLocalProjectAdded );
   QObject::connect( &mLocalProjects, &LocalProjectsManager::localProjectRemoved, this, &MerginProjectModel::onLocalProjectRemoved );
 
-  mAdditionalItem->status = Invalid;
+  mAdditionalItem->status = NonProjectItem;
 }
 
 QVariant MerginProjectModel::data( const QModelIndex &index, int role ) const
@@ -61,8 +61,8 @@ QVariant MerginProjectModel::data( const QModelIndex &index, int role ) const
           return QVariant( QStringLiteral( "noVersion" ) );
         case ProjectStatus::Modified:
           return QVariant( QStringLiteral( "modified" ) );
-        case ProjectStatus::Invalid:
-          return QVariant( QStringLiteral( "invalid" ) );
+        case ProjectStatus::NonProjectItem:
+          return QVariant( QStringLiteral( "nonProjectItem" ) );
       }
       break;
     }

--- a/app/merginprojectmodel.cpp
+++ b/app/merginprojectmodel.cpp
@@ -171,17 +171,6 @@ int MerginProjectModel::lastPage() const
   return mLastPage;
 }
 
-int MerginProjectModel::expectedProjectCount() const
-{
-  return mExpectedProjectCount;
-}
-
-void MerginProjectModel::setExpectedProjectCount( int expectedProjectCount )
-{
-  mExpectedProjectCount = expectedProjectCount;
-  emit expectedProjectCountChanged();
-}
-
 QString MerginProjectModel::searchExpression() const
 {
   return mSearchExpression;

--- a/app/merginprojectmodel.cpp
+++ b/app/merginprojectmodel.cpp
@@ -62,7 +62,7 @@ QVariant MerginProjectModel::data( const QModelIndex &index, int role ) const
         case ProjectStatus::Modified:
           return QVariant( QStringLiteral( "modified" ) );
         case ProjectStatus::Invalid:
-          return QVariant( QStringLiteral( "invalid" ) ); // TODO
+          return QVariant( QStringLiteral( "invalid" ) );
       }
       break;
     }

--- a/app/merginprojectmodel.cpp
+++ b/app/merginprojectmodel.cpp
@@ -100,20 +100,16 @@ int MerginProjectModel::rowCount( const QModelIndex &parent ) const
   return mMerginProjects.count();
 }
 
-void MerginProjectModel::updateModel( const MerginProjectList &merginProjects, QHash<QString, TransactionStatus> pendingProjects, int expectedProjectCount, bool isFirstPage )
+void MerginProjectModel::updateModel( const MerginProjectList &merginProjects, QHash<QString, TransactionStatus> pendingProjects, int expectedProjectCount, int page )
 {
   beginResetModel();
   mMerginProjects.removeOne( mAdditionalItem );
 
-  if ( isFirstPage )
+  if ( page == 1 )
   {
     mMerginProjects.clear();
-    setLastPage( 1 );
   }
-  else
-  {
-    setLastPage( lastPage() + 1 );
-  }
+  setLastPage( page );
 
 
   for ( MerginProjectListEntry entry : merginProjects )

--- a/app/merginprojectmodel.h
+++ b/app/merginprojectmodel.h
@@ -71,8 +71,16 @@ class MerginProjectModel: public QAbstractListModel
     int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
 
     //! Updates list of projects with synchronization progress if a project is pending
-    //! @param isFirstPage If true clears current model, othewise merginProjects will be appended.
-    void updateModel( const MerginProjectList &merginProjects, QHash<QString, TransactionStatus> pendingProjects, int expectedProjectCount, bool isFirstPage = true );
+    //!
+    /**
+    * Sets projectNamespace and projectName from sourceString - url or any string from which takes last (name)
+    * and the previous of last (namespace) substring after splitting sourceString with slash.
+    * \param merginProjects List of mergin projects
+    * \param pendingProjects Projects in pending state
+    * \param expectedProjectCount Total number of projects
+    * \param page Int representing page.
+    */
+    void updateModel( const MerginProjectList &merginProjects, QHash<QString, TransactionStatus> pendingProjects, int expectedProjectCount, int page );
 
     int filterCreator() const;
     void setFilterCreator( int filterCreator );
@@ -111,6 +119,7 @@ class MerginProjectModel: public QAbstractListModel
     QString mSearchExpression;
     int mExpectedProjectCount;
     int mLastPage;
+    //! Special item as a placeholder for custom component with extended funtionality
     std::shared_ptr<MerginProject> mAdditionalItem = std::make_shared<MerginProject>();
 
 };

--- a/app/merginprojectmodel.h
+++ b/app/merginprojectmodel.h
@@ -70,11 +70,8 @@ class MerginProjectModel: public QAbstractListModel
 
     int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
 
-    //! Updates list of projects with synchronization progress if a project is pending
-    //!
     /**
-    * Sets projectNamespace and projectName from sourceString - url or any string from which takes last (name)
-    * and the previous of last (namespace) substring after splitting sourceString with slash.
+    * Updates list of projects with synchronization progress if a project is pending.
     * \param merginProjects List of mergin projects
     * \param pendingProjects Projects in pending state
     * \param expectedProjectCount Total number of projects

--- a/app/merginprojectmodel.h
+++ b/app/merginprojectmodel.h
@@ -43,7 +43,6 @@ class MerginProjectModel: public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY( QString searchExpression READ searchExpression WRITE setSearchExpression )
-    Q_PROPERTY( int expectedProjectCount READ expectedProjectCount NOTIFY expectedProjectCountChanged )
     Q_PROPERTY( int lastPage READ lastPage NOTIFY lastPageChanged )
 
   public:
@@ -88,14 +87,10 @@ class MerginProjectModel: public QAbstractListModel
     QString searchExpression() const;
     void setSearchExpression( const QString &searchExpression );
 
-    int expectedProjectCount() const;
-    void setExpectedProjectCount( int expectedProjectCount );
-
     int lastPage() const;
     void setLastPage( int lastPage );
 
   signals:
-    void expectedProjectCountChanged();
     void lastPageChanged();
 
   public slots:
@@ -114,7 +109,6 @@ class MerginProjectModel: public QAbstractListModel
     ProjectList mMerginProjects;
     LocalProjectsManager &mLocalProjects;
     QString mSearchExpression;
-    int mExpectedProjectCount;
     int mLastPage;
     //! Special item as a placeholder for custom component with extended funtionality
     std::shared_ptr<MerginProject> mAdditionalItem = std::make_shared<MerginProject>();

--- a/app/merginprojectmodel.h
+++ b/app/merginprojectmodel.h
@@ -43,6 +43,8 @@ class MerginProjectModel: public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY( QString searchExpression READ searchExpression WRITE setSearchExpression )
+    Q_PROPERTY( int expectedProjectCount READ expectedProjectCount NOTIFY expectedProjectCountChanged )
+    Q_PROPERTY( int lastPage READ lastPage NOTIFY lastPageChanged )
 
   public:
     enum Roles
@@ -69,7 +71,8 @@ class MerginProjectModel: public QAbstractListModel
     int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
 
     //! Updates list of projects with synchronization progress if a project is pending
-    void resetProjects( const MerginProjectList &merginProjects, QHash<QString, TransactionStatus> pendingProjects );
+    //! @param isFirstPage If true clears current model, othewise merginProjects will be appended.
+    void updateModel( const MerginProjectList &merginProjects, QHash<QString, TransactionStatus> pendingProjects, int expectedProjectCount, bool isFirstPage = true );
 
     int filterCreator() const;
     void setFilterCreator( int filterCreator );
@@ -79,6 +82,16 @@ class MerginProjectModel: public QAbstractListModel
 
     QString searchExpression() const;
     void setSearchExpression( const QString &searchExpression );
+
+    int expectedProjectCount() const;
+    void setExpectedProjectCount( int expectedProjectCount );
+
+    int lastPage() const;
+    void setLastPage( int lastPage );
+
+  signals:
+    void expectedProjectCountChanged();
+    void lastPageChanged();
 
   public slots:
     void syncProjectStatusChanged( const QString &projectFullName, qreal progress );
@@ -96,6 +109,9 @@ class MerginProjectModel: public QAbstractListModel
     ProjectList mMerginProjects;
     LocalProjectsManager &mLocalProjects;
     QString mSearchExpression;
+    int mExpectedProjectCount;
+    int mLastPage;
+    std::shared_ptr<MerginProject> mAdditionalItem = std::make_shared<MerginProject>();
 
 };
 #endif // MERGINPROJECTMODEL_H

--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -49,6 +49,7 @@ QtObject {
     property real panelOpacity: 1
     property real lowHighlightOpacity: 0.4
     property real highHighlightOpacity: 0.8
+    property real cornerRadius: 8 * QgsQuick.Utils.dp
 
     property real refWidth: 640
     property real refHeight: 1136

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -392,6 +392,12 @@ Item {
           contentWidth: grid.width
           clip: true
 
+          onCountChanged: {
+            if (merginProjectsList.visible || __merginProjectsModel.lastPage > 1) {
+              merginProjectsList.positionViewAtIndex(merginProjectsList.currentIndex, ListView.End)
+            }
+          }
+
           property int cellWidth: width
           property int cellHeight: projectsPanel.rowHeight
           property int borderWidth: 1
@@ -506,7 +512,7 @@ Item {
           iconSize: projectsPanel.iconSize
           projectFullName: __merginApi.getFullProjectName(projectNamespace, projectName)
           progressValue: syncProgress
-          isAdditional: status === "invalid"
+          isAdditional: status === "nonProjectItem"
 
           onMenuClicked: {
             if (status === "upToDate") return
@@ -540,6 +546,8 @@ Item {
               searchText = searchBar.text
             }
 
+            // Note that current index used to save last item position
+            merginProjectsList.currentIndex = merginProjectsList.count - 1
             __merginApi.listProjects(searchText, flag, "", __merginProjectsModel.lastPage + 1)
           }
 

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -260,6 +260,7 @@ Item {
       SearchBar {
         id: searchBar
         y: header.height
+        allowTimer: true
 
         onSearchTextChanged: {
           if (toolbar.highlighted === homeBtn.text) {

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -530,16 +530,17 @@ Item {
           }
 
           onDelegateButtonClicked: {
-            var flag = "explore"
+            var flag = ""
+            var searchText = ""
             if (toolbar.highlighted == myProjectsBtn.text) {
-              flag = "shared"
+              flag = "created"
             } else if (toolbar.highlighted == sharedProjectsBtn.text) {
                flag = "shared"
             } else if (toolbar.highlighted == exploreBtn.text) {
-              flag = "explore"
-           }
+              searchText = searchBar.text
+            }
 
-            __merginApi.fetchProjectList("", flag, "", __merginProjectsModel.lastPage + 1) // TODO
+            __merginApi.listProjects(searchText, flag, "", __merginProjectsModel.lastPage + 1)
           }
 
         }
@@ -609,7 +610,7 @@ Item {
                 toolbar.highlighted = myProjectsBtn.text
                 stackView.pending = true
                 showMergin = true
-                __merginApi.listProjectsPaginated("", "created")
+                __merginApi.listProjects("", "created")
               }
             }
           }
@@ -628,7 +629,7 @@ Item {
                 toolbar.highlighted = sharedProjectsBtn.text
                 stackView.pending = true
                 showMergin = true
-                __merginApi.listProjectsPaginated("", "shared")
+                __merginApi.listProjects("", "shared")
               }
             }
           }
@@ -647,7 +648,7 @@ Item {
                 toolbar.highlighted = exploreBtn.text
                 stackView.pending = true
                 showMergin = true
-                __merginApi.listProjectsPaginated( searchBar.text )
+                __merginApi.listProjects( searchBar.text )
               }
             }
           }
@@ -704,7 +705,7 @@ Item {
             onClicked: {
               stackView.pending = true
               // filters suppose to not change
-              __merginApi.listProjectsPaginated( searchBar.text )
+              __merginApi.listProjects( searchBar.text )
               reloadList.visible = false
             }
             background: Rectangle {

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -413,6 +413,7 @@ Item {
 
       Component {
         id: delegateItem
+
         ProjectDelegateItem {
           id: delegateItemContent
           cellWidth: projectsPanel.width
@@ -493,6 +494,7 @@ Item {
 
       Component {
         id: delegateItemMergin
+
         ProjectDelegateItem {
           cellWidth: projectsPanel.width
           cellHeight: projectsPanel.rowHeight
@@ -504,6 +506,7 @@ Item {
           iconSize: projectsPanel.iconSize
           projectFullName: __merginApi.getFullProjectName(projectNamespace, projectName)
           progressValue: syncProgress
+          isAdditional: status === "invalid"
 
           onMenuClicked: {
             if (status === "upToDate") return
@@ -524,6 +527,19 @@ Item {
             } else if (status === "modified") {
               __merginApi.uploadProject(projectNamespace, projectName)
             }
+          }
+
+          onDelegateButtonClicked: {
+            var flag = "explore"
+            if (toolbar.highlighted == myProjectsBtn.text) {
+              flag = "shared"
+            } else if (toolbar.highlighted == sharedProjectsBtn.text) {
+               flag = "shared"
+            } else if (toolbar.highlighted == exploreBtn.text) {
+              flag = "explore"
+           }
+
+            __merginApi.fetchProjectList("", flag, "", __merginProjectsModel.lastPage + 1) // TODO
           }
 
         }
@@ -593,7 +609,7 @@ Item {
                 toolbar.highlighted = myProjectsBtn.text
                 stackView.pending = true
                 showMergin = true
-                __merginApi.listProjects("", "created")
+                __merginApi.listProjectsPaginated("", "created")
               }
             }
           }
@@ -612,7 +628,7 @@ Item {
                 toolbar.highlighted = sharedProjectsBtn.text
                 stackView.pending = true
                 showMergin = true
-                __merginApi.listProjects("", "shared")
+                __merginApi.listProjectsPaginated("", "shared")
               }
             }
           }
@@ -631,7 +647,7 @@ Item {
                 toolbar.highlighted = exploreBtn.text
                 stackView.pending = true
                 showMergin = true
-                __merginApi.listProjects( searchBar.text )
+                __merginApi.listProjectsPaginated( searchBar.text )
               }
             }
           }
@@ -688,7 +704,7 @@ Item {
             onClicked: {
               stackView.pending = true
               // filters suppose to not change
-              __merginApi.listProjects( searchBar.text )
+              __merginApi.listProjectsPaginated( searchBar.text )
               reloadList.visible = false
             }
             background: Rectangle {

--- a/app/qml/ProjectDelegateItem.qml
+++ b/app/qml/ProjectDelegateItem.qml
@@ -14,6 +14,7 @@ import QtGraphicalEffects 1.0
 import lc 1.0
 import QgsQuick 0.1 as QgsQuick
 import "."  // import InputStyle singleton
+import "./components"
 
 Rectangle {
     id: itemContainer
@@ -32,9 +33,12 @@ Rectangle {
     property bool disabled: false
     property real itemMargin: InputStyle.panelMargin
     property real progressValue: 0
+    property bool isAdditional: false
+
 
     signal itemClicked();
     signal menuClicked()
+    signal delegateButtonClicked()
 
     MouseArea {
         anchors.fill: parent
@@ -52,6 +56,7 @@ Rectangle {
     Item {
         width: parent.width
         height: parent.height
+        visible: !itemContainer.isAdditional
 
         RowLayout {
             id: row
@@ -160,4 +165,15 @@ Rectangle {
             anchors.bottom: parent.bottom
         }
     }
+
+    // Additional item
+    DelegateButton {
+      visible: itemContainer.isAdditional
+      width: itemContainer.width
+      height: itemContainer.height
+      text: qsTr("Fetch more")
+
+      onClicked: itemContainer.delegateButtonClicked()
+    }
+
 }

--- a/app/qml/components/DelegateButton.qml
+++ b/app/qml/components/DelegateButton.qml
@@ -1,0 +1,40 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.2
+import "./.."  // import InputStyle singleton
+
+Item {
+  signal clicked()
+
+  property string text
+  property real cornerRadius: InputStyle.cornerRadius
+  property var bgColor: InputStyle.highlightColor
+  property var textColor: "white"
+
+  id: delegateButtonContainer
+
+  Button {
+    id: delegateButton
+    text: delegateButtonContainer.text
+    height: delegateButtonContainer.height / 2
+    width: delegateButtonContainer.height * 2
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.verticalCenter: parent.verticalCenter
+    font.pixelSize: InputStyle.fontPixelSizeTitle
+
+    background: Rectangle {
+      color: delegateButtonContainer.bgColor
+      radius: delegateButtonContainer.cornerRadius
+    }
+
+    onClicked: delegateButtonContainer.clicked()
+
+    contentItem: Text {
+      text: delegateButton.text
+      font: delegateButton.font
+      color: delegateButtonContainer.textColor
+      horizontalAlignment: Text.AlignHCenter
+      verticalAlignment: Text.AlignVCenter
+      elide: Text.ElideRight
+    }
+  }
+}

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -52,7 +52,6 @@
         <file>TextHyperlink.qml</file>
         <file>LogPanel.qml</file>
         <file>components/PasswordField.qml</file>
-        <file>components/SettingsSwitch.qml</file>
         <file>components/DelegateButton.qml</file>
     </qresource>
 </RCC>

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -52,5 +52,7 @@
         <file>TextHyperlink.qml</file>
         <file>LogPanel.qml</file>
         <file>components/PasswordField.qml</file>
+        <file>components/SettingsSwitch.qml</file>
+        <file>components/DelegateButton.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Listing all projects has been replaced with listing with paging functionality.

Note: `NonProjectItem` project status has been introduced to easily distinguish real project items and fetch button item in a model (and view). This approach of introducing an extra item in the list has been agreed before the implementation.

UPDATED:
 - fixed sorting by name 
 - fixed jumping at the beginning after fetching new project items
 - partially fixed searching

Known issues:
- Inconsistent project list when a content of a page has been changed on server in a meanwhile of browsing - user already fetched a batch of projects, a project has been deleted on Mergin and therefore another project is lost since order of project has been changed. Reloading the whole page resolves the issue. (https://github.com/lutraconsulting/input/issues/1050)
- Search functionality for explore has been updated to be able search project by name (for time-being, see https://github.com/lutraconsulting/input/issues/1080). Currently filtering of `my` and `shared` projects are done on client side by the project model. Therefore search functionality is performed only on those projects which have been already fetched and stored in the model. 
<img width="311" alt="Screenshot 2020-12-03 at 12 23 17" src="https://user-images.githubusercontent.com/6735606/101010240-89ce5500-3562-11eb-9f15-4239e677c458.png">


closes #1043 