### PR TITLE
Project wizard

### DIFF
--- a/app/fieldsmodel.cpp
+++ b/app/fieldsmodel.cpp
@@ -1,0 +1,101 @@
+#include "fieldsmodel.h"
+
+FieldsModel::FieldsModel( QObject *parent )
+  : QAbstractListModel( parent )
+{
+}
+
+bool FieldsModel::addField( const QString &name, const QString &type )
+{
+  // TODO check if field with the given name exists
+  beginResetModel();
+
+  QgsField field;
+  field.setName( name );
+  mFields.append( field );
+
+  endResetModel();
+  return true;
+  //emit dataChanged();
+}
+
+QHash<int, QByteArray> FieldsModel::roleNames() const
+{
+  QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
+  roles[AttributeName]  = QByteArrayLiteral( "AttributeName" );
+  roles[WidgetType]  = QByteArrayLiteral( "WidgetType" );
+  roles[Field] = QByteArrayLiteral( "Field" );
+
+  return roles;
+}
+
+
+int FieldsModel::rowCount( const QModelIndex &parent ) const
+{
+  return mFields.count();
+}
+
+QVariant FieldsModel::data( const QModelIndex &index, int role ) const
+{
+  int row = index.row();
+  if ( row < 0 || row >= mFields.count() )
+    return QVariant();
+
+  QgsField field = mFields.at( row );
+
+  switch ( role )
+  {
+    case AttributeName:
+      return field.name();
+      break;
+
+//    case FieldType:
+//      field.type();
+//      break;
+
+    case WidgetType:
+      QVariant();
+      break;
+
+    case Field:
+      return field;
+      break;
+  }
+
+  return QVariant();
+}
+
+bool FieldsModel::setData( const QModelIndex &index, const QVariant &value, int role )
+{
+  if ( data( index, role ) == value )
+    return true;
+
+//  switch ( role )
+//  {
+//    case AttributeValue:
+//    {
+//      QVariant val( value );
+//      QgsField fld = mFeatureLayerPair.feature().fields().at( index.row() );
+
+//      if ( !fld.convertCompatible( val ) )
+//      {
+//        QgsMessageLog::logMessage( tr( "Value \"%1\" %4 could not be converted to a compatible value for field %2(%3)." ).arg( value.toString(), fld.name(), fld.typeName(), value.isNull() ? "NULL" : "NOT NULL" ) );
+//        return false;
+//      }
+//      bool success = mFeatureLayerPair.featureRef().setAttribute( index.row(), val );
+//      if ( success )
+//        emit dataChanged( index, index, QVector<int>() << role );
+//      return success;
+//      break;
+//    }
+
+//    case RememberAttribute:
+//    {
+//      mRememberedAttributes[ index.row() ] = value.toBool();
+//      emit dataChanged( index, index, QVector<int>() << role );
+//      break;
+//    }
+//  }
+
+  return false;
+}

--- a/app/fieldsmodel.cpp
+++ b/app/fieldsmodel.cpp
@@ -48,9 +48,9 @@ QVariantMap FieldsModel::supportedTypes()
 {
   QVariantMap supportedTypes;
   supportedTypes.insert( "TextEdit", "Text" );
-  supportedTypes.insert( "DateTime", "DateTime" );
+  supportedTypes.insert( "DateTime", "Date&time" );
   supportedTypes.insert( "Range", "Number" );
-  supportedTypes.insert( "CheckBox", "CheckBox" );
+  supportedTypes.insert( "CheckBox", "Checkbox" );
   supportedTypes.insert( "ExternalResource", "Photo" );
 
   return supportedTypes;

--- a/app/fieldsmodel.cpp
+++ b/app/fieldsmodel.cpp
@@ -7,15 +7,27 @@ FieldsModel::FieldsModel( QObject *parent )
   initModel();
 }
 
-bool FieldsModel::addField( const QString &name, const QString &type, const QString &widgetType )
+bool FieldsModel::addField( const QString &name, const QString &widgetType )
 {
+
+  if ( contains( name ) )
+  {
+    if ( name.isEmpty() )
+    {
+      notify( tr( "Please fill a name of previous field before adding a new field." ) );
+    }
+    else
+    {
+      notify( tr( "Field %1 already exists." ).arg( name ) );
+    }
+    return false;
+  }
 
   beginResetModel();
 
   FieldConfiguration fc;
   fc.attributeName = name;
   fc.widgetType = widgetType;
-  fc.fieldType = type;
   mFields.append( fc );
 
   endResetModel();
@@ -36,10 +48,9 @@ bool FieldsModel::removeField( int row )
 QVariantMap FieldsModel::supportedTypes()
 {
   QVariantMap supportedTypes;
-  supportedTypes.insert( "TextEdit", "TextEdit" );
+  supportedTypes.insert( "TextEdit", "Text" );
   supportedTypes.insert( "DateTime", "DateTime" );
-  supportedTypes.insert( "Range", "Range" );
-  supportedTypes.insert( "TextEdit", "TextEdit" );
+  supportedTypes.insert( "Range", "Number" );
   supportedTypes.insert( "CheckBox", "CheckBox" );
   supportedTypes.insert( "ExternalResource", "Photo" );
 
@@ -55,7 +66,6 @@ QHash<int, QByteArray> FieldsModel::roleNames() const
 {
   QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
   roles[AttributeName]  = QByteArrayLiteral( "AttributeName" );
-  roles[FieldType]  = QByteArrayLiteral( "FieldType" );
   roles[WidgetType]  = QByteArrayLiteral( "WidgetType" );
 
   return roles;
@@ -131,10 +141,17 @@ QString FieldsModel::findWidgetTypeByFieldName( const QString name ) const
 
 void FieldsModel::initModel()
 {
-  addField( "Date", "datetime", "DateTime" );
-  addField( "Notes", "text", "TextEdit" );
-  addField( "Photo", "text", "ExternalResource" );
-  // ONLY FOR testing
-  addField( "Number", "integer", "Range" );
-  addField( "Bool", "bool", "CheckBox" );
+  addField( "Date", "DateTime" );
+  addField( "Notes", "TextEdit" );
+  addField( "Photo", "ExternalResource" );
+}
+
+bool FieldsModel::contains( const QString &name )
+{
+  for ( int i = 0; i < mFields.count(); ++i )
+  {
+    if ( mFields.at( i ).attributeName == name )
+      return true;
+  }
+  return false;
 }

--- a/app/fieldsmodel.cpp
+++ b/app/fieldsmodel.cpp
@@ -4,7 +4,6 @@
 FieldsModel::FieldsModel( QObject *parent )
   : QAbstractListModel( parent )
 {
-  initModel();
 }
 
 bool FieldsModel::addField( const QString &name, const QString &widgetType )
@@ -114,15 +113,19 @@ bool FieldsModel::setData( const QModelIndex &index, const QVariant &value, int 
   {
     case AttributeName:
     {
+      if ( contains( value.toString() ) )
+      {
+        notify( tr( "Field %1 already exists. \nWon't be added to the project." ).arg( value.toString() ) );
+      }
       mFields[row].attributeName = value.toString();
       emit dataChanged( index, index, {AttributeName} );
-      break;
+      return true;
     }
     case WidgetType:
     {
       mFields[row].widgetType = value.toString();
       emit dataChanged( index, index, {WidgetType} );
-      break;
+      return true;
     }
   }
 
@@ -141,6 +144,7 @@ QString FieldsModel::findWidgetTypeByFieldName( const QString name ) const
 
 void FieldsModel::initModel()
 {
+  mFields.clear();
   addField( "Date", "DateTime" );
   addField( "Notes", "TextEdit" );
   addField( "Photo", "ExternalResource" );

--- a/app/fieldsmodel.cpp
+++ b/app/fieldsmodel.cpp
@@ -9,18 +9,15 @@ FieldsModel::FieldsModel( QObject *parent )
 
 bool FieldsModel::addField( const QString &name, const QString &type, const QString &widgetType )
 {
-  // TODO check if field with the given name exists - cannot append a field with existing name
+if (mFields.indexFromName(name) >= 0) {
+    notify(QString("Field '%1' has not been added due to empty or existing name ").arg(name));
+ }
+
   beginResetModel();
   QgsField field = createField( name, type, widgetType );
-  bool added = mFields.append( field );
-
-  if ( !added )
-  {
-    qDebug() << "Field has not been added due to empty or existing name: " << name;
-    // TODO notify
-  }
+  mFields.append( field );
   endResetModel();
-  return added;
+  return true;
 }
 
 bool FieldsModel::removeField( int row )
@@ -110,7 +107,6 @@ bool FieldsModel::setData( const QModelIndex &index, const QVariant &value, int 
   {
     case AttributeName:
     {
-      mFields[row].setName( value.toString() );
       mFields.rename( row, value.toString() );
       emit dataChanged( index, index, {AttributeName} );
       break;
@@ -171,6 +167,7 @@ QVariant::Type FieldsModel::parseType( const QString &type )
     return QVariant::Bool;
   else if ( type == QLatin1String( "binary" ) )
     return QVariant::Invalid; // TODO
+  return QVariant::Invalid;
 }
 
 QgsField FieldsModel::createField( const QString &name, const QString &type, const QString &widgetType )

--- a/app/fieldsmodel.cpp
+++ b/app/fieldsmodel.cpp
@@ -3,6 +3,7 @@
 FieldsModel::FieldsModel( QObject *parent )
   : QAbstractListModel( parent )
 {
+    initModel();
 }
 
 bool FieldsModel::addField( const QString &name, const QString &type )
@@ -12,11 +13,23 @@ bool FieldsModel::addField( const QString &name, const QString &type )
 
   QgsField field;
   field.setName( name );
+  field.setType(QVariant::nameToType(type.toUtf8()));
   mFields.append( field );
 
   endResetModel();
   return true;
   //emit dataChanged();
+}
+
+QStringList FieldsModel::supportedTypes()
+{
+    QStringList supportedTypes;
+    supportedTypes << "text";
+    supportedTypes << "attachement";
+    supportedTypes << "date";
+
+
+    return supportedTypes;
 }
 
 QHash<int, QByteArray> FieldsModel::roleNames() const
@@ -98,4 +111,34 @@ bool FieldsModel::setData( const QModelIndex &index, const QVariant &value, int 
 //  }
 
   return false;
+}
+
+void FieldsModel::initModel()
+{
+    addField("Date", "text");
+    addField("Notes", "text");
+    addField("Photo", "text");
+}
+
+QVariant FieldsModel::parseType(const QString &type)
+{
+//    if ( type == QLatin1String( "text" ) )
+//         return QVariant::type()
+//       else if ( type == QLatin1String( "integer" ) )
+//         ogrType = OFTInteger;
+//       else if ( type == QLatin1String( "integer64" ) )
+//         ogrType = OFTInteger64;
+//       else if ( type == QLatin1String( "real" ) )
+//         ogrType = OFTReal;
+//       else if ( type == QLatin1String( "date" ) )
+//         ogrType = OFTDate;
+//       else if ( type == QLatin1String( "datetime" ) )
+//         ogrType = OFTDateTime;
+//       else if ( type == QLatin1String( "bool" ) )
+//       {
+//         ogrType = OFTInteger;
+//         isBool = true;
+//       }
+//       else if ( type == QLatin1String( "binary" ) )
+//         ogrType = OFTBinary;
 }

--- a/app/fieldsmodel.cpp
+++ b/app/fieldsmodel.cpp
@@ -132,16 +132,6 @@ bool FieldsModel::setData( const QModelIndex &index, const QVariant &value, int 
   return false;
 }
 
-QString FieldsModel::findWidgetTypeByFieldName( const QString name ) const
-{
-  for ( int i = 0; i < mFields.count(); ++i )
-  {
-    if ( mFields.at( i ).attributeName == name )
-      return mFields.at( i ).widgetType;
-  }
-  return QString( "TextEdit" );
-}
-
 void FieldsModel::initModel()
 {
   mFields.clear();

--- a/app/fieldsmodel.h
+++ b/app/fieldsmodel.h
@@ -9,6 +9,13 @@
 #include "qgsfield.h"
 #include "qgsfields.h"
 
+struct FieldConfiguration
+{
+  QString attributeName;
+  QString fieldType;
+  QString widgetType;
+};
+
 class FieldsModel: public QAbstractListModel
 {
     Q_OBJECT
@@ -21,9 +28,9 @@ class FieldsModel: public QAbstractListModel
     //! Feature roles
     enum FeatureRoles
     {
-      AttributeName = Qt::UserRole + 1,  //!< Attribute's display name (the original field name or a custom alias)
+      AttributeName = Qt::UserRole + 1,  //!< Attribute's display name (the original field name)
       FieldType,
-      WidgetType,
+      WidgetType,  //!< Widget type name. Should match QT/QML editor widgets names.
     };
 
     //! Creates a new fields model
@@ -31,28 +38,26 @@ class FieldsModel: public QAbstractListModel
 
     Q_INVOKABLE bool addField( const QString &name, const QString &type, const QString &widgetType = QString( "TextEdit" ) );
     Q_INVOKABLE bool removeField( int rowIndex );
+    //! Returns map of supported widget's name (key) and string representation (value).
     Q_INVOKABLE QVariantMap supportedTypes();
-    Q_INVOKABLE QgsFields fields();
-
 
     QHash<int, QByteArray> roleNames() const override;
     int rowCount( const QModelIndex &parent ) const override;
     QVariant data( const QModelIndex &index, int role ) const override;
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
 
+    QList<FieldConfiguration> fields();
     QString findWidgetTypeByFieldName( const QString name ) const;
 
   signals:
     void widgetListChanged();
-    void notify(const QString &message );
+    void notify( const QString &message );
 
   private:
-    QgsFields mFields;
+    QList<FieldConfiguration> mFields;
 
     //! Inits model with default fields
     void initModel();
-    QVariant::Type parseType( const QString &type );
-    QgsField createField( const QString &name, const QString &type, const QString &widgetType );
 };
 
 #endif // FIELDSMODEL_H

--- a/app/fieldsmodel.h
+++ b/app/fieldsmodel.h
@@ -29,14 +29,13 @@ class FieldsModel: public QAbstractListModel
     enum FeatureRoles
     {
       AttributeName = Qt::UserRole + 1,  //!< Attribute's display name (the original field name)
-      FieldType,
       WidgetType,  //!< Widget type name. Should match QT/QML editor widgets names.
     };
 
     //! Creates a new fields model
     explicit FieldsModel( QObject *parent = nullptr );
 
-    Q_INVOKABLE bool addField( const QString &name, const QString &type, const QString &widgetType = QString( "TextEdit" ) );
+    Q_INVOKABLE bool addField( const QString &name, const QString &widgetType = QString( "TextEdit" ) );
     Q_INVOKABLE bool removeField( int rowIndex );
     //! Returns map of supported widget's name (key) and string representation (value).
     Q_INVOKABLE QVariantMap supportedTypes();
@@ -58,6 +57,7 @@ class FieldsModel: public QAbstractListModel
 
     //! Inits model with default fields
     void initModel();
+    bool contains( const QString &name );
 };
 
 #endif // FIELDSMODEL_H

--- a/app/fieldsmodel.h
+++ b/app/fieldsmodel.h
@@ -44,6 +44,7 @@ class FieldsModel: public QAbstractListModel
 
   signals:
     void widgetListChanged();
+    void notify(const QString &message );
 
   private:
     QgsFields mFields;

--- a/app/fieldsmodel.h
+++ b/app/fieldsmodel.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QAbstractListModel>
 #include <QVector>
+#include <QMap>
 
 #include "qgsfield.h"
 #include "qgsfields.h"
@@ -21,15 +22,16 @@ class FieldsModel: public QAbstractListModel
     enum FeatureRoles
     {
       AttributeName = Qt::UserRole + 1,  //!< Attribute's display name (the original field name or a custom alias)
+      FieldType,
       WidgetType,
-      Field,                             //!< Field definition (QgsField)
     };
 
     //! Creates a new fields model
     explicit FieldsModel( QObject *parent = nullptr );
 
-    Q_INVOKABLE bool addField( const QString &name, const QString &type );
-    Q_INVOKABLE QStringList supportedTypes();
+    Q_INVOKABLE bool addField( const QString &name, const QString &type, const QString &widgetType = QString( "TextEdit" ) );
+    Q_INVOKABLE bool removeField( int rowIndex );
+    Q_INVOKABLE QVariantMap supportedTypes();
     Q_INVOKABLE QgsFields fields();
 
 
@@ -38,19 +40,18 @@ class FieldsModel: public QAbstractListModel
     QVariant data( const QModelIndex &index, int role ) const override;
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
 
+    QString findWidgetTypeByFieldName( const QString name ) const;
+
   signals:
     void widgetListChanged();
 
   private:
-    //QList<QgsField> mFields;
     QgsFields mFields;
 
-    //QgsFields;
-    //QStringList widgetList;
     //! Inits model with default fields
     void initModel();
     QVariant::Type parseType( const QString &type );
-    QgsField createField( const QString &name, const QString &type );
+    QgsField createField( const QString &name, const QString &type, const QString &widgetType );
 };
 
 #endif // FIELDSMODEL_H

--- a/app/fieldsmodel.h
+++ b/app/fieldsmodel.h
@@ -28,14 +28,22 @@ class FieldsModel: public QAbstractListModel
     explicit FieldsModel( QObject *parent = nullptr );
 
     Q_INVOKABLE bool addField( const QString &name, const QString &type );
+    Q_INVOKABLE QStringList supportedTypes();
 
     QHash<int, QByteArray> roleNames() const override;
     int rowCount( const QModelIndex &parent ) const override;
     QVariant data( const QModelIndex &index, int role ) const override;
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
 
-  private:
+signals:
+    void widgetListChanged();
+
+private:
     QList<QgsField> mFields;
+    //QStringList widgetList;
+    //! Inits model with default fields
+    void initModel();
+    QVariant parseType(const QString &type);
 };
 
 #endif // FIELDSMODEL_H

--- a/app/fieldsmodel.h
+++ b/app/fieldsmodel.h
@@ -1,0 +1,41 @@
+#ifndef FIELDSMODEL_H
+#define FIELDSMODEL_H
+
+#include <QObject>
+#include <QAbstractListModel>
+#include <QVector>
+
+#include "qgsfield.h"
+
+class FieldsModel: public QAbstractListModel
+{
+    Q_OBJECT
+  public:
+    /**
+     * Feature roles enum.
+     */
+    Q_ENUMS( FeatureRoles )
+
+    //! Feature roles
+    enum FeatureRoles
+    {
+      AttributeName = Qt::UserRole + 1,  //!< Attribute's display name (the original field name or a custom alias)
+      WidgetType,
+      Field,                             //!< Field definition (QgsField)
+    };
+
+    //! Creates a new fields model
+    explicit FieldsModel( QObject *parent = nullptr );
+
+    Q_INVOKABLE bool addField( const QString &name, const QString &type );
+
+    QHash<int, QByteArray> roleNames() const override;
+    int rowCount( const QModelIndex &parent ) const override;
+    QVariant data( const QModelIndex &index, int role ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
+
+  private:
+    QList<QgsField> mFields;
+};
+
+#endif // FIELDSMODEL_H

--- a/app/fieldsmodel.h
+++ b/app/fieldsmodel.h
@@ -39,6 +39,8 @@ class FieldsModel: public QAbstractListModel
     Q_INVOKABLE bool removeField( int rowIndex );
     //! Returns map of supported widget's name (key) and string representation (value).
     Q_INVOKABLE QVariantMap supportedTypes();
+    //! Inits model with default fields
+    Q_INVOKABLE void initModel();
 
     QHash<int, QByteArray> roleNames() const override;
     int rowCount( const QModelIndex &parent ) const override;
@@ -55,8 +57,7 @@ class FieldsModel: public QAbstractListModel
   private:
     QList<FieldConfiguration> mFields;
 
-    //! Inits model with default fields
-    void initModel();
+
     bool contains( const QString &name );
 };
 

--- a/app/fieldsmodel.h
+++ b/app/fieldsmodel.h
@@ -6,6 +6,7 @@
 #include <QVector>
 
 #include "qgsfield.h"
+#include "qgsfields.h"
 
 class FieldsModel: public QAbstractListModel
 {
@@ -29,21 +30,27 @@ class FieldsModel: public QAbstractListModel
 
     Q_INVOKABLE bool addField( const QString &name, const QString &type );
     Q_INVOKABLE QStringList supportedTypes();
+    Q_INVOKABLE QgsFields fields();
+
 
     QHash<int, QByteArray> roleNames() const override;
     int rowCount( const QModelIndex &parent ) const override;
     QVariant data( const QModelIndex &index, int role ) const override;
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
 
-signals:
+  signals:
     void widgetListChanged();
 
-private:
-    QList<QgsField> mFields;
+  private:
+    //QList<QgsField> mFields;
+    QgsFields mFields;
+
+    //QgsFields;
     //QStringList widgetList;
     //! Inits model with default fields
     void initModel();
-    QVariant parseType(const QString &type);
+    QVariant::Type parseType( const QString &type );
+    QgsField createField( const QString &name, const QString &type );
 };
 
 #endif // FIELDSMODEL_H

--- a/app/fieldsmodel.h
+++ b/app/fieldsmodel.h
@@ -46,9 +46,8 @@ class FieldsModel: public QAbstractListModel
     int rowCount( const QModelIndex &parent ) const override;
     QVariant data( const QModelIndex &index, int role ) const override;
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
-
+    //! Returns fields configuration
     QList<FieldConfiguration> fields();
-    QString findWidgetTypeByFieldName( const QString name ) const;
 
   signals:
     void widgetListChanged();

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -400,6 +400,40 @@ QString InputUtils::appPlatform()
   return platform;
 }
 
+
+QString InputUtils::findUniquePath( const QString &path, bool isPathDir )
+{
+  QFileInfo pathInfo( path );
+  if ( pathInfo.exists() )
+  {
+    int i = 0;
+    QFileInfo info( path + QString::number( i ) );
+    while ( info.exists() && ( info.isDir() || !isPathDir ) )
+    {
+      ++i;
+      info.setFile( path + QString::number( i ) );
+    }
+    return path + QString::number( i );
+  }
+  else
+  {
+    return path;
+  }
+}
+
+
+QString InputUtils::createUniqueProjectDirectory( const QString &baseDataDir, const QString &projectName )
+{
+  QString projectDirPath = findUniquePath( baseDataDir + "/" + projectName );
+  QDir projectDir( projectDirPath );
+  if ( !projectDir.exists() )
+  {
+    QDir dir( "" );
+    dir.mkdir( projectDirPath );
+  }
+  return projectDirPath;
+}
+
 void InputUtils::onQgsLogMessageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level )
 {
   QString levelStr;

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -140,6 +140,16 @@ class InputUtils: public QObject
     /** InputApp platform */
     static QString appPlatform();
 
+    /**
+    * Returns given path if doesn't exists, otherwise the slightly modified non-existing path by adding a number to given path.
+    * \param QString path
+    * \param QString isPathDir True if the result path suppose to be a folder
+    */
+    static QString findUniquePath( const QString &path, bool isPathDir = true );
+
+    //! Creates a unique project directory for given project name (used for initial download of a project)
+    static QString createUniqueProjectDirectory( const QString &baseDataDir, const QString &projectName );
+
   signals:
     Q_INVOKABLE void showNotificationRequested( const QString &message );
 

--- a/app/localprojectsmanager.cpp
+++ b/app/localprojectsmanager.cpp
@@ -107,16 +107,27 @@ void LocalProjectsManager::updateProjectStatus( const QString &projectDir )
   Q_ASSERT( false );  // should not happen
 }
 
-void LocalProjectsManager::addMerginProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName )
+void LocalProjectsManager::addProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName )
 {
   LocalProjectInfo project;
   project.projectDir = projectDir;
   project.qgisProjectFilePath = findQgisProjectFile( projectDir, project.qgisProjectError );
   project.projectNamespace = projectNamespace;
   project.projectName = projectName;
-  // version info and status should be updated afterwards
 
   mProjects << project;
+}
+
+void LocalProjectsManager::addMerginProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName )
+{
+  addProject( projectDir, projectNamespace, projectName );
+  // version info and status should be updated afterwards
+  emit localMerginProjectAdded( projectDir );
+}
+
+void LocalProjectsManager::addLocalProject( const QString &projectDir, const QString &projectName )
+{
+  addProject( projectDir, QString(), projectName );
   emit localProjectAdded( projectDir );
 }
 

--- a/app/localprojectsmanager.cpp
+++ b/app/localprojectsmanager.cpp
@@ -116,6 +116,8 @@ void LocalProjectsManager::addMerginProject( const QString &projectDir, const QS
   project.projectName = projectName;
   // version info and status should be updated afterwards
 
+
+  qDebug() << "@! PROJECT ADDED" << projectDir;
   mProjects << project;
   emit localProjectAdded( projectDir );
 }
@@ -319,6 +321,12 @@ ProjectStatus LocalProjectsManager::currentProjectStatus( const LocalProjectInfo
   }
 
   return ProjectStatus::UpToDate;
+}
+
+void LocalProjectsManager::addLocalProject( const QString &projectDir, const QString &projectName )
+{
+  // TODO unused params
+  reloadProjectDir();
 }
 
 void LocalProjectsManager::updateProjectStatus( LocalProjectInfo &project )

--- a/app/localprojectsmanager.cpp
+++ b/app/localprojectsmanager.cpp
@@ -116,8 +116,6 @@ void LocalProjectsManager::addMerginProject( const QString &projectDir, const QS
   project.projectName = projectName;
   // version info and status should be updated afterwards
 
-
-  qDebug() << "@! PROJECT ADDED" << projectDir;
   mProjects << project;
   emit localProjectAdded( projectDir );
 }
@@ -321,12 +319,6 @@ ProjectStatus LocalProjectsManager::currentProjectStatus( const LocalProjectInfo
   }
 
   return ProjectStatus::UpToDate;
-}
-
-void LocalProjectsManager::addLocalProject( const QString &projectDir, const QString &projectName )
-{
-  // TODO unused params
-  reloadProjectDir();
 }
 
 void LocalProjectsManager::updateProjectStatus( LocalProjectInfo &project )

--- a/app/localprojectsmanager.h
+++ b/app/localprojectsmanager.h
@@ -118,10 +118,6 @@ class LocalProjectsManager : public QObject
     void localProjectAdded( const QString &projectDir );
     void localProjectRemoved( const QString &projectDir );
 
-  public slots:
-    //! TODO only temporary
-    void addLocalProject( const QString &projectDir, const QString &projectName );
-
   private:
     void updateProjectStatus( LocalProjectInfo &project );
 

--- a/app/localprojectsmanager.h
+++ b/app/localprojectsmanager.h
@@ -118,6 +118,10 @@ class LocalProjectsManager : public QObject
     void localProjectAdded( const QString &projectDir );
     void localProjectRemoved( const QString &projectDir );
 
+  public slots:
+    //! TODO only temporary
+    void addLocalProject( const QString &projectDir, const QString &projectName );
+
   private:
     void updateProjectStatus( LocalProjectInfo &project );
 

--- a/app/localprojectsmanager.h
+++ b/app/localprojectsmanager.h
@@ -79,8 +79,11 @@ class LocalProjectsManager : public QObject
 
     void updateProjectStatus( const QString &projectDir );
 
-    //! Should add an entry about newly created project
+    //! Should add an entry about newly created Mergin project
     void addMerginProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName );
+
+    //! Should add an entry about newly created local project
+    void addLocalProject( const QString &projectDir, const QString &projectName );
 
     //! Should forget about that project (it has been removed already)
     void removeProject( const QString &projectDir );
@@ -115,11 +118,14 @@ class LocalProjectsManager : public QObject
 
   signals:
     void projectMetadataChanged( const QString &projectDir );
+    void localMerginProjectAdded( const QString &projectDir );
     void localProjectAdded( const QString &projectDir );
     void localProjectRemoved( const QString &projectDir );
 
   private:
     void updateProjectStatus( LocalProjectInfo &project );
+    //! Should add an entry about newly created project. Emits no signals
+    void addProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName );
 
   private:
     QString mDataDir;   //!< directory with all local projects

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -369,7 +369,7 @@ int main( int argc, char *argv[] )
   MerginProjectStatusModel mpsm( localProjects );
   InputHelp help( ma.get(), &iu );
   FieldsModel fm;
-  ProjectWizard pw;
+  ProjectWizard pw( projectDir, &fm );
 
   // layer models
   LayersModel lm;
@@ -386,6 +386,7 @@ int main( int argc, char *argv[] )
   QObject::connect( &app, &QCoreApplication::aboutToQuit, &loader, &Loader::appAboutToQuit );
   QObject::connect( ma.get(), &MerginApi::syncProjectFinished, &pm, &ProjectModel::syncedProjectFinished );
   QObject::connect( ma.get(), &MerginApi::projectDetached, &pm, &ProjectModel::findProjectFiles );
+  QObject::connect( &pw, &ProjectWizard::projectCreated, &pm, &ProjectModel::addLocalProject );
   QObject::connect( ma.get(), &MerginApi::listProjectsFinished, &mpm, &MerginProjectModel::updateModel );
   QObject::connect( ma.get(), &MerginApi::syncProjectStatusChanged, &mpm, &MerginProjectModel::syncProjectStatusChanged );
   QObject::connect( ma.get(), &MerginApi::reloadProject, &loader, &Loader::reloadProject );
@@ -486,6 +487,7 @@ int main( int argc, char *argv[] )
   engine.rootContext()->setContextProperty( "__activeLayer", &al );
   engine.rootContext()->setContextProperty( "__purchasing", purchasing.get() );
   engine.rootContext()->setContextProperty( "__fieldsModel", &fm );
+  engine.rootContext()->setContextProperty( "__projectWizard", &pw );
 
 #ifdef MOBILE_OS
   engine.rootContext()->setContextProperty( "__appwindowvisibility", QWindow::Maximized );

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -393,6 +393,7 @@ int main( int argc, char *argv[] )
   QObject::connect( &mtm, &MapThemesModel::mapThemeChanged, &recordingLpm, &LayersProxyModel::onMapThemeChanged );
   QObject::connect( &loader, &Loader::projectReloaded, vm.get(), &VariablesManager::merginProjectChanged );
   QObject::connect( &loader, &Loader::projectWillBeReloaded, &inputProjUtils, &InputProjUtils::resetHandlers );
+  QObject::connect( &pw, &ProjectWizard::notify, &iu, &InputUtils::showNotificationRequested );
   QObject::connect( QgsApplication::messageLog(),
                     static_cast<void ( QgsMessageLog::* )( const QString &message, const QString &tag, Qgis::MessageLevel level )>( &QgsMessageLog::messageReceived ),
                     &iu,

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -227,6 +227,7 @@ void initDeclarative()
   qmlRegisterUncreatableType<ActiveLayer>( "lc", 1, 0, "ActiveLayer", "" );
   qmlRegisterType<DigitizingController>( "lc", 1, 0, "DigitizingController" );
   qmlRegisterType<PositionDirection>( "lc", 1, 0, "PositionDirection" );
+  qmlRegisterType<FieldsModel>( "lc", 1, 0, "FieldsModel" );
 }
 
 #ifdef INPUT_TEST
@@ -368,8 +369,7 @@ int main( int argc, char *argv[] )
   MerginProjectModel mpm( localProjects );
   MerginProjectStatusModel mpsm( localProjects );
   InputHelp help( ma.get(), &iu );
-  FieldsModel fm;
-  ProjectWizard pw( projectDir, &fm );
+  ProjectWizard pw( projectDir );
 
   // layer models
   LayersModel lm;
@@ -487,7 +487,6 @@ int main( int argc, char *argv[] )
   engine.rootContext()->setContextProperty( "__browseDataLayersModel", &browseLpm );
   engine.rootContext()->setContextProperty( "__activeLayer", &al );
   engine.rootContext()->setContextProperty( "__purchasing", purchasing.get() );
-  engine.rootContext()->setContextProperty( "__fieldsModel", &fm );
   engine.rootContext()->setContextProperty( "__projectWizard", &pw );
 
 #ifdef MOBILE_OS

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -50,6 +50,7 @@
 #include "variablesmanager.h"
 #include "inputhelp.h"
 #include "inputprojutils.h"
+#include "fieldsmodel.h"
 
 #ifdef INPUT_TEST
 #include "test/testmerginapi.h"
@@ -366,6 +367,7 @@ int main( int argc, char *argv[] )
   MerginProjectModel mpm( localProjects );
   MerginProjectStatusModel mpsm( localProjects );
   InputHelp help( ma.get(), &iu );
+  FieldsModel fm;
 
   // layer models
   LayersModel lm;
@@ -481,6 +483,7 @@ int main( int argc, char *argv[] )
   engine.rootContext()->setContextProperty( "__browseDataLayersModel", &browseLpm );
   engine.rootContext()->setContextProperty( "__activeLayer", &al );
   engine.rootContext()->setContextProperty( "__purchasing", purchasing.get() );
+  engine.rootContext()->setContextProperty( "__fieldsModel", &fm );
 
 #ifdef MOBILE_OS
   engine.rootContext()->setContextProperty( "__appwindowvisibility", QWindow::Maximized );

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -51,6 +51,7 @@
 #include "inputhelp.h"
 #include "inputprojutils.h"
 #include "fieldsmodel.h"
+#include "projectwizard.h"
 
 #ifdef INPUT_TEST
 #include "test/testmerginapi.h"
@@ -368,6 +369,7 @@ int main( int argc, char *argv[] )
   MerginProjectStatusModel mpsm( localProjects );
   InputHelp help( ma.get(), &iu );
   FieldsModel fm;
+  ProjectWizard pw;
 
   // layer models
   LayersModel lm;

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -386,7 +386,7 @@ int main( int argc, char *argv[] )
   QObject::connect( &app, &QCoreApplication::aboutToQuit, &loader, &Loader::appAboutToQuit );
   QObject::connect( ma.get(), &MerginApi::syncProjectFinished, &pm, &ProjectModel::syncedProjectFinished );
   QObject::connect( ma.get(), &MerginApi::projectDetached, &pm, &ProjectModel::findProjectFiles );
-  QObject::connect( &pw, &ProjectWizard::projectCreated, &pm, &ProjectModel::addLocalProject );
+  QObject::connect( &pw, &ProjectWizard::projectCreated, &localProjects, &LocalProjectsManager::addLocalProject );
   QObject::connect( ma.get(), &MerginApi::listProjectsFinished, &mpm, &MerginProjectModel::updateModel );
   QObject::connect( ma.get(), &MerginApi::syncProjectStatusChanged, &mpm, &MerginProjectModel::syncProjectStatusChanged );
   QObject::connect( ma.get(), &MerginApi::reloadProject, &loader, &Loader::reloadProject );

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -514,20 +514,16 @@ class MerginApi: public QObject
     */
     QString generateConflictFileName( const QString &path, int version );
 
-    // TODO use method from InputUtils
-    /**
-    * Returns given path if doesn't exists, otherwise the slightly modified non-existing path by adding a number to given path.
-    * \param QString path
-    * \param QString isPathDir True if the result path suppose to be a folder
-    */
-    QString findUniquePath( const QString &path, bool isPathDir = true );
+//    // TODO use method from InputUtils
+//    /**
+//    * Returns given path if doesn't exists, otherwise the slightly modified non-existing path by adding a number to given path.
+//    * \param QString path
+//    * \param QString isPathDir True if the result path suppose to be a folder
+//    */
+//    QString findUniquePath( const QString &path, bool isPathDir = true );
     /** Creates a request to get project details (list of project files).
      */
     QNetworkReply *getProjectInfo( const QString &projectFullName, bool withoutAuth = false );
-
-    // TODO use method from InputUtils
-    //! Creates a unique project directory for given project name (used for initial download of a project)
-    QString createUniqueProjectDirectory( const QString &projectName );
 
     //! Called when download/update of project data has finished to finalize things and emit sync finished signal
     void finalizeProjectUpdate( const QString &projectFullName );

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -513,6 +513,8 @@ class MerginApi: public QObject
     * \param int version
     */
     QString generateConflictFileName( const QString &path, int version );
+
+    // TODO use method from InputUtils
     /**
     * Returns given path if doesn't exists, otherwise the slightly modified non-existing path by adding a number to given path.
     * \param QString path
@@ -523,6 +525,7 @@ class MerginApi: public QObject
      */
     QNetworkReply *getProjectInfo( const QString &projectFullName, bool withoutAuth = false );
 
+    // TODO use method from InputUtils
     //! Creates a unique project directory for given project name (used for initial download of a project)
     QString createUniqueProjectDirectory( const QString &projectName );
 

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -514,13 +514,6 @@ class MerginApi: public QObject
     */
     QString generateConflictFileName( const QString &path, int version );
 
-//    // TODO use method from InputUtils
-//    /**
-//    * Returns given path if doesn't exists, otherwise the slightly modified non-existing path by adding a number to given path.
-//    * \param QString path
-//    * \param QString isPathDir True if the result path suppose to be a folder
-//    */
-//    QString findUniquePath( const QString &path, bool isPathDir = true );
     /** Creates a request to get project details (list of project files).
      */
     QNetworkReply *getProjectInfo( const QString &projectFullName, bool withoutAuth = false );

--- a/app/merginprojectmodel.cpp
+++ b/app/merginprojectmodel.cpp
@@ -16,7 +16,7 @@ MerginProjectModel::MerginProjectModel( LocalProjectsManager &localProjects, QOb
   , mLocalProjects( localProjects )
 {
   QObject::connect( &mLocalProjects, &LocalProjectsManager::projectMetadataChanged, this, &MerginProjectModel::projectMetadataChanged );
-  QObject::connect( &mLocalProjects, &LocalProjectsManager::localProjectAdded, this, &MerginProjectModel::onLocalProjectAdded );
+  QObject::connect( &mLocalProjects, &LocalProjectsManager::localMerginProjectAdded, this, &MerginProjectModel::onLocalProjectAdded );
   QObject::connect( &mLocalProjects, &LocalProjectsManager::localProjectRemoved, this, &MerginProjectModel::onLocalProjectRemoved );
 
   mAdditionalItem->status = NonProjectItem;

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -187,7 +187,9 @@ void ProjectModel::syncedProjectFinished( const QString &projectDir, const QStri
 
 void ProjectModel::addLocalProject( const QString &projectDir, const QString &projectName )
 {
-  mLocalProjects.addLocalProject( projectDir, projectName );
+  Q_UNUSED( projectDir );
+  Q_UNUSED( projectName );
+  mLocalProjects.reloadProjectDir();
   findProjectFiles();
 }
 

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -185,6 +185,12 @@ void ProjectModel::syncedProjectFinished( const QString &projectDir, const QStri
   reloadProjectFiles( projectDir, projectFullName, successfully );
 }
 
+void ProjectModel::addLocalProject( const QString &projectDir, const QString &projectName )
+{
+  mLocalProjects.addLocalProject( projectDir, projectName );
+  findProjectFiles();
+}
+
 void ProjectModel::reloadProjectFiles( QString projectFolder, QString projectName, bool successful )
 {
   if ( !successful ) return;
@@ -192,7 +198,5 @@ void ProjectModel::reloadProjectFiles( QString projectFolder, QString projectNam
   if ( projectFolder.isEmpty() ) return;
 
   Q_UNUSED( projectName );
-  beginResetModel();
   findProjectFiles();
-  endResetModel();
 }

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -28,6 +28,8 @@ ProjectModel::ProjectModel( LocalProjectsManager &localProjects, QObject *parent
   , mLocalProjects( localProjects )
 {
   findProjectFiles();
+
+  QObject::connect( &mLocalProjects, &LocalProjectsManager::localProjectAdded, this, &ProjectModel::addLocalProject );
 }
 
 ProjectModel::~ProjectModel() {}
@@ -185,10 +187,9 @@ void ProjectModel::syncedProjectFinished( const QString &projectDir, const QStri
   reloadProjectFiles( projectDir, projectFullName, successfully );
 }
 
-void ProjectModel::addLocalProject( const QString &projectDir, const QString &projectName )
+void ProjectModel::addLocalProject( const QString &projectDir )
 {
   Q_UNUSED( projectDir );
-  Q_UNUSED( projectName );
   mLocalProjects.reloadProjectDir();
   findProjectFiles();
 }

--- a/app/projectsmodel.h
+++ b/app/projectsmodel.h
@@ -70,7 +70,7 @@ class ProjectModel : public QAbstractListModel
 
   public slots:
     void syncedProjectFinished( const QString &projectDir, const QString &projectFullName, bool successfully );
-    void addLocalProject( const QString &projectDir, const QString &projectName );
+    void addLocalProject( const QString &projectDir );
     void findProjectFiles();
 
   private:

--- a/app/projectsmodel.h
+++ b/app/projectsmodel.h
@@ -70,7 +70,6 @@ class ProjectModel : public QAbstractListModel
 
   public slots:
     void syncedProjectFinished( const QString &projectDir, const QString &projectFullName, bool successfully );
-    // TODO temporary function till local project will not be added to Mergin
     void addLocalProject( const QString &projectDir, const QString &projectName );
     void findProjectFiles();
 

--- a/app/projectsmodel.h
+++ b/app/projectsmodel.h
@@ -70,6 +70,8 @@ class ProjectModel : public QAbstractListModel
 
   public slots:
     void syncedProjectFinished( const QString &projectDir, const QString &projectFullName, bool successfully );
+    // TODO temporary function till local project will not be added to Mergin
+    void addLocalProject( const QString &projectDir, const QString &projectName );
     void findProjectFiles();
 
   private:

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -1,0 +1,19 @@
+#include "projectwizard.h"
+
+ProjectWizard::ProjectWizard()
+{
+
+}
+
+void ProjectWizard::createProject()
+{
+
+    QString projectName = QString("TODO"); // TODO;
+    // Create a new folder for a project
+
+
+    QString fileName( mDatabase->filePath() );
+      if ( !fileName.endsWith( QLatin1String( ".gpkg" ), Qt::CaseInsensitive ) )
+        fileName += QLatin1String( ".gpkg" );
+
+}

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -2,8 +2,10 @@
 #include "inpututils.h"
 
 #include "qgsproject.h"
+#include "qgsrasterlayer.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorfilewriter.h"
+#include "qgsdatetimefieldformatter.h"
 
 #include <ogr_api.h>
 #include <ogr_srs_api.h>
@@ -25,27 +27,24 @@ QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir )
   QString projectGpkgPath( QString( "%1/%2.%3" ).arg( projectDir ).arg( gpkgName ).arg( "gpkg" ) );
   QString layerName( QStringLiteral( "Points" ) );
   QgsCoordinateReferenceSystem layerCrs( " EPSG:4326" );
+  QgsFields predefinedFields = mFieldsModel->fields();
 
-  QgsFields fields = mFieldsModel->fields();
-  //QgsFields fields;
+  // Write layer as gpkg
   QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?crs=EPSG:4326" ), layerName, "memory" );
-  //layer->setCrs(layerCrs);
-  qDebug() << "!!! SAVING Layer" << layer->isValid() <<  projectGpkgPath;
-
-  //QgsVectorDataProvider *dataProvider = layer->dataProvider();
   layer->startEditing();
-  for ( QgsField f : fields )
+  layer->setCrs( layerCrs );
+  for ( QgsField f : predefinedFields )
   {
-    //dataProvider->addAttributes()
     layer->addAttribute( f );
   }
+  layer->updateFields();
   layer->commitChanges();
 
   QgsVectorFileWriter::SaveVectorOptions options;
-//  options.driverName = QStringLiteral( "GPKG" );
-//  options.layerName = layerName;
-//  options.fileEncoding = QStringLiteral( "UTF-8" );
-  std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( projectGpkgPath, fields, QgsWkbTypes::Point, layerCrs, QgsCoordinateTransformContext(), options ) );
+  options.driverName = QStringLiteral( "GPKG" );
+  options.layerName = layerName;
+  options.fileEncoding = QStringLiteral( "UTF-8" ); // TODO check name/col name with special chars
+  std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( projectGpkgPath, predefinedFields, QgsWkbTypes::Point, layerCrs, QgsCoordinateTransformContext(), options ) );
 
 
   QString errorMessage;
@@ -58,35 +57,86 @@ QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir )
     nullptr,
     &errorMessage );
 
-//  QgsVectorLayer vl2( QStringLiteral( "%1|layername=%2" ).arg( projectGpkgPath ).arg( layerName ), layerName, "ogr" );
-//  qDebug() << "!!! Layer validity check" << layer->isValid() << vl2.isValid();
-//  Q_ASSERT( vl2.isValid() );
+  // Check and configure layer
+  QgsVectorLayer *layer2 = new QgsVectorLayer( projectGpkgPath, "Points", "ogr" );
 
-  qDebug() << "!!! SAVING Layer2" << layer->isValid() <<  projectGpkgPath << errorMessage;
-  return layer;
+  Q_ASSERT( layer2->isValid() );
+
+  layer2->startEditing();
+  layer2->setCrs( layerCrs );
+  for ( int i = 0; i < layer2->fields().count(); ++i )
+  {
+    QgsField f = layer2->fields().at( i );
+    QgsEditorWidgetSetup setup = getEditorWidget( f, mFieldsModel->findWidgetTypeByFieldName( f.name() ) );
+    layer2->setEditorWidgetSetup( i, setup );
+  }
+  layer2->commitChanges();
+
+  return layer2;
 }
 
 void ProjectWizard::createProject( QString const &projectName )
 {
-  //QString projectName = QString( "TODO" ); // TODO;
   QString projectDir = InputUtils::createUniqueProjectDirectory( mDataDir, projectName );
-  QString projectFilepath( QString( "%1/%2.%3" ).arg( projectDir ).arg( projectName ).arg( "qgz" ) );
-  QgsVectorLayer *layer = createGpkgLayer( projectDir );
-
-//  std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "none?field=code:int&field=regular:string" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
-//  QVERIFY( tempLayer->isValid() );
-
-  QgsProject project;
-  project.addMapLayer( layer );
-  // TODO add BG map
-  project.setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) );
-
-  project.addMapLayer( layer );
+  QString projectFilepath( QString( "%1/%2.%3" ).arg( projectDir ).arg( projectName ).arg( "qgs" ) );
   QString gpkgName( QStringLiteral( "data" ) );
   QString projectGpkgPath( QString( "%1/%2.%3" ).arg( projectDir ).arg( gpkgName ).arg( "gpkg" ) );
-  // QgsProject::instance()->setFileName( fullPath.filePath() );
+
+  QgsProject project;
+
+  // add background layer
+  QString urlWithParams( "tilePixelRatio=1&type=xyz&url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0" );
+  QgsRasterLayer *bgLayer = new QgsRasterLayer( urlWithParams, "OpenStreetMap", "wms" );
+  project.addMapLayer( bgLayer );
+
+  // Add vector layer
+  QgsVectorLayer *layer = createGpkgLayer( projectDir );
+  project.addMapLayer( layer );
+
+  project.setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) );
   project.writePath( projectGpkgPath );
   project.write( projectFilepath );
 
   emit projectCreated( projectDir, projectName );
+}
+
+QgsEditorWidgetSetup ProjectWizard::getEditorWidget( const QgsField &field, const QString &widgetType )
+{
+
+  // TODO support Slider, SpinBox
+  // TODO DateTime formatter: qgsdatetimefieldformatter
+  qDebug() << "FIELD SETUP" << field.name() << field.typeName() << field.type() << widgetType;
+  if ( field.name() == QStringLiteral( "fid" ) )
+    return QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() );
+
+  if ( widgetType.isEmpty() )
+  {
+    return QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), QVariantMap() );
+  }
+  else
+  {
+    QVariantMap config;
+    if ( widgetType == QStringLiteral( "TextEdit" ) )
+    {
+      config.insert( QStringLiteral( "isMultiline" ), false );
+      config.insert( QStringLiteral( "UseHtml" ), false );
+    }
+    else if ( widgetType == QStringLiteral( "DateTime" ) )
+    {
+      config.insert( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::DATETIME_FORMAT );
+      config.insert( QStringLiteral( "display_format" ), QgsDateTimeFieldFormatter::DATETIME_FORMAT );
+    }
+    // TODO better widget for Range: Slider, etc
+    else if ( widgetType == QStringLiteral( "Range" ) )
+    {
+      config.insert( QStringLiteral( "Style" ), QStringLiteral( "SpinBox" ) );
+    }
+    else if ( widgetType == QStringLiteral( "ExternalResource" ) )
+    {
+      config.insert( QStringLiteral( "RelativeStorage" ), 1 );
+      config.insert( QStringLiteral( "StorageMode" ), 0 );
+    }
+
+    return QgsEditorWidgetSetup( widgetType, config );;
+  }
 }

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -7,13 +7,6 @@
 #include "qgsvectorfilewriter.h"
 #include "qgsdatetimefieldformatter.h"
 
-#include <ogr_api.h>
-#include <ogr_srs_api.h>
-#include <gdal_version.h>
-
-#include <cpl_error.h>
-#include <cpl_string.h>
-
 ProjectWizard::ProjectWizard( const QString &dataDir, FieldsModel *fieldsModel, QObject *parent )
   : QObject( parent )
   , mDataDir( dataDir )
@@ -44,7 +37,7 @@ QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir )
   QgsVectorFileWriter::SaveVectorOptions options;
   options.driverName = QStringLiteral( "GPKG" );
   options.layerName = layerName;
-  options.fileEncoding = QStringLiteral( "UTF-8" ); // TODO check name/col name with special chars
+  options.fileEncoding = QStringLiteral( "UTF-8" );
   std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( projectGpkgPath, predefinedFields, QgsWkbTypes::Point, layerCrs, QgsCoordinateTransformContext(), options ) );
 
 

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -19,7 +19,7 @@ QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir )
 {
   QString gpkgName( QStringLiteral( "data" ) );
   QString projectGpkgPath( QString( "%1/%2.%3" ).arg( projectDir ).arg( gpkgName ).arg( "gpkg" ) );
-  QString layerName( QStringLiteral( "Points" ) );
+  QString layerName( QStringLiteral( "Survey" ) );
   QgsCoordinateReferenceSystem layerCrs( LAYER_CRS_ID );
   QgsFields predefinedFields = createFields( mFieldsModel->fields() );
 
@@ -52,7 +52,7 @@ QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir )
     &errorMessage );
 
   // Check and configure layer
-  QgsVectorLayer *l = new QgsVectorLayer( projectGpkgPath, "Points", "ogr" );
+  QgsVectorLayer *l = new QgsVectorLayer( projectGpkgPath, layerName, "ogr" );
 
   Q_ASSERT( l->isValid() );
 

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -20,11 +20,11 @@ QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir )
   QString gpkgName( QStringLiteral( "data" ) );
   QString projectGpkgPath( QString( "%1/%2.%3" ).arg( projectDir ).arg( gpkgName ).arg( "gpkg" ) );
   QString layerName( QStringLiteral( "Points" ) );
-  QgsCoordinateReferenceSystem layerCrs( "EPSG:4326" );
+  QgsCoordinateReferenceSystem layerCrs( LAYER_CRS_ID );
   QgsFields predefinedFields = createFields( mFieldsModel->fields() );
 
   // Write layer as gpkg
-  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?crs=EPSG:4326" ), layerName, "memory" );
+  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?crs=%1" ).arg( LAYER_CRS_ID ), layerName, "memory" );
   layer->startEditing();
   layer->setCrs( layerCrs );
   for ( QgsField f : predefinedFields )
@@ -79,15 +79,15 @@ void ProjectWizard::createProject( QString const &projectName )
   QgsProject project;
 
   // add background layer
-  QString urlWithParams( "tilePixelRatio=1&type=xyz&url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0" );
-  QgsRasterLayer *bgLayer = new QgsRasterLayer( urlWithParams, "OpenStreetMap", "wms" );
+  QString urlWithParams( BG_MAPS_CONFIG );
+  QgsRasterLayer *bgLayer = new QgsRasterLayer( BG_MAPS_CONFIG, QStringLiteral( "OpenStreetMap" ), QStringLiteral( "wms" ) );
   project.addMapLayer( bgLayer );
 
   // Add vector layer
   QgsVectorLayer *layer = createGpkgLayer( projectDir );
   project.addMapLayer( layer );
 
-  project.setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) );
+  project.setCrs( QgsCoordinateReferenceSystem( PROJECT_CRS_ID ) );
   project.writePath( projectGpkgPath );
   project.write( projectFilepath );
 

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -19,6 +19,7 @@ ProjectWizard::ProjectWizard( const QString &dataDir, FieldsModel *fieldsModel, 
   , mDataDir( dataDir )
   , mFieldsModel( fieldsModel )
 {
+     QObject::connect( mFieldsModel, &FieldsModel::notify, this, &ProjectWizard::notify );
 }
 
 QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir )
@@ -58,21 +59,21 @@ QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir )
     &errorMessage );
 
   // Check and configure layer
-  QgsVectorLayer *layer2 = new QgsVectorLayer( projectGpkgPath, "Points", "ogr" );
+  QgsVectorLayer *l = new QgsVectorLayer( projectGpkgPath, "Points", "ogr" );
 
-  Q_ASSERT( layer2->isValid() );
+  Q_ASSERT( l->isValid() );
 
-  layer2->startEditing();
-  layer2->setCrs( layerCrs );
-  for ( int i = 0; i < layer2->fields().count(); ++i )
+  l->startEditing();
+  l->setCrs( layerCrs );
+  for ( int i = 0; i < l->fields().count(); ++i )
   {
-    QgsField f = layer2->fields().at( i );
+    QgsField f = l->fields().at( i );
     QgsEditorWidgetSetup setup = getEditorWidget( f, mFieldsModel->findWidgetTypeByFieldName( f.name() ) );
-    layer2->setEditorWidgetSetup( i, setup );
+    l->setEditorWidgetSetup( i, setup );
   }
-  layer2->commitChanges();
+  l->commitChanges();
 
-  return layer2;
+  return l;
 }
 
 void ProjectWizard::createProject( QString const &projectName )
@@ -97,6 +98,7 @@ void ProjectWizard::createProject( QString const &projectName )
   project.writePath( projectGpkgPath );
   project.write( projectFilepath );
 
+  emit notify( tr("Project %1 created").arg( projectName ));
   emit projectCreated( projectDir, projectName );
 }
 

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -1,19 +1,92 @@
 #include "projectwizard.h"
+#include "inpututils.h"
 
-ProjectWizard::ProjectWizard()
+#include "qgsproject.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectorfilewriter.h"
+
+#include <ogr_api.h>
+#include <ogr_srs_api.h>
+#include <gdal_version.h>
+
+#include <cpl_error.h>
+#include <cpl_string.h>
+
+ProjectWizard::ProjectWizard( const QString &dataDir, FieldsModel *fieldsModel, QObject *parent )
+  : QObject( parent )
+  , mDataDir( dataDir )
+  , mFieldsModel( fieldsModel )
 {
-
 }
 
-void ProjectWizard::createProject()
+QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir )
 {
+  QString gpkgName( QStringLiteral( "data" ) );
+  QString projectGpkgPath( QString( "%1/%2.%3" ).arg( projectDir ).arg( gpkgName ).arg( "gpkg" ) );
+  QString layerName( QStringLiteral( "Points" ) );
+  QgsCoordinateReferenceSystem layerCrs( " EPSG:4326" );
 
-    QString projectName = QString("TODO"); // TODO;
-    // Create a new folder for a project
+  QgsFields fields = mFieldsModel->fields();
+  //QgsFields fields;
+  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?crs=EPSG:4326" ), layerName, "memory" );
+  //layer->setCrs(layerCrs);
+  qDebug() << "!!! SAVING Layer" << layer->isValid() <<  projectGpkgPath;
+
+  //QgsVectorDataProvider *dataProvider = layer->dataProvider();
+  layer->startEditing();
+  for ( QgsField f : fields )
+  {
+    //dataProvider->addAttributes()
+    layer->addAttribute( f );
+  }
+  layer->commitChanges();
+
+  QgsVectorFileWriter::SaveVectorOptions options;
+//  options.driverName = QStringLiteral( "GPKG" );
+//  options.layerName = layerName;
+//  options.fileEncoding = QStringLiteral( "UTF-8" );
+  std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( projectGpkgPath, fields, QgsWkbTypes::Point, layerCrs, QgsCoordinateTransformContext(), options ) );
 
 
-    QString fileName( mDatabase->filePath() );
-      if ( !fileName.endsWith( QLatin1String( ".gpkg" ), Qt::CaseInsensitive ) )
-        fileName += QLatin1String( ".gpkg" );
+  QString errorMessage;
+  QgsVectorFileWriter::writeAsVectorFormatV2(
+    layer,
+    projectGpkgPath,
+    layer->transformContext(),
+    options,
+    nullptr,
+    nullptr,
+    &errorMessage );
 
+//  QgsVectorLayer vl2( QStringLiteral( "%1|layername=%2" ).arg( projectGpkgPath ).arg( layerName ), layerName, "ogr" );
+//  qDebug() << "!!! Layer validity check" << layer->isValid() << vl2.isValid();
+//  Q_ASSERT( vl2.isValid() );
+
+  qDebug() << "!!! SAVING Layer2" << layer->isValid() <<  projectGpkgPath << errorMessage;
+  return layer;
+}
+
+void ProjectWizard::createProject( QString const &projectName )
+{
+  //QString projectName = QString( "TODO" ); // TODO;
+  QString projectDir = InputUtils::createUniqueProjectDirectory( mDataDir, projectName );
+  QString projectFilepath( QString( "%1/%2.%3" ).arg( projectDir ).arg( projectName ).arg( "qgz" ) );
+  QgsVectorLayer *layer = createGpkgLayer( projectDir );
+
+//  std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "none?field=code:int&field=regular:string" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+//  QVERIFY( tempLayer->isValid() );
+
+  QgsProject project;
+  project.addMapLayer( layer );
+  // TODO add BG map
+  project.setCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) );
+
+  project.addMapLayer( layer );
+  QString gpkgName( QStringLiteral( "data" ) );
+  QString projectGpkgPath( QString( "%1/%2.%3" ).arg( projectDir ).arg( gpkgName ).arg( "gpkg" ) );
+  // QgsProject::instance()->setFileName( fullPath.filePath() );
+  project.writePath( projectGpkgPath );
+  project.write( projectFilepath );
+
+  emit projectCreated( projectDir, projectName );
 }

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -77,8 +77,6 @@ void ProjectWizard::createProject( QString const &projectName )
   QString projectFilepath( QString( "%1/%2.%3" ).arg( projectDir ).arg( projectName ).arg( "qgs" ) );
   QString gpkgName( QStringLiteral( "data" ) );
   QString projectGpkgPath( QString( "%1/%2.%3" ).arg( projectDir ).arg( gpkgName ).arg( "gpkg" ) );
-  bool hasPerms = QFile( projectGpkgPath ).setPermissions( QFileDevice::WriteOther );
-  qDebug() << "hasPermshasPermshasPermshasPerms" << hasPerms << QFile( projectGpkgPath ).permissions();
 
   QgsProject project;
 

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -13,7 +13,7 @@ ProjectWizard::ProjectWizard( const QString &dataDir, FieldsModel *fieldsModel, 
   , mFieldsModel( fieldsModel )
 {
 
-  mSettings = new QgsMapSettings();
+  mSettings = std::unique_ptr<QgsMapSettings>(new QgsMapSettings);
   QObject::connect( mFieldsModel, &FieldsModel::notify, this, &ProjectWizard::notify );
 }
 
@@ -58,7 +58,6 @@ QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir )
 
   Q_ASSERT( l->isValid() );
 
-  l->startEditing();
   l->setCrs( layerCrs );
   for ( int i = 0; i < l->fields().count(); ++i )
   {
@@ -66,7 +65,6 @@ QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir )
     QgsEditorWidgetSetup setup = getEditorWidget( f, mFieldsModel->findWidgetTypeByFieldName( f.name() ) );
     l->setEditorWidgetSetup( i, setup );
   }
-  l->commitChanges();
 
   return l;
 }

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -86,7 +86,7 @@ void ProjectWizard::createProject( QString const &projectName )
   QgsVectorLayer *layer = createGpkgLayer( projectDir );
   QList<QgsMapLayer *> layers;
   layers << bgLayer << layer;
-  project.addMapLayers(layers);
+  project.addMapLayers( layers );
 
   // Configurate mapSettings
   QgsCoordinateReferenceSystem projectCrs( PROJECT_CRS_ID );

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -85,7 +85,7 @@ void ProjectWizard::createProject( QString const &projectName )
   QgsRasterLayer *bgLayer = new QgsRasterLayer( BG_MAPS_CONFIG, QStringLiteral( "OpenStreetMap" ), QStringLiteral( "wms" ) );
   QgsVectorLayer *layer = createGpkgLayer( projectDir );
   QList<QgsMapLayer *> layers;
-  layers << bgLayer << layer;
+  layers << layer << bgLayer;
   project.addMapLayers( layers );
 
   // Configurate mapSettings

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -36,6 +36,10 @@ class ProjectWizard : public QObject
 
     QString mDataDir;
     FieldsModel *mFieldsModel;
+
+    const QString BG_MAPS_CONFIG = QStringLiteral( "tilePixelRatio=1&type=xyz&url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0" );
+    const QString PROJECT_CRS_ID = QStringLiteral( "EPSG:3857" );
+    const QString LAYER_CRS_ID = QStringLiteral( "EPSG:4326" );
 };
 
 #endif // PROJECTWIZARD_H

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -1,0 +1,17 @@
+#ifndef PROJECTWIZARD_H
+#define PROJECTWIZARD_H
+
+#include <QObject>
+#include "fieldsmodel.h"
+#include "qgsfieldmodel.h"
+
+class ProjectWizard
+{
+public:
+    ProjectWizard();
+
+private:
+
+};
+
+#endif // PROJECTWIZARD_H

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -4,14 +4,23 @@
 #include <QObject>
 #include "fieldsmodel.h"
 #include "qgsfieldmodel.h"
+#include "qgsvectorlayer.h"
 
-class ProjectWizard
+class ProjectWizard : public QObject
 {
-public:
-    ProjectWizard();
+    Q_OBJECT
+  public:
+    explicit ProjectWizard( const QString &dataDir, FieldsModel *fieldsModel, QObject *parent = nullptr );
+    ~ProjectWizard() = default;
 
-private:
+    Q_INVOKABLE void createProject( QString const &projectName );
+  signals:
+    void projectCreated( const QString &projectDir, const QString &projectName );
+  private:
+    QgsVectorLayer *createGpkgLayer( QString const &projectDir );
 
+    QString mDataDir;
+    FieldsModel *mFieldsModel;
 };
 
 #endif // PROJECTWIZARD_H

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -16,6 +16,7 @@ class ProjectWizard : public QObject
     Q_INVOKABLE void createProject( QString const &projectName );
   signals:
     void projectCreated( const QString &projectDir, const QString &projectName );
+    void notify(const QString &message );
   private:
     QgsVectorLayer *createGpkgLayer( QString const &projectDir );
     QgsEditorWidgetSetup getEditorWidget( QgsField const &field, const QString &widgetType );

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -6,6 +6,9 @@
 #include "qgsfieldmodel.h"
 #include "qgsvectorlayer.h"
 
+/**
+ * Controller for creating new Input project.
+ */
 class ProjectWizard : public QObject
 {
     Q_OBJECT
@@ -13,13 +16,23 @@ class ProjectWizard : public QObject
     explicit ProjectWizard( const QString &dataDir, FieldsModel *fieldsModel, QObject *parent = nullptr );
     ~ProjectWizard() = default;
 
+    /**
+     * Creates a new project in unique directory named accoridng project name.
+     * \param projectName  Project's name for newly created project.
+     */
     Q_INVOKABLE void createProject( QString const &projectName );
   signals:
+    /**
+      * Emitted after a project has been craeted.
+     */
     void projectCreated( const QString &projectDir, const QString &projectName );
-    void notify(const QString &message );
+    void notify( const QString &message );
   private:
     QgsVectorLayer *createGpkgLayer( QString const &projectDir );
     QgsEditorWidgetSetup getEditorWidget( QgsField const &field, const QString &widgetType );
+    QgsFields createFields( const QList<FieldConfiguration> fieldsConfig ) const;
+    QVariant::Type parseType( const QString &type ) const;
+    QString widgetToType( const QString &widgetType ) const;
 
     QString mDataDir;
     FieldsModel *mFieldsModel;

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -18,6 +18,7 @@ class ProjectWizard : public QObject
     void projectCreated( const QString &projectDir, const QString &projectName );
   private:
     QgsVectorLayer *createGpkgLayer( QString const &projectDir );
+    QgsEditorWidgetSetup getEditorWidget( QgsField const &field, const QString &widgetType );
 
     QString mDataDir;
     FieldsModel *mFieldsModel;

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -21,6 +21,11 @@ class ProjectWizard : public QObject
      * \param projectName  Project's name for newly created project.
      */
     Q_INVOKABLE void createProject( QString const &projectName );
+
+  public slots:
+    //! To append "mapcanvas" property to project file required to correctly show a project.
+    void writeMapCanvasSetting( QDomDocument &doc );
+
   signals:
     /**
       * Emitted after a project has been craeted.
@@ -36,6 +41,7 @@ class ProjectWizard : public QObject
 
     QString mDataDir;
     FieldsModel *mFieldsModel;
+    QgsMapSettings *mSettings;
 
     const QString BG_MAPS_CONFIG = QStringLiteral( "tilePixelRatio=1&type=xyz&url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0" );
     const QString PROJECT_CRS_ID = QStringLiteral( "EPSG:3857" );

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -14,14 +14,15 @@ class ProjectWizard : public QObject
 {
     Q_OBJECT
   public:
-    explicit ProjectWizard( const QString &dataDir, FieldsModel *fieldsModel, QObject *parent = nullptr );
+    explicit ProjectWizard( const QString &dataDir, QObject *parent = nullptr );
     ~ProjectWizard() = default;
 
     /**
      * Creates a new project in unique directory named accoridng project name.
-     * \param projectName  Project's name for newly created project.
+     * \param projectName Project's name for newly created project.
+     * \param fieldsModel Fields configuration model for a new project
      */
-    Q_INVOKABLE void createProject( QString const &projectName );
+    Q_INVOKABLE void createProject( QString const &projectName, FieldsModel *fieldsModel );
 
   public slots:
     //! To append "mapcanvas" property to project file required to correctly show a project.
@@ -34,14 +35,14 @@ class ProjectWizard : public QObject
     void projectCreated( const QString &projectDir, const QString &projectName );
     void notify( const QString &message );
   private:
-    QgsVectorLayer *createGpkgLayer( QString const &projectDir );
+    QgsVectorLayer *createGpkgLayer( QString const &projectDir, QList<FieldConfiguration> const &fieldsConfig );
     QgsEditorWidgetSetup getEditorWidget( QgsField const &field, const QString &widgetType );
     QgsFields createFields( const QList<FieldConfiguration> fieldsConfig ) const;
     QVariant::Type parseType( const QString &type ) const;
     QString widgetToType( const QString &widgetType ) const;
+    QString findWidgetTypeByFieldName( const QString name, const QList<FieldConfiguration> fieldsConfig ) const;
 
     QString mDataDir;
-    FieldsModel *mFieldsModel;
     std::unique_ptr<QgsMapSettings> mSettings = nullptr;
 
     const QString BG_MAPS_CONFIG = QStringLiteral( "tilePixelRatio=1&type=xyz&url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0" );

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -5,6 +5,7 @@
 #include "fieldsmodel.h"
 #include "qgsfieldmodel.h"
 #include "qgsvectorlayer.h"
+#include "qgsmapsettings.h"
 
 /**
  * Controller for creating new Input project.
@@ -41,7 +42,7 @@ class ProjectWizard : public QObject
 
     QString mDataDir;
     FieldsModel *mFieldsModel;
-    QgsMapSettings *mSettings;
+    std::unique_ptr<QgsMapSettings> mSettings = nullptr;
 
     const QString BG_MAPS_CONFIG = QStringLiteral( "tilePixelRatio=1&type=xyz&url=https://tile.openstreetmap.org/%7Bz%7D/%7Bx%7D/%7By%7D.png&zmax=19&zmin=0" );
     const QString PROJECT_CRS_ID = QStringLiteral( "EPSG:3857" );

--- a/app/qml/FeatureToolbar.qml
+++ b/app/qml/FeatureToolbar.qml
@@ -100,7 +100,7 @@ Item {
 
                 width: toolbar.itemSize
                 text: qsTr("Save")
-                imageSource: "yes.svg"
+                imageSource: InputStyle.checkIcon
                 enabled: toolbar.saveBtnEnabled
 
                 onActivated: toolbar.saveClicked()

--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -64,6 +64,7 @@ QtObject {
     property var removeIcon: "qrc:/trash.svg"
     property var galleryIcon: "qrc:/gallery.svg"
     property var backIcon: "qrc:/back.svg"
+    property var checkIcon: "qrc:/check.svg"
     property var plusIcon: "qrc:/plus.svg"
     property var noIcon: "qrc:/no.svg"
     property var editIcon: "qrc:/edit.svg"

--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -65,6 +65,7 @@ QtObject {
     property var galleryIcon: "qrc:/gallery.svg"
     property var backIcon: "qrc:/back.svg"
     property var plusIcon: "qrc:/plus.svg"
+    property var noIcon: "qrc:/no.svg"
     property var editIcon: "qrc:/edit.svg"
     property var infoIcon: "qrc:/info.svg"
     property var tableIcon: "qrc:/table.svg"

--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -40,6 +40,7 @@ QtObject {
     property int panelMargin: scale(30)
     property real rowHeight: scale(64)
     property real rowHeightHeader: scale(64)
+    property real delegateBtnHeight: rowHeight * 0.8
     property real scaleBarHeight: fontPixelSizeSmall * 3 //according scaleBar text
 
     property real panelSpacing: QgsQuick.Utils.dp * 5

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -378,7 +378,6 @@ Item {
             height: projectsPanel.rowHeight
             width: parent.width
             text: qsTr("Create project")
-            anchors.centerIn: parent
             onClicked: {
               if (__inputUtils.hasStoragePermission()) {
                 __fieldsModel.initModel()

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -383,10 +383,10 @@ Item {
               if (__inputUtils.hasStoragePermission()) {
                 __fieldsModel.initModel()
                 stackView.push(projectWizardComp)
-            } else {
-                __inputUtils.acquireStoragePermission()
+              } else if (__inputUtils.acquireStoragePermission()) {
+                restartAppDialog.open()
+              }
             }
-          }
          }
 
           Text {

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -630,9 +630,13 @@ Item {
           height: parent.height
           width: parent.width/2
           btnWidth: InputStyle.rowHeightHeader * 3
+          btnHeight: parent.height
           text: qsTr("Create project")
           anchors.centerIn: parent
-          onClicked: stackView.push(projectWizardComp)
+          onClicked: {
+            __fieldsModel.initModel()
+            stackView.push(projectWizardComp)
+          }
         }
       }
 
@@ -913,7 +917,7 @@ Item {
       objectName: "projectWizard"
       height: projectsPanel.height
       width: projectsPanel.width
-      onBackClicked: {
+      onBack: {
         stackView.popOnePageOrClose()
       }
     }

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -276,6 +276,18 @@ Item {
         }
       }
 
+      // Temp button
+      Button {
+        id: projectWizardBtn
+        width: 100
+        height: 100
+        text: "Magic"
+        onClicked: {
+          //projectWizzardPanel
+          stackView.push(projectWizardComp)
+        }
+      }
+
       // Content
       ColumnLayout {
         id: contentLayout
@@ -870,6 +882,19 @@ Item {
         stackView.popOnePageOrClose()
       }
       onSubscribeClicked: {
+        stackView.popOnePageOrClose()
+      }
+    }
+  }
+
+  Component {
+    id: projectWizardComp
+
+    ProjectWizardPage {
+      id: projectWizardPanel
+      height: projectsPanel.height
+      width: projectsPanel.width
+      onBackClicked: {
         stackView.popOnePageOrClose()
       }
     }

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -15,6 +15,7 @@ import QtQuick.Dialogs 1.2
 import QgsQuick 0.1 as QgsQuick
 import lc 1.0
 import "."  // import InputStyle singleton
+import "./components/"
 
 Item {
 
@@ -273,18 +274,6 @@ Item {
           } else if (toolbar.highlighted === myProjectsBtn.text) {
             __merginProjectsModel.searchExpression = text
           }
-        }
-      }
-
-      // Temp button
-      Button {
-        id: projectWizardBtn
-        width: 100
-        height: 100
-        text: "Magic"
-        onClicked: {
-          //projectWizzardPanel
-          stackView.push(projectWizardComp)
         }
       }
 
@@ -617,6 +606,30 @@ Item {
 
         }
       }
+
+      // Content bellow ListView section
+      Rectangle {
+        width: projectsPanel.width
+        height: InputStyle.rowHeightHeader
+        Layout.fillWidth: true
+        anchors.bottom: toolbar.top
+        z: 100
+        // DelegateButtonContainer
+        color: "red"
+
+        Component.onCompleted: console.log("!!!!!", projectsPanel.width, width)
+
+        DelegateButton {
+          height: InputStyle.rowHeightHeader
+          width: height * 4
+          text: qsTr("Create project")
+          anchors.centerIn: parent
+          //Layout.alignment: Qt.AlignVCenter
+          onClicked: stackView.push(projectWizardComp)
+        }
+      }
+
+
 
 
       // Toolbar

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -622,6 +622,7 @@ Item {
         height: InputStyle.rowHeightHeader
         Layout.fillWidth: true
         anchors.bottom: toolbar.top
+        anchors.bottomMargin: InputStyle.panelMargin
         z: 100
 
         DelegateButton {

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -623,11 +623,11 @@ Item {
         Layout.fillWidth: true
         anchors.bottom: toolbar.top
         z: 100
-        // DelegateButtonContainer
 
         DelegateButton {
           height: InputStyle.rowHeightHeader
-          width: parent/4
+          width: parent.width/2
+          btnWidth: InputStyle.rowHeightHeader * 4
           text: qsTr("Create project")
           anchors.centerIn: parent
           //Layout.alignment: Qt.AlignVCenter

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -380,7 +380,6 @@ Item {
             text: qsTr("Create project")
             onClicked: {
               if (__inputUtils.hasStoragePermission()) {
-                __fieldsModel.initModel()
                 stackView.push(projectWizardComp)
               } else if (__inputUtils.acquireStoragePermission()) {
                 restartAppDialog.open()

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -634,10 +634,14 @@ Item {
           text: qsTr("Create project")
           anchors.centerIn: parent
           onClicked: {
-            __fieldsModel.initModel()
-            stackView.push(projectWizardComp)
+            if (__inputUtils.hasStoragePermission()) {
+              __fieldsModel.initModel()
+              stackView.push(projectWizardComp)
+          } else {
+              __inputUtils.acquireStoragePermission()
           }
         }
+       }
       }
 
 

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -627,15 +627,12 @@ Item {
         DelegateButton {
           height: InputStyle.rowHeightHeader
           width: parent.width/2
-          btnWidth: InputStyle.rowHeightHeader * 4
+          btnWidth: InputStyle.rowHeightHeader * 3
           text: qsTr("Create project")
           anchors.centerIn: parent
-          //Layout.alignment: Qt.AlignVCenter
           onClicked: stackView.push(projectWizardComp)
         }
       }
-
-
 
 
       // Toolbar

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -141,6 +141,15 @@ Item {
       }
 
       Connections {
+        target: __projectWizard
+        onProjectCreated: {
+          if  (stackView.currentItem.objectName === "projectWizard") {
+            stackView.popOnePageOrClose()
+          }
+        }
+      }
+
+      Connections {
         target: __merginApi
         onListProjectsFinished: {
           stackView.pending = false
@@ -608,20 +617,17 @@ Item {
       }
 
       // Content bellow ListView section
-      Rectangle {
+      Item {
         width: projectsPanel.width
         height: InputStyle.rowHeightHeader
         Layout.fillWidth: true
         anchors.bottom: toolbar.top
         z: 100
         // DelegateButtonContainer
-        color: "red"
-
-        Component.onCompleted: console.log("!!!!!", projectsPanel.width, width)
 
         DelegateButton {
           height: InputStyle.rowHeightHeader
-          width: height * 4
+          width: parent/4
           text: qsTr("Create project")
           anchors.centerIn: parent
           //Layout.alignment: Qt.AlignVCenter
@@ -905,6 +911,7 @@ Item {
 
     ProjectWizardPage {
       id: projectWizardPanel
+      objectName: "projectWizard"
       height: projectsPanel.height
       width: projectsPanel.width
       onBackClicked: {

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -619,14 +619,15 @@ Item {
       // Content bellow ListView section
       Item {
         width: projectsPanel.width
-        height: InputStyle.rowHeightHeader
+        height: InputStyle.rowHeightHeader * 0.8
+        visible: !showMergin // only if local project page is selected
         Layout.fillWidth: true
         anchors.bottom: toolbar.top
         anchors.bottomMargin: InputStyle.panelMargin
         z: 100
 
         DelegateButton {
-          height: InputStyle.rowHeightHeader
+          height: parent.height
           width: parent.width/2
           btnWidth: InputStyle.rowHeightHeader * 3
           text: qsTr("Create project")

--- a/app/qml/MerginProjectPanel.qml
+++ b/app/qml/MerginProjectPanel.qml
@@ -374,6 +374,21 @@ Item {
 
           delegate: delegateItem
 
+          footer:  DelegateButton {
+            height: projectsPanel.rowHeight
+            width: parent.width
+            text: qsTr("Create project")
+            anchors.centerIn: parent
+            onClicked: {
+              if (__inputUtils.hasStoragePermission()) {
+                __fieldsModel.initModel()
+                stackView.push(projectWizardComp)
+            } else {
+                __inputUtils.acquireStoragePermission()
+            }
+          }
+         }
+
           Text {
             id: noProjectsText
             anchors.fill: parent
@@ -615,35 +630,6 @@ Item {
 
         }
       }
-
-      // Content bellow ListView section
-      Item {
-        width: projectsPanel.width
-        height: InputStyle.rowHeightHeader * 0.8
-        visible: !showMergin // only if local project page is selected
-        Layout.fillWidth: true
-        anchors.bottom: toolbar.top
-        anchors.bottomMargin: InputStyle.panelMargin
-        z: 100
-
-        DelegateButton {
-          height: parent.height
-          width: parent.width/2
-          btnWidth: InputStyle.rowHeightHeader * 3
-          btnHeight: parent.height
-          text: qsTr("Create project")
-          anchors.centerIn: parent
-          onClicked: {
-            if (__inputUtils.hasStoragePermission()) {
-              __fieldsModel.initModel()
-              stackView.push(projectWizardComp)
-          } else {
-              __inputUtils.acquireStoragePermission()
-          }
-        }
-       }
-      }
-
 
       // Toolbar
       Rectangle {

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -127,7 +127,8 @@ Item {
             width: parent.width
             btnWidth: projectWizardPanel.rowHeight * 3
             btnHeight:projectWizardPanel.rowHeight * 0.8
-            text: qsTr("+ Add field")
+            text: qsTr("Add field")
+            iconSource: InputStyle.plusIcon
             onClicked: {
               __fieldsModel.addField("", "TextEdit")
               if (fieldList.visible) {

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -95,7 +95,7 @@ Item {
         id: attributesLabel
         height: projectWizardPanel.rowheight
         width: parent.width
-        text: qsTr("Attributes")
+        text: qsTr("Fields")
         color: InputStyle.fontColor
         font.pixelSize: InputStyle.fontPixelSizeNormal
         Layout.preferredHeight: projectWizardPanel.rowHeight

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -6,9 +6,7 @@ import QtQuick.Dialogs 1.2
 import QgsQuick 0.1 as QgsQuick
 import lc 1.0
 import "."
-import "./components"
-
-// import InputStyle singleton
+import "./components" // import InputStyle singleton
 Item {
   id: projectWizardPanel
 
@@ -28,12 +26,6 @@ Item {
 
     projectWizardPanel.items
   }
-
-  Connections {
-    target: __projectWizard
-    onProjectCreated: __inputUtils.showNotification( qsTr(" Project %1 created ").arg( projectName ) )
-  }
-
 
   // background
   Rectangle {

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -103,11 +103,18 @@ Item {
       }
 
       ListView {
+        id: fieldList
         model: __fieldsModel
         width: parent.width
         Layout.fillWidth: true
         Layout.fillHeight: true
         clip: true
+
+        onCountChanged: {
+          if (fieldList.visible) {
+            fieldList.positionViewAtEnd()
+          }
+        }
 
         delegate: FieldRow {
           height: projectWizardPanel.rowHeight
@@ -122,8 +129,7 @@ Item {
       Row {
         id: listButtonContainer
         width: parent.width
-        height: projectWizardPanel.rowHeight
-        Layout.preferredHeight: projectWizardPanel.rowHeight
+        Layout.preferredHeight: projectWizardPanel.rowHeight * 0.8
         Layout.fillWidth: true
         Button {
           id: delegateButton
@@ -138,7 +144,7 @@ Item {
             radius: InputStyle.cornerRadius
           }
 
-          onClicked: __fieldsModel.addField("", "text", "TextEdit")
+          onClicked: __fieldsModel.addField("", "TextEdit")
 
           contentItem: Text {
             text: delegateButton.text

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -21,7 +21,7 @@ Item {
   property var supportedTypes: {
     var types = __fieldsModel.supportedTypes()
     for (var prop in types) {
-      projectWizardPanel.items.append({ "display": types[prop], "value": prop })
+      projectWizardPanel.items.append({ "display": types[prop], "widget": prop })
     }
 
     projectWizardPanel.items
@@ -78,7 +78,6 @@ Item {
         placeholderText: qsTr("Project name")
         font.capitalization: Font.MixedCase
         inputMethodHints: Qt.ImhNoPredictiveText
-        text: "TODO" // TODO
         Layout.fillWidth: true
         Layout.preferredHeight: projectWizardPanel.rowHeight
 
@@ -139,7 +138,7 @@ Item {
             radius: InputStyle.cornerRadius
           }
 
-          onClicked: __fieldsModel.addField("", "text")
+          onClicked: __fieldsModel.addField("", "text", "TextEdit")
 
           contentItem: Text {
             text: delegateButton.text
@@ -181,12 +180,15 @@ Item {
           id: createProjectBtn
           width: toolbar.itemSize
           text: qsTr("Create project")
-          enabled: projectNameField.text
-          faded: !enabled
-          imageSource: InputStyle.plusIcon
+          faded: !projectNameField.text
+          imageSource: InputStyle.checkIcon
 
           onActivated: {
-            __projectWizard.createProject(projectNameField.text)
+            if (faded) {
+              __inputUtils.showNotification(qsTr("Empty project name"))
+            } else {
+              __projectWizard.createProject(projectNameField.text)
+            }
           }
         }
       }

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -124,8 +124,6 @@ Item {
         footer: DelegateButton {
             height: projectWizardPanel.rowHeight
             width: parent.width
-            btnWidth: projectWizardPanel.rowHeight * 3
-            btnHeight:projectWizardPanel.rowHeight * 0.8
             text: qsTr("Add field")
             iconSource: InputStyle.plusIcon
             onClicked: {

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -56,19 +56,19 @@ Item {
     }
 
     TextField {
-      id: registerName
+      id: projectNameField
       width: parent.width
       height: projectWizardPanel.rowHeight
       font.pixelSize: InputStyle.fontPixelSizeNormal
       color: projectWizardPanel.fontColor
-      placeholderText: qsTr("")
+      placeholderText: qsTr("Project name")
       font.capitalization: Font.MixedCase
       inputMethodHints: Qt.ImhNoPredictiveText
+      text: "TODO" // TODO
     }
 
     Repeater {
       model: __fieldsModel
-
 
       FieldRow {
         height: projectWizardPanel.rowHeight
@@ -76,6 +76,7 @@ Item {
         color: projectWizardPanel.fontColor
         widgetList: __fieldsModel.supportedTypes()
       }
+
     }
 
     Row {
@@ -140,7 +141,7 @@ Item {
           imageSource: InputStyle.plusIcon
 
           onActivated: {
-            // TODO
+            __projectWizard.createProject(projectNameField.text)
           }
         }
       }

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -77,7 +77,6 @@ Item {
         height: projectWizardPanel.rowHeight
         font.pixelSize: InputStyle.fontPixelSizeNormal
         color: projectWizardPanel.fontColor
-        placeholderText: qsTr("Project name")
         font.capitalization: Font.MixedCase
         inputMethodHints: Qt.ImhNoPredictiveText
         Layout.fillWidth: true

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -17,14 +17,16 @@ Item {
   property var bgColor: InputStyle.clrPanelMain
   property real panelMargin: 10 * QgsQuick.Utils.dp
 
-  property ListModel items: ListModel {}
-  property var supportedTypes: {
+  property ListModel widgetsModel: ListModel {}
+
+  //! Inits widgetsModel data just after its created, but before Component.complete is emitted (for both model or components where its used)
+  property bool isWidgetModelReady: {
     var types = __fieldsModel.supportedTypes()
     for (var prop in types) {
-      projectWizardPanel.items.append({ "display": types[prop], "widget": prop })
+      projectWizardPanel.widgetsModel.append({ "display": types[prop], "widget": prop })
     }
 
-    projectWizardPanel.items
+    true
   }
 
   // background
@@ -109,52 +111,30 @@ Item {
         Layout.fillWidth: true
         Layout.fillHeight: true
         clip: true
-
-        onCountChanged: {
-          if (fieldList.visible) {
-            fieldList.positionViewAtEnd()
-          }
-        }
+        spacing: projectWizardPanel.rowHeight * 0.1 // same as delegateButton "margin"
 
         delegate: FieldRow {
           height: projectWizardPanel.rowHeight
           width: contentLayout.width
           color: projectWizardPanel.fontColor
-          widgetList: projectWizardPanel.supportedTypes
+          widgetList: projectWizardPanel.widgetsModel
 
           onRemoveClicked: __fieldsModel.removeField(index)
         }
-      }
 
-      Row {
-        id: listButtonContainer
-        width: parent.width
-        Layout.preferredHeight: projectWizardPanel.rowHeight * 0.8
-        Layout.fillWidth: true
-        Button {
-          id: delegateButton
-          text: qsTr("Add attribute")
-          height: parent.height
-          width: height * 3
-          anchors.verticalCenter: parent.verticalCenter
-          font.pixelSize: InputStyle.fontPixelSizeTitle
-
-          background: Rectangle {
-            color: InputStyle.highlightColor
-            radius: InputStyle.cornerRadius
+        footer: DelegateButton {
+            height: projectWizardPanel.rowHeight
+            width: parent.width
+            btnWidth: projectWizardPanel.rowHeight * 3
+            btnHeight:projectWizardPanel.rowHeight * 0.8
+            text: qsTr("+ Add field")
+            onClicked: {
+              __fieldsModel.addField("", "TextEdit")
+              if (fieldList.visible) {
+                fieldList.positionViewAtEnd()
+              }
+            }
           }
-
-          onClicked: __fieldsModel.addField("", "TextEdit")
-
-          contentItem: Text {
-            text: delegateButton.text
-            font: delegateButton.font
-            color: "white"
-            horizontalAlignment: Text.AlignHCenter
-            verticalAlignment: Text.AlignVCenter
-            elide: Text.ElideRight
-          }
-        }
       }
     }
   }

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -1,0 +1,134 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+import QtGraphicalEffects 1.0
+import QtQuick.Dialogs 1.2
+import QgsQuick 0.1 as QgsQuick
+import lc 1.0
+import "."  // import InputStyle singleton
+
+Item {
+  id: projectWizardPanel
+
+  signal backClicked
+
+  property real rowHeight: InputStyle.rowHeight
+  property var fontColor: InputStyle.fontColor
+  property var bgColor: InputStyle.clrPanelMain
+
+
+  // background
+  Rectangle {
+    width: parent.width
+    height: parent.height
+    color: projectWizardPanel.bgColor
+  }
+
+  PanelHeader {
+    id: header
+    height: InputStyle.rowHeightHeader
+    width: projectWizardPanel.width
+    color: InputStyle.clrPanelMain
+    rowHeight: InputStyle.rowHeightHeader
+    titleText: qsTr("Create Project")
+
+    onBack: {
+        projectWizardPanel.backClicked()
+    }
+  }
+
+  Column {
+    id: contentLayout
+    height: projectWizardPanel.height-header.height
+    width: projectWizardPanel.width
+    y: header.height
+    spacing: 0
+
+    Label {
+      height: projectWizardPanel.rowheight
+      width: parent.width
+//      horizontalAlignment: Qt.AlignHCenter
+//      verticalAlignment: Qt.AlignLeft
+      text: qsTr("Project name")
+      color: InputStyle.fontColor
+      font.pixelSize: InputStyle.fontPixelSizeNormal
+    }
+
+    TextField {
+      id: registerName
+      width: parent.width
+      height: projectWizardPanel.rowHeight
+      font.pixelSize: InputStyle.fontPixelSizeNormal
+      color: projectWizardPanel.fontColor
+      placeholderText: qsTr("")
+      font.capitalization: Font.MixedCase
+      inputMethodHints: Qt.ImhNoPredictiveText
+    }
+
+    Repeater {
+      model: __fieldsModel
+
+        Row {
+          id: fieldItem
+          //text: Name
+          //color: "red"
+          height: projectWizardPanel.rowHeight
+          width: projectWizardPanel.width
+
+          TextField {
+            id: textField
+            height: projectWizardPanel.rowHeight
+            topPadding: 10 * QgsQuick.Utils.dp
+            bottomPadding: 10 * QgsQuick.Utils.dp
+            anchors.left: parent.left
+            anchors.right: parent.right
+            font.pixelSize: InputStyle.fontPixelSizeNormal
+            color: projectWizardPanel.fontColor
+            placeholderText: "Field name"
+
+            background: Rectangle {
+                anchors.fill: parent
+                border.color: textField.activeFocus ? InputStyle.fontColor: InputStyle.panelBackgroundLight
+                border.width: textField.activeFocus ? 2 : 1
+                color: InputStyle.clrPanelMain
+                radius: InputStyle.cornerRadius
+            }
+        }
+      }
+    }
+
+   Row {
+     width: parent.width
+     height: projectWizardPanel.rowHeight
+     Button {
+         id: delegateButton
+         text: qsTr("Add field")
+         height: parent.height
+         width: height * 2
+         //anchors.horizontalCenter: parent.horizontalCenter
+         anchors.verticalCenter: parent.verticalCenter
+         font.pixelSize: InputStyle.fontPixelSizeTitle
+
+         background: Rectangle {
+           color: InputStyle.highlightColor
+           radius: InputStyle.cornerRadius
+         }
+
+         onClicked: __fieldsModel.addField("new", "")
+
+         contentItem: Text {
+           text: delegateButton.text
+           font: delegateButton.font
+           color: "white"
+           horizontalAlignment: Text.AlignHCenter
+           verticalAlignment: Text.AlignVCenter
+           elide: Text.ElideRight
+         }
+       }
+   }
+
+   }
+
+
+
+}

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -10,7 +10,7 @@ import "./components" // import InputStyle singleton
 Item {
   id: projectWizardPanel
 
-  signal backClicked
+  signal back
 
   property real rowHeight: InputStyle.rowHeight
   property var fontColor: InputStyle.fontColor
@@ -43,7 +43,7 @@ Item {
     titleText: qsTr("Create Project")
 
     onBack: {
-      projectWizardPanel.backClicked()
+      projectWizardPanel.back()
     }
   }
 
@@ -133,9 +133,9 @@ Item {
         Layout.fillWidth: true
         Button {
           id: delegateButton
-          text: qsTr("Add field")
+          text: qsTr("Add attribute")
           height: parent.height
-          width: height * 2
+          width: height * 3
           anchors.verticalCenter: parent.verticalCenter
           font.pixelSize: InputStyle.fontPixelSizeTitle
 

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -5,8 +5,10 @@ import QtGraphicalEffects 1.0
 import QtQuick.Dialogs 1.2
 import QgsQuick 0.1 as QgsQuick
 import lc 1.0
-import "."  // import InputStyle singleton
+import "."
+import "./components"
 
+// import InputStyle singleton
 Item {
   id: projectWizardPanel
 
@@ -15,7 +17,6 @@ Item {
   property real rowHeight: InputStyle.rowHeight
   property var fontColor: InputStyle.fontColor
   property var bgColor: InputStyle.clrPanelMain
-
 
   // background
   Rectangle {
@@ -33,22 +34,22 @@ Item {
     titleText: qsTr("Create Project")
 
     onBack: {
-        projectWizardPanel.backClicked()
+      projectWizardPanel.backClicked()
     }
   }
 
   Column {
     id: contentLayout
-    height: projectWizardPanel.height-header.height
+    height: projectWizardPanel.height - header.height
     width: projectWizardPanel.width
     y: header.height
-    spacing: 0
+    spacing: InputStyle.panelSpacing
 
     Label {
       height: projectWizardPanel.rowheight
       width: parent.width
-//      horizontalAlignment: Qt.AlignHCenter
-//      verticalAlignment: Qt.AlignLeft
+      //      horizontalAlignment: Qt.AlignHCenter
+      //      verticalAlignment: Qt.AlignLeft
       text: qsTr("Project name")
       color: InputStyle.fontColor
       font.pixelSize: InputStyle.fontPixelSizeNormal
@@ -68,67 +69,83 @@ Item {
     Repeater {
       model: __fieldsModel
 
-        Row {
-          id: fieldItem
-          //text: Name
-          //color: "red"
-          height: projectWizardPanel.rowHeight
-          width: projectWizardPanel.width
 
-          TextField {
-            id: textField
-            height: projectWizardPanel.rowHeight
-            topPadding: 10 * QgsQuick.Utils.dp
-            bottomPadding: 10 * QgsQuick.Utils.dp
-            anchors.left: parent.left
-            anchors.right: parent.right
-            font.pixelSize: InputStyle.fontPixelSizeNormal
-            color: projectWizardPanel.fontColor
-            placeholderText: "Field name"
-
-            background: Rectangle {
-                anchors.fill: parent
-                border.color: textField.activeFocus ? InputStyle.fontColor: InputStyle.panelBackgroundLight
-                border.width: textField.activeFocus ? 2 : 1
-                color: InputStyle.clrPanelMain
-                radius: InputStyle.cornerRadius
-            }
-        }
+      FieldRow {
+        height: projectWizardPanel.rowHeight
+        width: projectWizardPanel.width
+        color: projectWizardPanel.fontColor
+        widgetList: __fieldsModel.supportedTypes()
       }
     }
 
-   Row {
-     width: parent.width
-     height: projectWizardPanel.rowHeight
-     Button {
-         id: delegateButton
-         text: qsTr("Add field")
-         height: parent.height
-         width: height * 2
-         //anchors.horizontalCenter: parent.horizontalCenter
-         anchors.verticalCenter: parent.verticalCenter
-         font.pixelSize: InputStyle.fontPixelSizeTitle
+    Row {
+      width: parent.width
+      height: projectWizardPanel.rowHeight
+      Button {
+        id: delegateButton
+        text: qsTr("Add field")
+        height: parent.height
+        width: height * 2
+        //anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        font.pixelSize: InputStyle.fontPixelSizeTitle
 
-         background: Rectangle {
-           color: InputStyle.highlightColor
-           radius: InputStyle.cornerRadius
-         }
+        background: Rectangle {
+          color: InputStyle.highlightColor
+          radius: InputStyle.cornerRadius
+        }
 
-         onClicked: __fieldsModel.addField("new", "")
+        onClicked: __fieldsModel.addField("", "text")
 
-         contentItem: Text {
-           text: delegateButton.text
-           font: delegateButton.font
-           color: "white"
-           horizontalAlignment: Text.AlignHCenter
-           verticalAlignment: Text.AlignVCenter
-           elide: Text.ElideRight
-         }
-       }
-   }
+        contentItem: Text {
+          text: delegateButton.text
+          font: delegateButton.font
+          color: "white"
+          horizontalAlignment: Text.AlignHCenter
+          verticalAlignment: Text.AlignVCenter
+          elide: Text.ElideRight
+        }
+      }
+    }
+  }
 
-   }
+  // footer toolbar
+  Rectangle {
+    property int itemSize: toolbar.height * 0.8
 
+    id: toolbar
+    height: InputStyle.rowHeightHeader
+    width: parent.width
+    anchors.bottom: parent.bottom
+    color: InputStyle.clrPanelBackground
+
+    MouseArea {
+      anchors.fill: parent
+      onClicked: {} // dont do anything, just do not let click event propagate
+    }
+
+    Row {
+      height: toolbar.height
+      width: parent.width
+      anchors.bottom: parent.bottom
+
+      Item {
+        width: parent.width/parent.children.length
+        height: parent.height
+        MainPanelButton {
+          id: createProjectBtn
+          width: toolbar.itemSize
+          text: qsTr("Create project")
+          faded: false // TOOD
+          imageSource: InputStyle.plusIcon
+
+          onActivated: {
+            // TODO
+          }
+        }
+      }
+    }
+  }
 
 
 }

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -21,12 +21,18 @@ Item {
 
   //! Inits widgetsModel data just after its created, but before Component.complete is emitted (for both model or components where its used)
   property bool isWidgetModelReady: {
-    var types = __fieldsModel.supportedTypes()
+    var types = fieldsModel.supportedTypes()
     for (var prop in types) {
       projectWizardPanel.widgetsModel.append({ "display": types[prop], "widget": prop })
     }
 
     true
+  }
+
+  FieldsModel {
+    id: fieldsModel
+    onNotify: __inputUtils.showNotification(message)
+    Component.onCompleted: fieldsModel.initModel()
   }
 
   // background
@@ -105,7 +111,7 @@ Item {
 
       ListView {
         id: fieldList
-        model: __fieldsModel
+        model: fieldsModel
         width: parent.width
         Layout.fillWidth: true
         Layout.fillHeight: true
@@ -118,7 +124,7 @@ Item {
           color: projectWizardPanel.fontColor
           widgetList: projectWizardPanel.widgetsModel
 
-          onRemoveClicked: __fieldsModel.removeField(index)
+          onRemoveClicked: fieldsModel.removeField(index)
         }
 
         footer: DelegateButton {
@@ -127,7 +133,7 @@ Item {
             text: qsTr("Add field")
             iconSource: InputStyle.plusIcon
             onClicked: {
-              __fieldsModel.addField("", "TextEdit")
+              fieldsModel.addField("", "TextEdit")
               if (fieldList.visible) {
                 fieldList.positionViewAtEnd()
               }
@@ -171,7 +177,7 @@ Item {
             if (faded) {
               __inputUtils.showNotification(qsTr("Empty project name"))
             } else {
-              __projectWizard.createProject(projectNameField.text)
+              __projectWizard.createProject(projectNameField.text, fieldsModel )
             }
           }
         }

--- a/app/qml/components/DelegateButton.qml
+++ b/app/qml/components/DelegateButton.qml
@@ -1,16 +1,17 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.2
-import "./.."  // import InputStyle singleton
-
+import QtGraphicalEffects 1.0
+import "./.." // import InputStyle singleton
 Item {
-  signal clicked()
+  signal clicked
 
   property string text
   property real cornerRadius: InputStyle.cornerRadius
   property var bgColor: InputStyle.highlightColor
-  property var textColor: "white"
+  property var fontColor: "white"
   property real btnWidth: delegateButtonContainer.height * 2
   property real btnHeight: delegateButtonContainer.height * 0.8
+  property var iconSource
 
   id: delegateButtonContainer
 
@@ -30,13 +31,30 @@ Item {
 
     onClicked: delegateButtonContainer.clicked()
 
-    contentItem: Text {
-      text: delegateButton.text
-      font: delegateButton.font
-      color: delegateButtonContainer.textColor
-      horizontalAlignment: Text.AlignHCenter
-      verticalAlignment: Text.AlignVCenter
-      elide: Text.ElideRight
+    contentItem: Row {
+      anchors.fill: parent
+      spacing: 0
+
+      Symbol {
+        id: icon
+        visible: !!delegateButtonContainer.iconSource
+        height: visible ? delegateButtonContainer.btnHeight : 0
+        width: height
+        iconSize: height/2
+        source: delegateButtonContainer.iconSource
+        fontColor: delegateButtonContainer.fontColor
+      }
+
+      Text {
+        height: delegateButtonContainer.btnHeight
+        width: delegateButtonContainer.btnWidth - icon.width
+        text: delegateButton.text
+        font: delegateButton.font
+        color: delegateButtonContainer.fontColor
+        horizontalAlignment: icon.visible ? Text.AlignLeft : Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        elide: Text.ElideRight
+      }
     }
   }
 }

--- a/app/qml/components/DelegateButton.qml
+++ b/app/qml/components/DelegateButton.qml
@@ -9,8 +9,8 @@ Item {
   property real cornerRadius: InputStyle.cornerRadius
   property var bgColor: InputStyle.highlightColor
   property var fontColor: "white"
-  property real btnWidth: delegateButtonContainer.height * 2
-  property real btnHeight: delegateButtonContainer.height * 0.8
+  property real btnWidth: delegateButtonContainer.height * 3
+  property real btnHeight: InputStyle.delegateBtnHeight
   property var iconSource: ""
 
   id: delegateButtonContainer

--- a/app/qml/components/DelegateButton.qml
+++ b/app/qml/components/DelegateButton.qml
@@ -16,7 +16,7 @@ Item {
   Button {
     id: delegateButton
     text: delegateButtonContainer.text
-    height: delegateButtonContainer.height / 2
+    height: delegateButtonContainer.height
     width: delegateButtonContainer.btnWidth
     anchors.horizontalCenter: parent.horizontalCenter
     anchors.verticalCenter: parent.verticalCenter

--- a/app/qml/components/DelegateButton.qml
+++ b/app/qml/components/DelegateButton.qml
@@ -11,7 +11,7 @@ Item {
   property var fontColor: "white"
   property real btnWidth: delegateButtonContainer.height * 2
   property real btnHeight: delegateButtonContainer.height * 0.8
-  property var iconSource
+  property var iconSource: ""
 
   id: delegateButtonContainer
 

--- a/app/qml/components/DelegateButton.qml
+++ b/app/qml/components/DelegateButton.qml
@@ -10,13 +10,14 @@ Item {
   property var bgColor: InputStyle.highlightColor
   property var textColor: "white"
   property real btnWidth: delegateButtonContainer.height * 2
+  property real btnHeight: delegateButtonContainer.height * 0.8
 
   id: delegateButtonContainer
 
   Button {
     id: delegateButton
     text: delegateButtonContainer.text
-    height: delegateButtonContainer.height
+    height: delegateButtonContainer.btnHeight
     width: delegateButtonContainer.btnWidth
     anchors.horizontalCenter: parent.horizontalCenter
     anchors.verticalCenter: parent.verticalCenter

--- a/app/qml/components/DelegateButton.qml
+++ b/app/qml/components/DelegateButton.qml
@@ -9,6 +9,7 @@ Item {
   property real cornerRadius: InputStyle.cornerRadius
   property var bgColor: InputStyle.highlightColor
   property var textColor: "white"
+  property real btnWidth: delegateButtonContainer.height * 2
 
   id: delegateButtonContainer
 
@@ -16,7 +17,7 @@ Item {
     id: delegateButton
     text: delegateButtonContainer.text
     height: delegateButtonContainer.height / 2
-    width: delegateButtonContainer.height * 2
+    width: delegateButtonContainer.btnWidth
     anchors.horizontalCenter: parent.horizontalCenter
     anchors.verticalCenter: parent.verticalCenter
     font.pixelSize: InputStyle.fontPixelSizeTitle

--- a/app/qml/components/FieldRow.qml
+++ b/app/qml/components/FieldRow.qml
@@ -30,13 +30,12 @@ Item {
       bottomPadding: 10 * QgsQuick.Utils.dp
       font.pixelSize: InputStyle.fontPixelSizeNormal
       color: fieldDelegate.color
-      placeholderText: qsTr("Attribute name")
+      placeholderText: qsTr("Field name")
       text: AttributeName
       Layout.fillHeight: true
       Layout.preferredWidth: row.itemSize
 
       onEditingFinished: AttributeName = text
-
 
       background: Rectangle {
         anchors.fill: parent
@@ -75,11 +74,11 @@ Item {
       delegate: ItemDelegate {
         width: comboBox.width
         height: comboBox.height * 0.8
-        text: model.display
+        text: model.display.replace('&', "&&") // issue ampersand character showing up as underscore
         font.weight: comboBox.currentIndex === index ? Font.DemiBold : Font.Normal
         font.pixelSize: InputStyle.fontPixelSizeNormal
         highlighted: comboBox.highlightedIndex === index
-        leftPadding: 5 * QgsQuick.Utils.dp
+        leftPadding: textField.leftPadding
         onClicked: {
           WidgetType = model.widget
           comboBox.currentIndex = index
@@ -93,7 +92,7 @@ Item {
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
         elide: Text.ElideRight
-        leftPadding: 5 * QgsQuick.Utils.dp
+        leftPadding: textField.leftPadding
         color: InputStyle.fontColor
       }
 

--- a/app/qml/components/FieldRow.qml
+++ b/app/qml/components/FieldRow.qml
@@ -9,7 +9,7 @@ import "./.." // import InputStyle singleton
 
 Item {
   id: fieldDelegate
-  signal removeClicked
+  signal removeClicked(var index)
 
   property real rowHeight: InputStyle.rowHeightHeader
   property real iconSize: rowHeight
@@ -21,6 +21,7 @@ Item {
     height: fieldDelegate.rowHeight
     width: fieldDelegate.width
     spacing: InputStyle.panelSpacing
+    property real itemSize: (parent.width - fieldDelegate.rowHeight)/2
 
     TextField {
       id: textField
@@ -30,8 +31,8 @@ Item {
       font.pixelSize: InputStyle.fontPixelSizeNormal
       color: fieldDelegate.color
       placeholderText: AttributeName ? AttributeName : qsTr("Attribute name")
-      Layout.fillWidth: true
       Layout.fillHeight: true
+      Layout.preferredWidth: row.itemSize
 
       onAccepted: AttributeName = text
 
@@ -47,28 +48,86 @@ Item {
     ComboBox {
       id: comboBox
       height: row.height
-      Layout.fillWidth: true
       Layout.fillHeight: true
-      model: fieldDelegate.widgetList
+      Layout.preferredWidth: row.itemSize
+      model: widgetList //fieldDelegate.widgetList
+//      textRole: "display"
+//      valueRole: "value"
+
+
+      MouseArea {
+        anchors.fill: parent
+        propagateComposedEvents: true
+
+        onClicked: mouse.accepted = false
+        onPressed: { forceActiveFocus(); mouse.accepted = false; }
+        onReleased: mouse.accepted = false;
+        onDoubleClicked: mouse.accepted = false;
+        onPositionChanged: mouse.accepted = false;
+        onPressAndHold: mouse.accepted = false;
+      }
+
+      delegate: ItemDelegate {
+        width: comboBox.width
+        height: comboBox.height * 0.8
+        text: model.display
+        font.weight: comboBox.currentIndex === index ? Font.DemiBold : Font.Normal
+        font.pixelSize: InputStyle.fontPixelSizeNormal
+        highlighted: comboBox.highlightedIndex === index
+        leftPadding: 5 * QgsQuick.Utils.dp
+        onClicked: {
+          FieldType = model.value
+          WidgetType = model.display
+          //comboBox.itemClicked( model.FeatureId ? model.FeatureId : index )
+          comboBox.currentIndex = index
+        }
+      }
+
+      contentItem: Text {
+        height: comboBox.height * 0.8
+        text: WidgetType
+        font.pixelSize: InputStyle.fontPixelSizeNormal
+        horizontalAlignment: Text.AlignLeft
+        verticalAlignment: Text.AlignVCenter
+        elide: Text.ElideRight
+        leftPadding: 5 * QgsQuick.Utils.dp
+        color: InputStyle.fontColor
+      }
+
+      background: Item {
+        implicitHeight: comboBox.height * 0.8
+
+        Rectangle {
+          anchors.fill: parent
+          id: backgroundRect
+          border.color: comboBox.pressed ? InputStyle.fontColor : InputStyle.panelBackgroundLight
+          border.width: comboBox.visualFocus ? 2 : 1
+          color: "white"
+          radius: InputStyle.cornerRadius
+        }
+      }
+
+
     }
 
     Item {
       id: imageBtn
       height: fieldDelegate.iconSize
       width: height
-      Layout.fillWidth: true
       Layout.fillHeight: true
 
       MouseArea {
         anchors.fill: parent
-        onClicked: fieldDelegate.removeClicked()
+        onClicked: {
+          fieldDelegate.removeClicked(index)
+        }
       }
 
       Image {
         id: image
         anchors.centerIn: imageBtn
         source: InputStyle.noIcon
-        height: imageBtn.height
+        height: imageBtn.height/2
         width: height
         sourceSize.width: width
         sourceSize.height: height

--- a/app/qml/components/FieldRow.qml
+++ b/app/qml/components/FieldRow.qml
@@ -31,7 +31,7 @@ Item {
       font.pixelSize: InputStyle.fontPixelSizeNormal
       color: fieldDelegate.color
       placeholderText: qsTr("Attribute name")
-      text: AttributeName ? AttributeName : ""
+      text: AttributeName
       Layout.fillHeight: true
       Layout.preferredWidth: row.itemSize
 

--- a/app/qml/components/FieldRow.qml
+++ b/app/qml/components/FieldRow.qml
@@ -5,11 +5,10 @@ import QtGraphicalEffects 1.0
 import QtQuick.Dialogs 1.2
 import QgsQuick 0.1 as QgsQuick
 import lc 1.0
-import "./.."
+import "./.." // import InputStyle singleton
 
-// import InputStyle singleton
 Item {
-  id: root
+  id: fieldDelegate
   signal removeClicked
 
   property real rowHeight: InputStyle.rowHeightHeader
@@ -19,8 +18,8 @@ Item {
 
   RowLayout {
     id: row
-    height: root.rowHeight
-    width: root.width
+    height: fieldDelegate.rowHeight
+    width: fieldDelegate.width
     spacing: InputStyle.panelSpacing
 
     TextField {
@@ -29,10 +28,12 @@ Item {
       topPadding: 10 * QgsQuick.Utils.dp
       bottomPadding: 10 * QgsQuick.Utils.dp
       font.pixelSize: InputStyle.fontPixelSizeNormal
-      color: root.color
-      placeholderText: FieldName ? FieldName : qsTr("Field name")
+      color: fieldDelegate.color
+      placeholderText: AttributeName ? AttributeName : qsTr("Attribute name")
       Layout.fillWidth: true
       Layout.fillHeight: true
+
+      onAccepted: AttributeName = text
 
       background: Rectangle {
         anchors.fill: parent
@@ -48,19 +49,19 @@ Item {
       height: row.height
       Layout.fillWidth: true
       Layout.fillHeight: true
-      model: root.widgetList
+      model: fieldDelegate.widgetList
     }
 
     Item {
       id: imageBtn
-      height: root.iconSize
+      height: fieldDelegate.iconSize
       width: height
       Layout.fillWidth: true
       Layout.fillHeight: true
 
       MouseArea {
         anchors.fill: parent
-        onClicked: root.removeClicked()
+        onClicked: fieldDelegate.removeClicked()
       }
 
       Image {
@@ -77,7 +78,7 @@ Item {
       ColorOverlay {
         anchors.fill: image
         source: image
-        color: root.color
+        color: fieldDelegate.color
       }
     }
   }

--- a/app/qml/components/FieldRow.qml
+++ b/app/qml/components/FieldRow.qml
@@ -1,0 +1,84 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+import QtGraphicalEffects 1.0
+import QtQuick.Dialogs 1.2
+import QgsQuick 0.1 as QgsQuick
+import lc 1.0
+import "./.."
+
+// import InputStyle singleton
+Item {
+  id: root
+  signal removeClicked
+
+  property real rowHeight: InputStyle.rowHeightHeader
+  property real iconSize: rowHeight
+  property color color: InputStyle.fontColor
+  property var widgetList: []
+
+  RowLayout {
+    id: row
+    height: root.rowHeight
+    width: root.width
+    spacing: InputStyle.panelSpacing
+
+    TextField {
+      id: textField
+      height: row.height
+      topPadding: 10 * QgsQuick.Utils.dp
+      bottomPadding: 10 * QgsQuick.Utils.dp
+      font.pixelSize: InputStyle.fontPixelSizeNormal
+      color: root.color
+      placeholderText: FieldName ? FieldName : qsTr("Field name")
+      Layout.fillWidth: true
+      Layout.fillHeight: true
+
+      background: Rectangle {
+        anchors.fill: parent
+        border.color: textField.activeFocus ? InputStyle.fontColor : InputStyle.panelBackgroundLight
+        border.width: textField.activeFocus ? 2 : 1
+        color: InputStyle.clrPanelMain
+        radius: InputStyle.cornerRadius
+      }
+    }
+
+    ComboBox {
+      id: comboBox
+      height: row.height
+      Layout.fillWidth: true
+      Layout.fillHeight: true
+      model: root.widgetList
+    }
+
+    Item {
+      id: imageBtn
+      height: root.iconSize
+      width: height
+      Layout.fillWidth: true
+      Layout.fillHeight: true
+
+      MouseArea {
+        anchors.fill: parent
+        onClicked: root.removeClicked()
+      }
+
+      Image {
+        id: image
+        anchors.centerIn: imageBtn
+        source: InputStyle.noIcon
+        height: imageBtn.height
+        width: height
+        sourceSize.width: width
+        sourceSize.height: height
+        fillMode: Image.PreserveAspectFit
+      }
+
+      ColorOverlay {
+        anchors.fill: image
+        source: image
+        color: root.color
+      }
+    }
+  }
+}

--- a/app/qml/components/FieldRow.qml
+++ b/app/qml/components/FieldRow.qml
@@ -30,11 +30,13 @@ Item {
       bottomPadding: 10 * QgsQuick.Utils.dp
       font.pixelSize: InputStyle.fontPixelSizeNormal
       color: fieldDelegate.color
-      placeholderText: AttributeName ? AttributeName : qsTr("Attribute name")
+      placeholderText: qsTr("Attribute name")
+      text: AttributeName ? AttributeName : ""
       Layout.fillHeight: true
       Layout.preferredWidth: row.itemSize
 
-      onAccepted: AttributeName = text
+      onEditingFinished: AttributeName = text
+
 
       background: Rectangle {
         anchors.fill: parent
@@ -51,6 +53,12 @@ Item {
       Layout.fillHeight: true
       Layout.preferredWidth: row.itemSize
       model: widgetList
+      textRole: "display"
+      valueRole: "widget"
+
+      Component.onCompleted: {
+        comboBox.currentIndex = comboBox.indexOfValue(WidgetType);
+      }
 
       MouseArea {
         anchors.fill: parent
@@ -73,15 +81,14 @@ Item {
         highlighted: comboBox.highlightedIndex === index
         leftPadding: 5 * QgsQuick.Utils.dp
         onClicked: {
-          FieldType = model.value
-          WidgetType = model.display
+          WidgetType = model.widget
           comboBox.currentIndex = index
         }
       }
 
       contentItem: Text {
         height: comboBox.height * 0.8
-        text: WidgetType
+        text: comboBox.displayText
         font.pixelSize: InputStyle.fontPixelSizeNormal
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter

--- a/app/qml/components/FieldRow.qml
+++ b/app/qml/components/FieldRow.qml
@@ -50,10 +50,7 @@ Item {
       height: row.height
       Layout.fillHeight: true
       Layout.preferredWidth: row.itemSize
-      model: widgetList //fieldDelegate.widgetList
-//      textRole: "display"
-//      valueRole: "value"
-
+      model: widgetList
 
       MouseArea {
         anchors.fill: parent
@@ -78,7 +75,6 @@ Item {
         onClicked: {
           FieldType = model.value
           WidgetType = model.display
-          //comboBox.itemClicked( model.FeatureId ? model.FeatureId : index )
           comboBox.currentIndex = index
         }
       }

--- a/app/qml/components/Symbol.qml
+++ b/app/qml/components/Symbol.qml
@@ -1,0 +1,33 @@
+import QtQuick 2.7
+import QtGraphicalEffects 1.0
+import "./.." // import InputStyle singleton
+
+Rectangle {
+
+  property real iconSize: InputStyle.rowHeight
+  property string source: ""
+  property color bgColor: "transparent"
+  property color fontColor: InputStyle.fontColor
+
+  id: iconContainer
+  height: iconContainer.iconSize
+  width: iconContainer.iconSize
+  color: iconContainer.bgColor
+
+  Image {
+    id: icon
+    anchors.centerIn: parent
+    source: iconContainer.source
+    width: iconContainer.iconSize
+    height: iconContainer.iconSize
+    sourceSize.width: width
+    sourceSize.height: height
+    fillMode: Image.PreserveAspectFit
+  }
+
+  ColorOverlay {
+    anchors.fill: icon
+    source: icon
+    color: iconContainer.fontColor
+  }
+}

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -51,6 +51,7 @@
         <file>ValueRelationWidget.qml</file>
         <file>TextHyperlink.qml</file>
         <file>LogPanel.qml</file>
+        <file>ProjectWizardPage.qml</file>
         <file>components/PasswordField.qml</file>
         <file>components/DelegateButton.qml</file>
         <file>components/InputSwitch.qml</file>

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -56,5 +56,6 @@
         <file>components/DelegateButton.qml</file>
         <file>components/FieldRow.qml</file>
         <file>components/InputSwitch.qml</file>
+        <file>components/Symbol.qml</file>
     </qresource>
 </RCC>

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -54,6 +54,7 @@
         <file>ProjectWizardPage.qml</file>
         <file>components/PasswordField.qml</file>
         <file>components/DelegateButton.qml</file>
+        <file>components/FieldRow.qml</file>
         <file>components/InputSwitch.qml</file>
     </qresource>
 </RCC>

--- a/app/sources.pri
+++ b/app/sources.pri
@@ -1,4 +1,5 @@
 SOURCES += \
+  $$PWD/fieldsmodel.cpp \
 inputhelp.cpp \
 activelayer.cpp \
 layersmodel.cpp \
@@ -38,6 +39,7 @@ exists(merginsecrets.cpp) {
 }
 
 HEADERS += \
+  $$PWD/fieldsmodel.h \
 inputhelp.h \
 activelayer.h \
 layersmodel.h \

--- a/app/sources.pri
+++ b/app/sources.pri
@@ -1,13 +1,14 @@
 SOURCES += \
-  $$PWD/fieldsmodel.cpp \
 inputhelp.cpp \
 activelayer.cpp \
+fieldsmodel.cpp \
 layersmodel.cpp \
 layersproxymodel.cpp \
 localprojectsmanager.cpp \
 main.cpp \
 merginprojectmetadata.cpp \
 projectsmodel.cpp \
+projectwizard.cpp \
 loader.cpp \
 digitizingcontroller.cpp \
 mapthemesmodel.cpp \
@@ -39,14 +40,15 @@ exists(merginsecrets.cpp) {
 }
 
 HEADERS += \
-  $$PWD/fieldsmodel.h \
 inputhelp.h \
 activelayer.h \
+fieldsmodel.h \
 layersmodel.h \
 layersproxymodel.h \
 localprojectsmanager.h \
 merginprojectmetadata.h \
 projectsmodel.h \
+projectwizard.h \
 loader.h \
 digitizingcontroller.h \
 mapthemesmodel.h \


### PR DESCRIPTION
Implementation of project wizard to locally create a new project according specification. Allows to create a project with point gpkg layer. Three fields are predefined with option to add or remove a field. To simply workflow, user defined a name and widget type (with default simple configuration). Accordingly field type is set.

Feel free to comment. I think there are some things to improve, but Id rather share some ideas before spending some more time on it.

Manual test updated.

NOTE: Please use `Squash and merge`  option.

Possible enhancement:
* support for more widget combined with more field types (e.g real + slider) - from discussion, now out of scope of this PR
* better handling of having two fields with same names
* floating "Create project" button with reserved space bellow the project list - currently overlapping the list.

Known issues:
* wrong iOS keyboard popup while typing field names
* On desktop build (at least not printed on Android), I got following error probably related to permissions. Note that adding write permissions to gpkg file does not work with QFile::setPermissions.
```
ERROR 1: sqlite3_exec(CREATE TABLE "Survey" ( "fid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "geom" POINT, "Date" DATETIME, "Notes" TEXT, "Photo" TEXT)) failed: attempt to write a readonly database
ERROR 1: sqlite3_exec(CREATE TABLE gpkg_extensions (table_name TEXT,column_name TEXT,extension_name TEXT NOT NULL,definition TEXT NOT NULL,scope TEXT NOT NULL,CONSTRAINT ge_tce UNIQUE (table_name, column_name, extension_name))) failed: attempt to write a readonly database
ERROR 1: sqlite3_exec(CREATE TABLE "ogr_empty_table" ( "fid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "geom" GEOMETRY)) failed: attempt to write a readonly database
```
Inspite of it, project seems to be valid.

https://user-images.githubusercontent.com/6735606/105025225-5a5da400-5a4d-11eb-8ae9-38de3f31d1a8.mp4

closes #1044 