### PR TITLE
Custom proj fix for iOS

### DIFF
--- a/app/inputprojutils.cpp
+++ b/app/inputprojutils.cpp
@@ -145,7 +145,7 @@ void InputProjUtils::initProjLib( const QString &pkgPath, const QString &project
 #endif
 
 #ifdef Q_OS_IOS
-  QString prefixPath = pkgPath + "/proj";
+  QString prefixPath = QCoreApplication::applicationDirPath() + "/qgis-data/proj";
   QString projFilePath = prefixPath + "/proj.db";
 #endif
 
@@ -165,7 +165,11 @@ void InputProjUtils::initProjLib( const QString &pkgPath, const QString &project
 #endif
 
   QStringList paths = {prefixPath};
+#ifdef Q_OS_IOS
+  mCurrentCustomProjDir = pkgPath + "/proj_custom";
+#else
   mCurrentCustomProjDir = prefixPath + "_custom";
+#endif
   qDebug() << "InputPROJ: Input Search Paths" << paths;
   qDebug() << "InputPROJ: Custom Search Path" << mCurrentCustomProjDir;
 

--- a/app/inputprojutils.cpp
+++ b/app/inputprojutils.cpp
@@ -133,43 +133,45 @@ static void _updateProj( const QStringList &searchPaths )
   delete [] newPaths;
 }
 
-
-void InputProjUtils::initProjLib( const QString &pkgPath, const QString &projectsPath )
+void InputProjUtils::setProjDir( const QString &appBundleDir )
 {
-#ifdef MOBILE_OS
 #ifdef ANDROID
   // win and ios resources are already in the bundle
-  InputUtils::cpDir( "assets:/qgis-data", pkgPath );
-  QString prefixPath = pkgPath + "/proj";
-  QString projFilePath = prefixPath + "/proj.db";
-#endif
-
-#ifdef Q_OS_IOS
-  QString prefixPath = QCoreApplication::applicationDirPath() + "/qgis-data/proj";
-  QString projFilePath = prefixPath + "/proj.db";
+  InputUtils::cpDir( "assets:/qgis-data", appBundleDir );
 #endif
 
 #ifdef Q_OS_WIN32
-  QString prefixPath = pkgPath + "\\proj";
-  QString projFilePath = prefixPath + "\\proj.db";
+  mProjDir = appBundleDir + "\\proj";
+  QString projFilePath = mProjDir + "\\proj.db";
+#else
+  mProjDir = appBundleDir + "/proj";
+  QString projFilePath = mProjDir + "/proj.db";
 #endif
 
   QFile projdb( projFilePath );
   if ( !projdb.exists() )
   {
-    InputUtils::log( QStringLiteral( "PROJ6 error" ), QStringLiteral( "The Input has failed to load PROJ6 database." ) );
+    InputUtils::log( QStringLiteral( "PROJ6 error" ), QStringLiteral( "The Input has failed to load PROJ6 database." ) + projFilePath );
   }
-#else
-  // Linux/MacOS, use bundled proj files
-  QString prefixPath = pkgPath + "/proj";
-#endif
+}
 
-  QStringList paths = {prefixPath};
+void InputProjUtils::setCurrentCustomProjDir( const QString &dataDir )
+{
 #ifdef Q_OS_IOS
-  mCurrentCustomProjDir = pkgPath + "/proj_custom";
+  // custom proj path has to be in data dir, not in the bundle
+  mCurrentCustomProjDir = dataDir + "/qgis_data/proj_custom";
 #else
-  mCurrentCustomProjDir = prefixPath + "_custom";
+  Q_UNUSED( dataDir )
+  mCurrentCustomProjDir = mProjDir + "_custom";
 #endif
+}
+
+void InputProjUtils::initProjLib( const QString &appBundleDir, const QString &dataDir, const QString &projectsPath )
+{
+  setProjDir( appBundleDir );
+  setCurrentCustomProjDir( dataDir );
+
+  QStringList paths = {mProjDir};
   qDebug() << "InputPROJ: Input Search Paths" << paths;
   qDebug() << "InputPROJ: Custom Search Path" << mCurrentCustomProjDir;
 

--- a/app/inputprojutils.h
+++ b/app/inputprojutils.h
@@ -39,7 +39,7 @@ class InputProjUtils: public QObject
      * Sets the PROJ_LIB dir, should be called before qgis application is initialized
      * Copies all custom projections from all loaded projects to the custom PROJ folder.
      */
-    void initProjLib( const QString &pkgPath, const QString &projectsPath );
+    void initProjLib( const QString &appBundleDir, const QString &dataDir, const QString &projectsPath );
 
     /**
      * Resets the custom handlers.
@@ -57,6 +57,9 @@ class InputProjUtils: public QObject
     void cleanCustomDir();
     void copyCustomProj( const QString &projectsPath );
 
+    void setCurrentCustomProjDir( const QString &dataDir );
+    void setProjDir( const QString &appBundleDir );
+
     void initCoordinateOperationHandlers();
 
     bool mPopUpShown = false;
@@ -68,6 +71,7 @@ class InputProjUtils: public QObject
     bool mFallbackOperationOccurredReported = false;
 
     QString mCurrentCustomProjDir;
+    QString mProjDir;
 };
 
 #endif // INPUTPROJUTILS_H

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -340,12 +340,6 @@ int main( int argc, char *argv[] )
   //TODO win32 package demo projects
 #endif
 
-  QString projDir;
-#ifdef MOBILE_OS
-  projDir = dataDir + "/qgis-data";
-#else
-  projDir = dataDir;
-#endif
   AppSettings as;
   InputProjUtils inputProjUtils;
 
@@ -355,7 +349,7 @@ int main( int argc, char *argv[] )
     copy_demo_projects( demoDir, projectDir );
     as.setDemoProjectsCopied( true );
   }
-  inputProjUtils.initProjLib( projDir, projectDir );
+  inputProjUtils.initProjLib( appBundleDir, dataDir, projectDir );
   init_qgis( appBundleDir );
 
   // Create Input classes

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -342,7 +342,7 @@ int main( int argc, char *argv[] )
 
   QString projDir;
 #ifdef MOBILE_OS
-  projDir = appBundleDir;
+  projDir = dataDir + "/qgis-data";
 #else
   projDir = dataDir;
 #endif


### PR DESCRIPTION
Bundle and data dir has different hash in absolute path
closes #1131

Android seems to have an issue with `fallbackOperationOccurredReported` - investigation in progress. 
To reproduce:
* clean install of app
* download test project with custom proj
* open project - a dialog about restart is opened
* restart app
* open the project