### PR TITLE
Initialize demo project only on the first run

### DIFF
--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -159,7 +159,7 @@ void AppSettings::setReuseLastEnteredValues( bool reuseLastEnteredValues )
 {
   if ( mReuseLastEnteredValues != reuseLastEnteredValues )
   {
-	setValue( "reuseLastEnteredValues", value );
+    setValue( "reuseLastEnteredValues", reuseLastEnteredValues );
     mReuseLastEnteredValues = reuseLastEnteredValues;
     emit reuseLastEnteredValuesChanged( mReuseLastEnteredValues );
   }

--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -42,10 +42,7 @@ void AppSettings::setDefaultLayer( const QString &value )
 {
   if ( defaultLayer() != value )
   {
-    QSettings settings;
-    settings.beginGroup( mGroupName );
-    settings.setValue( "defaultLayer/" + mActiveProject, value );
-    settings.endGroup();
+    setValue( "defaultLayer/" + mActiveProject, value );
     mDefaultLayers.insert( mActiveProject, value );
     emit defaultLayerChanged();
   }
@@ -61,10 +58,7 @@ void AppSettings::setDefaultProject( const QString &value )
   if ( mDefaultProject != value )
   {
     mDefaultProject = value;
-    QSettings settings;
-    settings.beginGroup( mGroupName );
-    settings.setValue( "defaultProject", value );
-    settings.endGroup();
+    setValue( "defaultProject", value );
 
     emit defaultProjectChanged();
   }
@@ -97,10 +91,7 @@ void AppSettings::setAutoCenterMapChecked( bool value )
   if ( mAutoCenterMapChecked != value )
   {
     mAutoCenterMapChecked = value;
-    QSettings settings;
-    settings.beginGroup( mGroupName );
-    settings.setValue( "autoCenter", value );
-    settings.endGroup();
+    setValue( "autoCenter", value );
 
     emit autoCenterMapCheckedChanged();
   }
@@ -127,10 +118,7 @@ void AppSettings::setGpsAccuracyTolerance( int value )
   if ( mGpsAccuracyTolerance != value )
   {
     mGpsAccuracyTolerance = value;
-    QSettings settings;
-    settings.beginGroup( mGroupName );
-    settings.setValue( "gpsTolerance", value );
-    settings.endGroup();
+    setValue( "gpsTolerance", value );
 
     emit gpsAccuracyToleranceChanged();
   }
@@ -146,13 +134,20 @@ void AppSettings::setLineRecordingInterval( int value )
   if ( mLineRecordingInterval != value )
   {
     mLineRecordingInterval = value;
-    QSettings settings;
-    settings.beginGroup( mGroupName );
-    settings.setValue( "lineRecordingInterval", value );
-    settings.endGroup();
+    setValue( "lineRecordingInterval", value );
 
     emit lineRecordingIntervalChanged();
   }
+}
+
+bool AppSettings::isAppInitialized()
+{
+  return value( QStringLiteral( "isAppInitialized" ), QVariant( false ) ).toBool();
+}
+
+void AppSettings::setAppInitialized( const bool value )
+{
+  setValue( "isAppInitialized", value );
 }
 
 bool AppSettings::reuseLastEnteredValues() const
@@ -164,10 +159,26 @@ void AppSettings::setReuseLastEnteredValues( bool reuseLastEnteredValues )
 {
   if ( mReuseLastEnteredValues != reuseLastEnteredValues )
   {
-    QSettings settings;
-    settings.beginGroup( mGroupName );
-    settings.setValue( "reuseLastEnteredValues", reuseLastEnteredValues );
+	setValue( "reuseLastEnteredValues", value );
     mReuseLastEnteredValues = reuseLastEnteredValues;
     emit reuseLastEnteredValuesChanged( mReuseLastEnteredValues );
   }
+}
+
+void AppSettings::setValue( const QString &key, const QVariant &value )
+{
+  QSettings settings;
+  settings.beginGroup( mGroupName );
+  settings.setValue( key, value );
+  settings.endGroup();
+}
+
+QVariant AppSettings::value( const QString &key, const QVariant &defaultValue )
+{
+  QSettings settings;
+  settings.beginGroup( mGroupName );
+  QVariant value = settings.value( key, defaultValue );
+  settings.endGroup();
+
+  return value;
 }

--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -140,14 +140,14 @@ void AppSettings::setLineRecordingInterval( int value )
   }
 }
 
-bool AppSettings::isAppInitialized()
+bool AppSettings::demoProjectsCopied()
 {
-  return value( QStringLiteral( "isAppInitialized" ), QVariant( false ) ).toBool();
+  return value( QStringLiteral( "demoProjectsCopied" ), QVariant( false ) ).toBool();
 }
 
-void AppSettings::setAppInitialized( const bool value )
+void AppSettings::setDemoProjectsCopied( const bool value )
 {
-  setValue( "isAppInitialized", value );
+  setValue( "demoProjectsCopied", value );
 }
 
 bool AppSettings::reuseLastEnteredValues() const

--- a/app/appsettings.h
+++ b/app/appsettings.h
@@ -12,6 +12,7 @@
 
 #include <QObject>
 #include <QHash>
+#include <QVariant>
 
 class AppSettings: public QObject
 {
@@ -48,6 +49,9 @@ class AppSettings: public QObject
     int lineRecordingInterval() const;
     void setLineRecordingInterval( int lineRecordingInterval );
 
+    bool isAppInitizalized();
+    void setAppInitizalized( const bool value );
+
     bool reuseLastEnteredValues() const;
 
   public slots:
@@ -82,6 +86,10 @@ class AppSettings: public QObject
 
     // used to allow remembering values of last created feature to speed up digitizing for user
     bool mReuseLastEnteredValues;
+
+    void setValue( const QString &key, const QVariant &value );
+    QVariant value( const QString &key, const QVariant &defaultValue = QVariant() );
+
 };
 
 #endif // APPSETTINGS_H

--- a/app/appsettings.h
+++ b/app/appsettings.h
@@ -49,8 +49,8 @@ class AppSettings: public QObject
     int lineRecordingInterval() const;
     void setLineRecordingInterval( int lineRecordingInterval );
 
-    bool isAppInitialized();
-    void setAppInitialized( const bool value );
+    bool demoProjectsCopied();
+    void setDemoProjectsCopied( const bool value );
 
     bool reuseLastEnteredValues() const;
 

--- a/app/appsettings.h
+++ b/app/appsettings.h
@@ -49,8 +49,8 @@ class AppSettings: public QObject
     int lineRecordingInterval() const;
     void setLineRecordingInterval( int lineRecordingInterval );
 
-    bool isAppInitizalized();
-    void setAppInitizalized( const bool value );
+    bool isAppInitialized();
+    void setAppInitialized( const bool value );
 
     bool reuseLastEnteredValues() const;
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -327,6 +327,7 @@ int main( int argc, char *argv[] )
 #ifdef ANDROID
   appBundleDir = dataDir + "/qgis-data";
   demoDir = "assets:/demo-projects";
+  demoDir = dataDir + "/qgis-data/resources/demo-projects";
 #endif
 #ifdef Q_OS_IOS
   appBundleDir = QCoreApplication::applicationDirPath() + "/qgis-data";
@@ -343,9 +344,15 @@ int main( int argc, char *argv[] )
 #else
   projDir = dataDir;
 #endif
-
+  AppSettings as;
   InputProjUtils inputProjUtils;
-  copy_demo_projects( demoDir, projectDir );
+
+  // copy demo projects if the app is launched for the first time
+  if ( !as.isAppInitialized() )
+  {
+    copy_demo_projects( demoDir, projectDir );
+    as.setAppInitialized( true );
+  }
   inputProjUtils.initProjLib( projDir, projectDir );
   init_qgis( appBundleDir );
 
@@ -355,7 +362,6 @@ int main( int argc, char *argv[] )
   LocalProjectsManager localProjects( projectDir );
   ProjectModel pm( localProjects );
   MapThemesModel mtm;
-  AppSettings as;
   std::unique_ptr<MerginApi> ma =  std::unique_ptr<MerginApi>( new MerginApi( localProjects ) );
   InputUtils iu;
   MerginProjectModel mpm( localProjects );

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -346,11 +346,11 @@ int main( int argc, char *argv[] )
   AppSettings as;
   InputProjUtils inputProjUtils;
 
-  // copy demo projects if the app is launched for the first time
-  if ( !as.isAppInitialized() )
+  // copy demo projects when the app is launched for the first time
+  if ( !as.demoProjectsCopied() )
   {
     copy_demo_projects( demoDir, projectDir );
-    as.setAppInitialized( true );
+    as.setDemoProjectsCopied( true );
   }
   inputProjUtils.initProjLib( projDir, projectDir );
   init_qgis( appBundleDir );

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -327,7 +327,6 @@ int main( int argc, char *argv[] )
 #ifdef ANDROID
   appBundleDir = dataDir + "/qgis-data";
   demoDir = "assets:/demo-projects";
-  demoDir = dataDir + "/qgis-data/resources/demo-projects";
 #endif
 #ifdef Q_OS_IOS
   appBundleDir = QCoreApplication::applicationDirPath() + "/qgis-data";


### PR DESCRIPTION
Introducing `isAppInitialized` qsettings variable to see if the app has been already launched or it is the first time run.
Demo projects are copied only on the very first run. This should allow user to delete demo project or kept demo project data from previous runs. 

closes #1109 