### PR TITLE
Reuse last entered value

### DIFF
--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -21,6 +21,7 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
   bool autoCenter = settings.value( "autoCenter", false ).toBool();
   int gpsTolerance = settings.value( "gpsTolerance", 10 ).toInt();
   int lineRecordingInterval = settings.value( "lineRecordingInterval", 3 ).toInt();
+  bool reuseLastEnteredValues = settings.value( "reuseLastEnteredValues", false ).toBool();
   settings.endGroup();
 
   setDefaultProject( path );
@@ -29,6 +30,7 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
   setAutoCenterMapChecked( autoCenter );
   setGpsAccuracyTolerance( gpsTolerance );
   setLineRecordingInterval( lineRecordingInterval );
+  setReuseLastEnteredValues( reuseLastEnteredValues );
 }
 
 QString AppSettings::defaultLayer() const
@@ -150,5 +152,22 @@ void AppSettings::setLineRecordingInterval( int value )
     settings.endGroup();
 
     emit lineRecordingIntervalChanged();
+  }
+}
+
+bool AppSettings::reuseLastEnteredValues() const
+{
+  return mReuseLastEnteredValues;
+}
+
+void AppSettings::setReuseLastEnteredValues( bool reuseLastEnteredValues )
+{
+  if ( mReuseLastEnteredValues != reuseLastEnteredValues )
+  {
+    QSettings settings;
+    settings.beginGroup( mGroupName );
+    settings.setValue( "reuseLastEnteredValues", reuseLastEnteredValues );
+    mReuseLastEnteredValues = reuseLastEnteredValues;
+    emit reuseLastEnteredValuesChanged( mReuseLastEnteredValues );
   }
 }

--- a/app/appsettings.h
+++ b/app/appsettings.h
@@ -23,6 +23,7 @@ class AppSettings: public QObject
     Q_PROPERTY( bool autoCenterMapChecked READ autoCenterMapChecked WRITE setAutoCenterMapChecked NOTIFY autoCenterMapCheckedChanged )
     Q_PROPERTY( int lineRecordingInterval READ lineRecordingInterval WRITE setLineRecordingInterval NOTIFY lineRecordingIntervalChanged )
     Q_PROPERTY( int gpsAccuracyTolerance READ gpsAccuracyTolerance WRITE setGpsAccuracyTolerance NOTIFY gpsAccuracyToleranceChanged )
+    Q_PROPERTY( bool reuseLastEnteredValues READ reuseLastEnteredValues WRITE setReuseLastEnteredValues NOTIFY reuseLastEnteredValuesChanged )
 
   public:
     explicit AppSettings( QObject *parent = nullptr );
@@ -47,6 +48,11 @@ class AppSettings: public QObject
     int lineRecordingInterval() const;
     void setLineRecordingInterval( int lineRecordingInterval );
 
+    bool reuseLastEnteredValues() const;
+
+  public slots:
+    void setReuseLastEnteredValues( bool reuseLastEnteredValues );
+
   signals:
     void defaultProjectChanged();
     void activeProjectChanged();
@@ -54,6 +60,8 @@ class AppSettings: public QObject
     void autoCenterMapCheckedChanged();
     void gpsAccuracyToleranceChanged();
     void lineRecordingIntervalChanged();
+
+    void reuseLastEnteredValuesChanged( bool reuseLastEnteredValues );
 
   private:
     // Projects path
@@ -72,6 +80,8 @@ class AppSettings: public QObject
 
     const QString mGroupName = QString( "inputApp" );
 
+    // used to allow remembering values of last created feature to speed up digitizing for user
+    bool mReuseLastEnteredValues;
 };
 
 #endif // APPSETTINGS_H

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -170,6 +170,7 @@ Drawer {
             anchors.bottom: toolbar.top
             externalResourceHandler: externalResourceBundle.handler
             toolbarVisible: false
+            allowRememberAttribute: __appSettings.reuseLastEnteredValues
             style: QgsQuick.FeatureFormStyling {
                 property color backgroundColor: "white"
                 property real backgroundOpacity: 1

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -235,6 +235,10 @@ Drawer {
                   property var today: QgsQuick.Utils.getThemeIcon("ic_today")
                   property var back: InputStyle.backIcon
                 }
+
+              property QtObject checkbox: QtObject {
+                property color baseColor: InputStyle.panelBackgroundDarker
+                }
               }
 
             model: QgsQuick.AttributeFormModel {

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -236,7 +236,7 @@ Drawer {
                   property var back: InputStyle.backIcon
                 }
 
-              property QtObject checkbox: QtObject {
+              property QtObject checkboxComponent: QtObject {
                 property color baseColor: InputStyle.panelBackgroundDarker
                 }
               }

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -201,6 +201,13 @@ Page {
                 }
             }
 
+            // Header "Recording"
+            PanelItem {
+                color: InputStyle.panelBackgroundLight
+                text: qsTr("Recording")
+                bold: true
+            }
+
             PanelItem {
                 height: settingsPanel.rowHeight
                 width: parent.width
@@ -219,6 +226,54 @@ Page {
                     width: height * 6
                     anchors.right: parent.right
                     anchors.rightMargin: InputStyle.panelMargin
+                }
+            }
+
+
+            PanelItem {
+                height: settingsPanel.rowHeight
+                width: parent.width
+                color: InputStyle.clrPanelMain
+                text: qsTr("Save last values")
+
+                Switch {
+                    anchors.margins: 0
+                    padding: 0
+                    id: rememberValuesCheck
+                    height: InputStyle.fontPixelSizeNormal
+                    width: height * 2
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.right: parent.right
+                    anchors.rightMargin: InputStyle.panelMargin
+                    checked: __appSettings.reuseLastEnteredValues
+                    onCheckedChanged: __appSettings.reuseLastEnteredValues = checked
+
+                    property color highlighColor: InputStyle.softGreen
+                    property color disabledColor: InputStyle.panelBackgroundDark
+
+                    indicator: Rectangle {
+                        implicitWidth: parent.width
+                        implicitHeight: parent.height
+                        x: rememberValuesCheck.leftPadding
+                        y: parent.height / 2 - height / 2
+                        radius: parent.height/2
+                        color: rememberValuesCheck.checked ? InputStyle.softGreen : "#ffffff"
+                        border.color: rememberValuesCheck.checked ? InputStyle.softGreen : rememberValuesCheck.disabledColor
+
+                        Rectangle {
+                            x: rememberValuesCheck.checked ? parent.width - width : 0
+                            width: parent.height
+                            height: parent.height
+                            radius: parent.height/2
+                            color: "#ffffff"
+                            border.color: rememberValuesCheck.checked ? InputStyle.softGreen : rememberValuesCheck.disabledColor
+                        }
+                    }
+                }
+
+                MouseArea {
+                  anchors.fill: parent
+                  onClicked: rememberValuesCheck.toggle()
                 }
             }
 

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -13,6 +13,7 @@ import QtQuick.Layouts 1.3
 import QtGraphicalEffects 1.0
 import lc 1.0
 import "."  // import InputStyle singleton
+import "./components"
 
 Page {
 
@@ -86,39 +87,11 @@ Page {
                 color: InputStyle.clrPanelMain
                 text: qsTr("Follow GPS with map")
 
-                Switch {
-                    anchors.margins: 0
-                    padding: 0
-                    id: autoCenterMapCheckBox
-                    height: InputStyle.fontPixelSizeNormal
-                    width: height * 2
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.right: parent.right
-                    anchors.rightMargin: InputStyle.panelMargin
-                    checked: __appSettings.autoCenterMapChecked
-                    onCheckedChanged: __appSettings.autoCenterMapChecked = checked
+                InputSwitch {
+                  id: autoCenterMapCheckBox
 
-                    property color highlighColor: InputStyle.softGreen
-                    property color disabledColor: InputStyle.panelBackgroundDark
-
-                    indicator: Rectangle {
-                        implicitWidth: parent.width
-                        implicitHeight: parent.height
-                        x: autoCenterMapCheckBox.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: parent.height/2
-                        color: autoCenterMapCheckBox.checked ? InputStyle.softGreen : "#ffffff"
-                        border.color: autoCenterMapCheckBox.checked ? InputStyle.softGreen : autoCenterMapCheckBox.disabledColor
-
-                        Rectangle {
-                            x: autoCenterMapCheckBox.checked ? parent.width - width : 0
-                            width: parent.height
-                            height: parent.height
-                            radius: parent.height/2
-                            color: "#ffffff"
-                            border.color: autoCenterMapCheckBox.checked ? InputStyle.softGreen : autoCenterMapCheckBox.disabledColor
-                        }
-                    }
+                  checked: __appSettings.autoCenterMapChecked
+                  onCheckedChanged: __appSettings.autoCenterMapChecked = checked
                 }
 
                 MouseArea {
@@ -234,41 +207,13 @@ Page {
                 height: settingsPanel.rowHeight
                 width: parent.width
                 color: InputStyle.clrPanelMain
-                text: qsTr("Save last values")
+                text: qsTr("Reuse last value option")
 
-                Switch {
-                    anchors.margins: 0
-                    padding: 0
-                    id: rememberValuesCheck
-                    height: InputStyle.fontPixelSizeNormal
-                    width: height * 2
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.right: parent.right
-                    anchors.rightMargin: InputStyle.panelMargin
-                    checked: __appSettings.reuseLastEnteredValues
-                    onCheckedChanged: __appSettings.reuseLastEnteredValues = checked
+                InputSwitch {
+                  id: rememberValuesCheck
 
-                    property color highlighColor: InputStyle.softGreen
-                    property color disabledColor: InputStyle.panelBackgroundDark
-
-                    indicator: Rectangle {
-                        implicitWidth: parent.width
-                        implicitHeight: parent.height
-                        x: rememberValuesCheck.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: parent.height/2
-                        color: rememberValuesCheck.checked ? InputStyle.softGreen : "#ffffff"
-                        border.color: rememberValuesCheck.checked ? InputStyle.softGreen : rememberValuesCheck.disabledColor
-
-                        Rectangle {
-                            x: rememberValuesCheck.checked ? parent.width - width : 0
-                            width: parent.height
-                            height: parent.height
-                            radius: parent.height/2
-                            color: "#ffffff"
-                            border.color: rememberValuesCheck.checked ? InputStyle.softGreen : rememberValuesCheck.disabledColor
-                        }
-                    }
+                  checked: __appSettings.reuseLastEnteredValues
+                  onCheckedChanged: __appSettings.reuseLastEnteredValues = checked
                 }
 
                 MouseArea {
@@ -323,7 +268,6 @@ Page {
               }
           }
         }
-
     }
 
     AboutPanel {

--- a/app/qml/components/InputSwitch.qml
+++ b/app/qml/components/InputSwitch.qml
@@ -1,0 +1,40 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.2
+
+import "../" // import InputStyle singleton
+
+Switch {
+  id: root
+
+  checked: false
+
+  anchors.margins: 0
+  padding: 0
+  height: InputStyle.fontPixelSizeNormal
+  width: height * 2
+  anchors.verticalCenter: parent.verticalCenter
+  anchors.right: parent.right
+  anchors.rightMargin: InputStyle.panelMargin
+
+  property color highlighColor: InputStyle.softGreen
+  property color disabledColor: InputStyle.panelBackgroundDark
+
+  indicator: Rectangle {
+    implicitWidth: parent.width
+    implicitHeight: parent.height
+    x: root.leftPadding
+    y: parent.height / 2 - height / 2
+    radius: parent.height/2
+    color: root.checked ? InputStyle.softGreen : "#ffffff"
+    border.color: root.checked ? InputStyle.softGreen : root.disabledColor
+
+    Rectangle {
+      x: root.checked ? parent.width - width : 0
+      width: parent.height
+      height: parent.height
+      radius: parent.height/2
+      color: "#ffffff"
+      border.color: root.checked ? InputStyle.softGreen : root.disabledColor
+    }
+  }
+}

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -53,5 +53,6 @@
         <file>LogPanel.qml</file>
         <file>components/PasswordField.qml</file>
         <file>components/DelegateButton.qml</file>
+        <file>components/InputSwitch.qml</file>
     </qresource>
 </RCC>

--- a/qgsquick/from_qgis/attributes/qgsquickattributeformmodel.cpp
+++ b/qgsquick/from_qgis/attributes/qgsquickattributeformmodel.cpp
@@ -77,6 +77,11 @@ void QgsQuickAttributeFormModel::forceClean()
   mSourceModel->forceClean();
 }
 
+void QgsQuickAttributeFormModel::setRememberValuesAllowed( bool rememberValuesAllowed )
+{
+  mSourceModel->setRememberValuesAllowed( rememberValuesAllowed );
+}
+
 bool QgsQuickAttributeFormModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
   return mSourceModel->data( mSourceModel->index( source_row, 0, source_parent ), CurrentlyVisible ).toBool();

--- a/qgsquick/from_qgis/attributes/qgsquickattributeformmodel.h
+++ b/qgsquick/from_qgis/attributes/qgsquickattributeformmodel.h
@@ -115,11 +115,11 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
     //! Resets the model
     Q_INVOKABLE void forceClean();
 
-public slots:
+  public slots:
     //! Allows or forbids attribute model to reuse last entered values
     void setRememberValuesAllowed( bool rememberValuesAllowed );
 
-signals:
+  signals:
     //! \copydoc QgsQuickAttributeFormModel::attributeModel
     void attributeModelChanged();
 

--- a/qgsquick/from_qgis/attributes/qgsquickattributeformmodel.h
+++ b/qgsquick/from_qgis/attributes/qgsquickattributeformmodel.h
@@ -51,8 +51,12 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
 
     //! Returns TRUE if all hard constraints defined on fields are satisfied with the current attribute values
     Q_PROPERTY( bool constraintsHardValid READ constraintsHardValid NOTIFY constraintsHardValidChanged )
+
     //! Returns TRUE if all soft constraints defined on fields are satisfied with the current attribute values
     Q_PROPERTY( bool constraintsSoftValid READ constraintsSoftValid NOTIFY constraintsSoftValidChanged )
+
+    //! Returns TRUE if remembering values is allowed
+    Q_PROPERTY( bool rememberValuesAllowed WRITE setRememberValuesAllowed )
 
   public:
 
@@ -111,7 +115,11 @@ class QUICK_EXPORT QgsQuickAttributeFormModel : public QSortFilterProxyModel
     //! Resets the model
     Q_INVOKABLE void forceClean();
 
-  signals:
+public slots:
+    //! Allows or forbids attribute model to reuse last entered values
+    void setRememberValuesAllowed( bool rememberValuesAllowed );
+
+signals:
     //! \copydoc QgsQuickAttributeFormModel::attributeModel
     void attributeModelChanged();
 

--- a/qgsquick/from_qgis/attributes/qgsquickattributeformmodelbase.cpp
+++ b/qgsquick/from_qgis/attributes/qgsquickattributeformmodelbase.cpp
@@ -252,6 +252,10 @@ void QgsQuickAttributeFormModelBase::flatten( QgsAttributeEditorContainer *conta
 
         QgsField field = mLayer->fields().at( fieldIndex );
 
+        Qt::CheckState rememberFlag = Qt::Unchecked;
+        if ( mAttributeModel->rememberValuesAllowed() && mAttributeModel->isFieldRemembered( fieldIndex ) )
+          rememberFlag = Qt::Checked;
+
         QStandardItem *item = new QStandardItem();
         item->setData( mLayer->attributeDisplayName( fieldIndex ), QgsQuickAttributeFormModel::Name );
         item->setData( mAttributeModel->featureLayerPair().feature().attribute( fieldIndex ), QgsQuickAttributeFormModel::AttributeValue );
@@ -259,7 +263,7 @@ void QgsQuickAttributeFormModelBase::flatten( QgsAttributeEditorContainer *conta
         QgsEditorWidgetSetup setup = mLayer->editorWidgetSetup( fieldIndex );
         item->setData( setup.type(), QgsQuickAttributeFormModel::EditorWidget );
         item->setData( setup.config(), QgsQuickAttributeFormModel::EditorWidgetConfig );
-        item->setData( mAttributeModel->rememberedAttributes().at( fieldIndex ) ? Qt::Checked : Qt::Unchecked, QgsQuickAttributeFormModel::RememberValue );
+        item->setData( rememberFlag, QgsQuickAttributeFormModel::RememberValue );
         item->setData( mLayer->fields().at( fieldIndex ), QgsQuickAttributeFormModel::Field );
         item->setData( QStringLiteral( "field" ), QgsQuickAttributeFormModel::ElementType );
         item->setData( fieldIndex, QgsQuickAttributeFormModel::FieldIndex );
@@ -426,6 +430,11 @@ void QgsQuickAttributeFormModelBase::forceClean()
   mExpressionContext = QgsExpressionContext();
   mConstraintsHardValid = false;
   mConstraintsSoftValid = false;
+}
+
+void QgsQuickAttributeFormModelBase::setRememberValuesAllowed( bool rememberValuesAllowed )
+{
+  mAttributeModel->setRememberValuesAllowed( rememberValuesAllowed );
 }
 
 bool QgsQuickAttributeFormModelBase::hasTabs() const

--- a/qgsquick/from_qgis/attributes/qgsquickattributeformmodelbase.h
+++ b/qgsquick/from_qgis/attributes/qgsquickattributeformmodelbase.h
@@ -108,6 +108,9 @@ class QgsQuickAttributeFormModelBase : public QStandardItemModel
     //! Resets the model
     Q_INVOKABLE void forceClean();
 
+    //! Allows or forbids attribute model to reuse last entered values
+    void setRememberValuesAllowed( bool rememberValuesAllowed );
+
   signals:
     //! \copydoc QgsQuickAttributeFormModelBase::attributeModel
     void attributeModelChanged();

--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
@@ -25,6 +25,8 @@ QgsQuickAttributeModel::QgsQuickAttributeModel( QObject *parent )
   connect( this, &QgsQuickAttributeModel::modelReset, this, &QgsQuickAttributeModel::featureLayerPairChanged );
   connect( this, &QgsQuickAttributeModel::featureChanged, this, &QgsQuickAttributeModel::featureLayerPairChanged );
   connect( this, &QgsQuickAttributeModel::layerChanged, this, &QgsQuickAttributeModel::featureLayerPairChanged );
+  connect( this, &QgsQuickAttributeModel::featureCreated, this, &QgsQuickAttributeModel::onFeatureCreated );
+  connect( this, &QgsQuickAttributeModel::rememberValuesAllowChanged, this, &QgsQuickAttributeModel::onRememberValuesAllowChanged );
 }
 
 QgsQuickFeatureLayerPair QgsQuickAttributeModel::featureLayerPair() const
@@ -40,10 +42,34 @@ void QgsQuickAttributeModel::setFeatureLayerPair( const QgsQuickFeatureLayerPair
 
 void QgsQuickAttributeModel::forceClean()
 {
-  mRememberedAttributes.clear();
+  mRememberedValues.clear();
   mFeatureLayerPair = QgsQuickFeatureLayerPair();
 }
 
+void QgsQuickAttributeModel::onFeatureCreated( const QgsFeature &feature )
+{
+  if ( mRememberValuesAllowed )
+  {
+    QString layerName = mFeatureLayerPair.layer()->id();
+
+    // save created feature to remember values
+    if ( mRememberedValues.contains( layerName ) )
+    {
+      mRememberedValues[layerName].feature = feature;
+    }
+  }
+}
+
+void QgsQuickAttributeModel::onRememberValuesAllowChanged()
+{
+  if ( mRememberValuesAllowed ) // add current layer
+  {
+    if ( mFeatureLayerPair.layer() )
+      mRememberedValues[mFeatureLayerPair.layer()->id()].attributeFilter.fill( false, mFeatureLayerPair.layer()->fields().size() );
+  }
+  else
+    mRememberedValues.clear();
+}
 
 void QgsQuickAttributeModel::setVectorLayer( QgsVectorLayer *layer )
 {
@@ -53,19 +79,30 @@ void QgsQuickAttributeModel::setVectorLayer( QgsVectorLayer *layer )
   beginResetModel();
   mFeatureLayerPair = QgsQuickFeatureLayerPair( mFeatureLayerPair.feature(), layer );
 
-
-  if ( const QgsVectorLayer *lLayer = mFeatureLayerPair.layer() )
+  if ( mRememberValuesAllowed )
   {
-    mRememberedAttributes.resize( lLayer->fields().size() );
-    mRememberedAttributes.fill( false );
-  }
-  else
-  {
-    mRememberedAttributes.clear();
+    if ( layer && !mRememberedValues.contains( layer->id() ) )
+    {
+      mRememberedValues[layer->id()].attributeFilter.fill( false, layer->fields().size() );
+    }
   }
 
   endResetModel();
   emit layerChanged();
+}
+
+void QgsQuickAttributeModel::prefillRememberedValues()
+{
+  RememberedValues from = mRememberedValues[mFeatureLayerPair.layer()->id()];
+  if ( !from.feature.isValid() )
+    return;
+
+  QgsAttributes fromAttributes = from.feature.attributes();
+  for( int i = 0; i < fromAttributes.length(); i++ )
+  {
+    if ( from.attributeFilter.at( i ) )
+      mFeatureLayerPair.featureRef().setAttribute( i, fromAttributes.at( i ) );
+  }
 }
 
 void QgsQuickAttributeModel::setFeature( const QgsFeature &feature )
@@ -75,8 +112,11 @@ void QgsQuickAttributeModel::setFeature( const QgsFeature &feature )
 
   beginResetModel();
   mFeatureLayerPair = QgsQuickFeatureLayerPair( feature, mFeatureLayerPair.layer() );
-  endResetModel();
 
+  if ( mRememberValuesAllowed && FID_IS_NULL( mFeatureLayerPair.feature().id() ) ) // this is a new feature
+    prefillRememberedValues();
+
+  endResetModel();
   emit featureChanged();
 }
 
@@ -117,7 +157,10 @@ QVariant QgsQuickAttributeModel::data( const QModelIndex &index, int role ) cons
       break;
 
     case RememberAttribute:
-      return mRememberedAttributes.at( index.row() );
+      if ( mRememberValuesAllowed )
+        return mRememberedValues[mFeatureLayerPair.layer()->id()].attributeFilter.at( index.row() );
+      else
+        return QVariant( false );
       break;
   }
 
@@ -150,8 +193,11 @@ bool QgsQuickAttributeModel::setData( const QModelIndex &index, const QVariant &
 
     case RememberAttribute:
     {
-      mRememberedAttributes[ index.row() ] = value.toBool();
-      emit dataChanged( index, index, QVector<int>() << role );
+      if ( mRememberValuesAllowed )
+      {
+        mRememberedValues[mFeatureLayerPair.layer()->id()].attributeFilter[index.row()] = value.toBool();
+        emit dataChanged( index, index, QVector<int>() << role );
+      }
       break;
     }
   }
@@ -251,7 +297,7 @@ void QgsQuickAttributeModel::resetAttributes()
   beginResetModel();
   for ( int i = 0; i < fields.count(); ++i )
   {
-    if ( !mRememberedAttributes.at( i ) )
+    if ( !mRememberValuesAllowed || !mRememberedValues[mFeatureLayerPair.layer()->id()].attributeFilter.at( i ) )
     {
       if ( !fields.at( i ).defaultValueDefinition().expression().isEmpty() )
       {
@@ -300,6 +346,8 @@ void QgsQuickAttributeModel::create()
                                Qgis::Critical );
   }
   commit();
+
+  emit featureCreated( mFeatureLayerPair.featureRef() );
 }
 
 bool QgsQuickAttributeModel::commit()
@@ -337,7 +385,27 @@ bool QgsQuickAttributeModel::startEditing()
   }
 }
 
-QVector<bool> QgsQuickAttributeModel::rememberedAttributes() const
+void QgsQuickAttributeModel::setRememberValuesAllowed( bool allowed )
 {
-  return mRememberedAttributes;
+  if ( allowed == mRememberValuesAllowed )
+    return;
+
+  mRememberValuesAllowed = allowed;
+  emit rememberValuesAllowChanged();
+}
+
+bool QgsQuickAttributeModel::rememberValuesAllowed() const
+{
+  return mRememberValuesAllowed;
+}
+
+bool QgsQuickAttributeModel::isFieldRemembered( const int fieldIndex ) const
+{
+  if ( !mRememberValuesAllowed || !mFeatureLayerPair.layer() || !mRememberedValues.contains( mFeatureLayerPair.layer()->id() ) )
+    return false;
+
+  if ( fieldIndex < 0 || fieldIndex > mRememberedValues[mFeatureLayerPair.layer()->id()].attributeFilter.size() )
+    return false;
+
+  return mRememberedValues[mFeatureLayerPair.layer()->id()].attributeFilter.at( fieldIndex );
 }

--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
@@ -98,7 +98,7 @@ void QgsQuickAttributeModel::prefillRememberedValues()
     return;
 
   QgsAttributes fromAttributes = from.feature.attributes();
-  for( int i = 0; i < fromAttributes.length(); i++ )
+  for ( int i = 0; i < fromAttributes.length(); i++ )
   {
     if ( from.attributeFilter.at( i ) )
       mFeatureLayerPair.featureRef().setAttribute( i, fromAttributes.at( i ) );

--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.h
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.h
@@ -68,7 +68,8 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     };
 
     //! Remembered values struct contains last created feature instance and a boolean vector masking attributes that should be remembered
-    struct RememberedValues {
+    struct RememberedValues
+    {
       QgsFeature feature;
       QVector<bool> attributeFilter;
     };

--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.h
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.h
@@ -33,10 +33,10 @@
  * related to layer and feature pair.
  *
  * On top of the QgsFeature attributes, support for "remember"
- * attribute is added. Remember attribute is used for
- * quick addition of the multiple features to the same layer.
- * A new feature can use "remembered" attribute values from
- * the last feature added.
+ * values is added. When model is allowed to remember values, it reuses
+ * values for last created features. However, this only work for attributes
+ * that passes filter (\see RememberedValues struct). This feature is used for quick addition
+ * of multiple features to the same layer.
  *
  *
  * \note QML Type: AttributeModel
@@ -65,6 +65,12 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
       AttributeValue,                    //!< Value of the feature's attribute
       Field,                             //!< Field definition (QgsField)
       RememberAttribute                  //!< Remember attribute value for next feature
+    };
+
+    //! Remembered values struct contains last created feature instance and a boolean vector masking attributes that should be remembered
+    struct RememberedValues {
+      QgsFeature feature;
+      QVector<bool> attributeFilter;
     };
 
     //! Creates a new feature attribute model
@@ -115,8 +121,8 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Resets remembered attributes
     Q_INVOKABLE virtual void resetAttributes();
 
-    //! Gets remembered attributes
-    QVector<bool> rememberedAttributes() const;
+    //! Gives information whether field with given index is remembered or not
+    bool isFieldRemembered( const int fieldIndex ) const;
 
     //! Gets current featureLayerPair
     QgsQuickFeatureLayerPair featureLayerPair() const;
@@ -127,7 +133,19 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Resets the model
     Q_INVOKABLE void forceClean();
 
+    //! Allows or forbids model to reuse last entered values
+    void setRememberValuesAllowed( bool allowed );
+
+    //! Returns whether model is remembering last entered values
+    bool rememberValuesAllowed() const;
+
   public slots:
+
+    //! Handles feature creation
+    void onFeatureCreated( const QgsFeature &feature );
+
+    //! Handles changing allowance of reusing last entered values
+    void onRememberValuesAllowChanged();
 
   signals:
     //! Feature or layer changed in feature layer pair
@@ -139,6 +157,12 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Layer changed, feature is the same
     void layerChanged();
 
+    //! Feature has been created
+    void featureCreated( const QgsFeature &feature );
+
+    //! Emitted when user allows reusing last entered values
+    void rememberValuesAllowChanged();
+
   protected:
     //! Commits model changes
     bool commit();
@@ -146,10 +170,18 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     bool startEditing();
 
     QgsQuickFeatureLayerPair mFeatureLayerPair;
-    QVector<bool> mRememberedAttributes;
+
   private:
     void setFeature( const QgsFeature &feature );
     void setVectorLayer( QgsVectorLayer *layer );
+
+    //! Fills remembered attributes from last created feature (mRememberedValues) to current feature (mFeatureLayerPair)
+    void prefillRememberedValues();
+
+    //! Remembered last created feature for each layer (key)
+    QHash<QString, RememberedValues> mRememberedValues;
+
+    bool mRememberValuesAllowed;
 };
 
 #endif // QGSQUICKATTRIBUTEMODEL_H

--- a/qgsquick/from_qgis/plugin/CMakeLists.txt
+++ b/qgsquick/from_qgis/plugin/CMakeLists.txt
@@ -11,6 +11,7 @@ set(QGIS_QUICK_PLUGIN_SRC
 
 set(QGIS_QUICK_PLUGIN_RESOURCES
   components/qgsquickicontextitem.qml
+  components/qgsquickcheckboxcomponent.qml
   editor/qgsquickeditorwidgetcombobox.qml
   editor/qgsquickcheckbox.qml
   editor/qgsquickdatetime.qml

--- a/qgsquick/from_qgis/plugin/components/qgsquickcheckboxcomponent.qml
+++ b/qgsquick/from_qgis/plugin/components/qgsquickcheckboxcomponent.qml
@@ -1,0 +1,90 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+import QtQuick 2.8
+import QtQuick.Templates 2.1 as T
+import "../" // import styling singleton
+
+T.CheckBox {
+    id: control
+
+    signal checkboxClicked( var buttonState )
+
+    property var spaceWidth: height / 4.0
+    property var baseSize: height / 5.5
+    property var baseColor: "black"
+
+    implicitHeight: indicator.implicitHeight + topPadding + bottomPadding
+    implicitWidth: indicator.implicitWidth + leftPadding + rightPadding
+
+    leftPadding: spaceWidth
+
+    onClicked: control.checkboxClicked( control.checkState )
+
+    indicator: Rectangle {
+        id: checkboxHandle
+        implicitWidth: baseSize * 2.6
+        implicitHeight: baseSize * 2.6
+        x: control.leftPadding
+        anchors.verticalCenter: parent.verticalCenter
+        radius: 2
+        border.color: baseColor
+
+        Rectangle {
+            id: rectangle
+            width: baseSize * 1.4
+            height: baseSize * 1.4
+            x: baseSize * 0.6
+            y: baseSize * 0.6
+            radius: baseSize * 0.4
+            visible: false
+            color: baseColor
+        }
+
+        states: [
+            State {
+                name: "unchecked"
+                when: !control.checked && !control.down
+            },
+            State {
+                name: "checked"
+                when: control.checked && !control.down
+
+                PropertyChanges {
+                    target: rectangle
+                    visible: true
+                }
+            },
+            State {
+                name: "unchecked_down"
+                when: !control.checked && control.down
+
+                PropertyChanges {
+                    target: rectangle
+                    color: baseColor
+                }
+
+                PropertyChanges {
+                    target: checkboxHandle
+                    border.color: baseColor
+                }
+            },
+            State {
+                name: "checked_down"
+                extend: "unchecked_down"
+                when: control.checked && control.down
+
+                PropertyChanges {
+                    target: rectangle
+                    visible: true
+                }
+            }
+        ]
+    }
+}

--- a/qgsquick/from_qgis/plugin/components/qgsquickcheckboxcomponent.qml
+++ b/qgsquick/from_qgis/plugin/components/qgsquickcheckboxcomponent.qml
@@ -9,7 +9,6 @@
 
 import QtQuick 2.8
 import QtQuick.Templates 2.1 as T
-import "../" // import styling singleton
 
 T.CheckBox {
     id: control

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -194,6 +194,11 @@ Item {
   }
 
   /**
+    * Forward change about remembering values to model
+    */
+  onAllowRememberAttributeChanged: form.model.rememberValuesAllowed = allowRememberAttribute
+
+  /**
    * This is a relay to forward private signals to internal components.
    */
   QtObject {

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -508,6 +508,7 @@ Item {
         QgsQuick.CheckboxComponent {
           id: rememberCheckbox
           visible: rememberCheckboxContainer.visible
+          baseColor: form.style.checkboxComponent.baseColor
 
           implicitWidth: 40 * QgsQuick.Utils.dp
           implicitHeight: width

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -420,7 +420,7 @@ Item {
       Item {
         id: placeholder
         height: childrenRect.height
-        anchors { left: parent.left; right: rememberCheckbox.left; top: constraintDescriptionLabel.bottom }
+        anchors { left: parent.left; right: rememberCheckboxContainer.left; top: constraintDescriptionLabel.bottom }
 
         Loader {
           id: attributeEditorLoader
@@ -493,17 +493,34 @@ Item {
         }
       }
 
-      CheckBox {
-        id: rememberCheckbox
-        checked: RememberValue ? true : false
-
+      Item {
+        id: rememberCheckboxContainer
         visible: form.allowRememberAttribute && form.state === "Add" && EditorWidget !== "Hidden"
-        width: visible ? undefined : 0
 
-        anchors { right: parent.right; top: fieldLabel.bottom }
+        implicitWidth: visible ? 40 * QgsQuick.Utils.dp : 0
+        implicitHeight: placeholder.height
 
-        onCheckedChanged: {
-          RememberValue = checked
+        anchors {
+          top: constraintDescriptionLabel.bottom
+          right: parent.right
+        }
+
+        QgsQuick.CheckboxComponent {
+          id: rememberCheckbox
+          visible: rememberCheckboxContainer.visible
+
+          implicitWidth: 40 * QgsQuick.Utils.dp
+          implicitHeight: width
+          x: -5 // hack to get over placeholder spacing
+          y: rememberCheckboxContainer.height/2 - rememberCheckbox.height/2
+
+          onCheckboxClicked: RememberValue = buttonState
+          checked: RememberValue ? true : false
+        }
+
+        MouseArea {
+          anchors.fill: parent
+          onClicked: rememberCheckbox.checkboxClicked( !rememberCheckbox.checkState )
         }
       }
     }

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
@@ -83,4 +83,8 @@ QtObject {
     property var back: QgsQuick.Utils.getThemeIcon("ic_back")
   }
 
+  property QtObject checkbox: QtObject {
+    property color baseColor: "black"
+  }
+
 }

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
@@ -83,8 +83,7 @@ QtObject {
     property var back: QgsQuick.Utils.getThemeIcon("ic_back")
   }
 
-  property QtObject checkbox: QtObject {
+  property QtObject checkboxComponent: QtObject {
     property color baseColor: "black"
   }
-
 }

--- a/qgsquick/from_qgis/plugin/qmldir
+++ b/qgsquick/from_qgis/plugin/qmldir
@@ -24,5 +24,6 @@ PositionMarker 0.1 qgsquickpositionmarker.qml
 ScaleBar 0.1 qgsquickscalebar.qml
 PhotoCapture 0.1 qgsquickphotopanel.qml
 MessageLog 0.1 qgsquickmessagelog.qml
+CheckboxComponent 0.1 qgsquickcheckboxcomponent.qml
 
 typeinfo qgsquick.qmltypes

--- a/qgsquick/from_qgis/plugin/qmldir
+++ b/qgsquick/from_qgis/plugin/qmldir
@@ -16,6 +16,7 @@ plugin qgis_quick_plugin
 # suppose to be used only internally in QgsQuick plugin
 EditorWidgetComboBox  0.1 qgsquickeditorwidgetcombobox.qml
 IconTextItem 0.1 qgsquickicontextitem.qml
+CheckboxComponent 0.1 qgsquickcheckboxcomponent.qml
 
 MapCanvas 0.1 qgsquickmapcanvas.qml
 FeatureForm 0.1 qgsquickfeatureform.qml
@@ -24,6 +25,5 @@ PositionMarker 0.1 qgsquickpositionmarker.qml
 ScaleBar 0.1 qgsquickscalebar.qml
 PhotoCapture 0.1 qgsquickphotopanel.qml
 MessageLog 0.1 qgsquickmessagelog.qml
-CheckboxComponent 0.1 qgsquickcheckboxcomponent.qml
 
 typeinfo qgsquick.qmltypes


### PR DESCRIPTION
Added possibility to reuse last entered values while creating new features. This option allows user to faster record new features.

To use this feature:
 - go to settings and check "Save last values"
 - create new feature = you will see checkboxes next to each attribute
 - click some of the checkboxes = these values will be saved for next feature
 - creat feature and try to create another one = selected attributes will be prefilled

Note:
- this also works when switching between multiple layers.
- setting is saved to QSettings and thus even when app is restarted, this check stays the same. (Though saved values are not preserved)
- look of checkboxes will be changed

**EDIT:**

- new UI

https://user-images.githubusercontent.com/22449698/106280790-a9ba8600-623e-11eb-9b53-698bc3c89076.mp4



Resolves #798 