### PR TITLE
Remove automatic permissions from Qt and remove RECORD_AUDIO permission

### DIFF
--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -86,8 +86,21 @@
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
          Remove the comment if you do not require these default permissions. -->
-    <!-- %%INSERT_PERMISSIONS -->
+    <!-- <insert double percentage signs to automatically insert permissions from Qt>INSERT_PERMISSIONS -->
+
+    <!-- Storage permissions -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
+    <!-- Access internet permissions -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
+    <!-- Location permissions -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+
+    <!-- Camera permissions -->
+    <uses-permission android:name="android.permission.CAMERA"/>
 
     <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
          Remove the comment if you do not require these default features. -->


### PR DESCRIPTION
Removed automatic expand of permissions from Qt to get rid of RECORD_AUDIO permission which we do not use.

Previously we have used these permissions:
<img src="https://user-images.githubusercontent.com/22449698/102606635-4f021a80-4127-11eb-88c7-59640a760024.png" width=700>

In Android app settings it looked like this:
<img src="https://user-images.githubusercontent.com/22449698/102606720-7822ab00-4127-11eb-810f-5174c28e3bea.jpg" width=300>

After this change, **Microphone** permission is not there, however, user can use speech-to-text feature provided by keyboard (it is up for a virtual keyboard to opt for RECORD_AUDIO permission).

Let's wait for CI builds to see if everything works properly (I lost splash screen, not sure if it is only problem with my local build or not)

Resolves #1069 