### PR TITLE
Storage permission

### DIFF
--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -73,6 +73,36 @@ bool AndroidUtils::checkAndAcquirePermissions( const QString &permissionString )
   return true;
 }
 
+bool AndroidUtils::checkPermission( const QString &permissionString )
+{
+#ifdef ANDROID
+  return QtAndroid::checkPermission( permissionString ) == QtAndroid::PermissionResult::Granted;
+#else
+  return true;
+#endif
+}
+
+bool AndroidUtils::requestStoragePermission()
+{
+#ifdef ANDROID
+
+  if ( !checkAndAcquirePermissions( "android.permission.WRITE_EXTERNAL_STORAGE" ) )
+  {
+    if ( !QtAndroid::shouldShowRequestPermissionRationale( "android.permission.WRITE_EXTERNAL_STORAGE" ) )
+    {
+      // permanently denied permission, user needs to go to settings to allow permission
+      showToast( tr( "Storage permission is permanently denied, please allow it in settings" ) );
+    }
+    else
+    {
+      showToast( tr( "Input needs a storage permission in order to manipulate or download a project" ) );
+    }
+    return false;
+  }
+
+#endif
+  return true;
+}
 
 void AndroidUtils::callImagePicker()
 {

--- a/app/androidutils.h
+++ b/app/androidutils.h
@@ -29,8 +29,12 @@ class AndroidUtils: public QObject
     explicit AndroidUtils( QObject *parent = nullptr );
 
     bool isAndroid() const;
+    bool checkPermission( const QString &permissionString );
+
     static void requirePermissions();
     static bool checkAndAcquirePermissions( const QString &permissionString );
+
+    Q_INVOKABLE bool requestStoragePermission();
 
     /**
       * Starts ACTION_PICK activity which opens a gallery. If an image is selected,

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -29,6 +29,7 @@ static const QString DATE_TIME_FORMAT = QStringLiteral( "yyMMdd-hhmmss" );
 
 InputUtils::InputUtils( QObject *parent ): QObject( parent )
 {
+  mAndroidUtils = std::unique_ptr<AndroidUtils>( new AndroidUtils() );
 }
 
 bool InputUtils::removeFile( const QString &filePath )
@@ -317,6 +318,29 @@ QString InputUtils::bytesToHumanSize( double bytes )
   {
     return QString::number( bytes / 1024.0 / 1024.0 / 1024.0 / 1024.0, 'f', precision ) + " TB";
   }
+}
+
+bool InputUtils::hasStoragePermission()
+{
+  if ( appPlatform() == QStringLiteral( "android" ) )
+  {
+    return mAndroidUtils->checkPermission( "android.permission.WRITE_EXTERNAL_STORAGE" );
+  }
+  return true;
+}
+
+bool InputUtils::acquireStoragePermission()
+{
+  if ( appPlatform() == QStringLiteral( "android" ) )
+  {
+    return mAndroidUtils->requestStoragePermission();
+  }
+  return true;
+}
+
+void InputUtils::quitApp()
+{
+  QCoreApplication::quit();
 }
 
 QString InputUtils::uuidWithoutBraces( const QUuid &uuid )

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -18,6 +18,7 @@
 #include <QUuid>
 #include "inputhelp.h"
 #include "merginapi.h"
+#include "androidutils.h"
 #include "qgsquickfeaturelayerpair.h"
 #include "qgsquickmapsettings.h"
 #include "qgsquickpositionkit.h"
@@ -90,6 +91,12 @@ class InputUtils: public QObject
      */
     Q_INVOKABLE static QString bytesToHumanSize( double bytes );
 
+    Q_INVOKABLE bool hasStoragePermission();
+
+    Q_INVOKABLE bool acquireStoragePermission();
+
+    Q_INVOKABLE void quitApp();
+
     /**
      * Method copies all entries from given source path to destination path. If cannot copy a file for the first time,
      * removes it and tries again (overwrite a file). If failes again, skips the file, sets result to false and continue.
@@ -143,6 +150,7 @@ class InputUtils: public QObject
     QString sanitizeName( const QString &path );
     static QString sLogFile;
     static void appendLog( const QByteArray &data, const QString &path );
+    std::unique_ptr<AndroidUtils> mAndroidUtils;
 };
 
 #endif // INPUTUTILS_H


### PR DESCRIPTION
When user did not grant storage permission, app behaved not in UX friendly way (showing projects with error, leading user to learn how to download first project)

We now detect missing storage permission and opt for it when user wants to download a project. 

https://user-images.githubusercontent.com/22449698/104316379-ad2edd00-54dc-11eb-87a5-f91fd511218c.mp4

Due to an implementation, it is hard to recover application and load projects after gaining storage permission so right now we ask user to restart application in order to apply changes.

This change affects only Android users. Resolves #1084 