### PR TITLE
Clear search text

### DIFF
--- a/app/qml/SearchBar.qml
+++ b/app/qml/SearchBar.qml
@@ -60,7 +60,7 @@ Rectangle {
     
     TextField {
       id: searchField
-      width: parent.width
+      width: parent.width - iconContainer.width
       height: InputStyle.rowHeight
       font.pixelSize: InputStyle.fontPixelSizeNormal
       color: root.fontColor
@@ -92,9 +92,8 @@ Rectangle {
     Item {
       id: iconContainer
       height: searchField.height
-      width: root.iconSize
+      width: searchField.height + root.panelMargin
       anchors.right: parent.right
-      anchors.rightMargin: root.panelMargin
       
       Image {
         id: cancelSearchBtn
@@ -106,22 +105,21 @@ Rectangle {
         anchors.centerIn: parent
         fillMode: Image.PreserveAspectFit
       }
-
-      MouseArea {
-        x: cancelSearchBtn.x - cancelSearchBtn.width
-        height: cancelSearchBtn.height * 3
-        width: root.iconSize * 3
-        onClicked: {
-          if ( searchField.displayText ) {
-            root.deactivate()
-          }
-        }
-      }
       
       ColorOverlay {
         anchors.fill: cancelSearchBtn
         source: cancelSearchBtn
         color: root.fontColor
+      }
+
+      MouseArea {
+        anchors.fill: iconContainer
+        z: 100
+        onClicked: {
+          if ( searchField.displayText ) {
+            root.deactivate()
+          }
+        }
       }
     }
   }

--- a/app/qml/SearchBar.qml
+++ b/app/qml/SearchBar.qml
@@ -37,8 +37,9 @@ Rectangle {
     * and the current element's forceActiveFocus() doesnt deactivates SearchBar focus.
     */
   function deactivate() {
-    searchField.text = ""
     searchField.focus = false
+    if ( searchField.length > 0 )
+      searchField.clear()
     searchTextChanged("")
   }
 


### PR DESCRIPTION
There is a new function to clear text of textfield. We now use that one instead of hard setting empty string to textfield.

Notice: there is something wrong either in Input or Qt (I could not get rid of) yelling this error when one clicks on **x** to clear text:
`W Input   : QMetaObject::invokeMethod: No such method QQuickContentItem::inputMethodQuery(Qt::InputMethodQuery,QVariant)` 

This closes #1038 however above message stays and should be looked at in future.