### PR TITLE
Camera permission crash

### DIFF
--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -98,7 +98,7 @@ void AndroidUtils::callCamera( const QString &targetPath )
   {
     if ( !QtAndroid::shouldShowRequestPermissionRationale( "android.permission.CAMERA" ) )
     {
-      // permanently denide permission, user needs to go to settings to allow permission
+      // permanently denied permission, user needs to go to settings to allow permission
       showToast( tr( "Camera permission is permanently denied, please allow it in settings" ) );
     }
     else

--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -51,7 +51,6 @@ bool AndroidUtils::isAndroid() const
 void AndroidUtils::requirePermissions()
 {
   checkAndAcquirePermissions( "android.permission.WRITE_EXTERNAL_STORAGE" );
-  checkAndAcquirePermissions( "android.permission.CAMERA" );
 }
 
 bool AndroidUtils::checkAndAcquirePermissions( const QString &permissionString )
@@ -94,6 +93,21 @@ void AndroidUtils::callImagePicker()
 void AndroidUtils::callCamera( const QString &targetPath )
 {
 #ifdef ANDROID
+
+  if ( checkAndAcquirePermissions( "android.permission.CAMERA" ) == false )
+  {
+    if ( !QtAndroid::shouldShowRequestPermissionRationale( "android.permission.CAMERA" ) )
+    {
+      // permanently denide permission, user needs to go to settings to allow permission
+      showToast( tr( "Camera permission is permanently denied, please allow it in settings" ) );
+    }
+    else
+    {
+      showToast( tr( "We need a camera permission in order to take a photo" ) );
+    }
+    return;
+  }
+
   const QString IMAGE_CAPTURE_ACTION = QString( "android.media.action.IMAGE_CAPTURE" );
 
   QAndroidJniObject activity = QAndroidJniObject::fromString( QStringLiteral( "uk.co.lutraconsulting.CameraActivity" ) );


### PR DESCRIPTION
Fixed by opting for a permission when starting a camera, if user do not provide permission camera wont start

+ also removed opting for permission in the application start

Resolves #1078 