### PR TITLE
Fix missing basefile for a new projects

### DIFF
--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -735,6 +735,10 @@ void MerginApi::createProjectFinished()
         QDir projectDir( info.projectDir );
         if ( projectDir.exists() && !projectDir.isEmpty() )
         {
+
+
+          // TODO @vsklencar create changeset
+          //createChangeset
           uploadProject( projectNamespace, projectName );
         }
       }
@@ -1840,7 +1844,21 @@ void MerginApi::uploadInfoReplyFinished()
       MerginFile merginFile = findFile( filePath, localFiles );
       merginFile.chunks = generateChunkIdsForSize( merginFile.size );
       addedMerginFiles.append( merginFile );
+
+      if ( MerginApi::isFileDiffable( filePath ) )
+      {
+        // .mergin folder and basefiles for changeset may not exist yet for a virgin project (never uploaded to Mergin)
+        QString basefile = transaction.projectDir + "/.mergin/" + filePath;
+        createPathIfNotExists( basefile );
+
+        QString sourcePath = transaction.projectDir + "/" + filePath;
+        if ( !QFile::copy( sourcePath, basefile ) )
+        {
+          InputUtils::log( "push " + projectFullName, "failed to copy new basefile for: " + filePath );
+        }
+      }
     }
+
     for ( QString filePath : transaction.diff.localUpdated )
     {
       MerginFile merginFile = findFile( filePath, localFiles );

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -735,10 +735,6 @@ void MerginApi::createProjectFinished()
         QDir projectDir( info.projectDir );
         if ( projectDir.exists() && !projectDir.isEmpty() )
         {
-
-
-          // TODO @vsklencar create changeset
-          //createChangeset
           uploadProject( projectNamespace, projectName );
         }
       }

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -62,6 +62,7 @@ class TestMerginApi: public QObject
     void testUpdateWithDiffs();
     void testUpdateWithMissedVersion();
     void testMigrateProject();
+    void testMigrateProjectAndSync();
     void testMigrateDetachProject();
 
     void testRegister();


### PR DESCRIPTION
Prepare basefile for changeset for a newly added files (mainly for a new project).

By adding migration to Mergin functionality, a new use case has been introduced with it. The only way how to obtain a project that can be synced with Mergin, was to donwload it. After download, a basefile for .gpkg files are copied. However, by migrating a new project to mergin, the basefile preparation was omitted (not needed before though), therefore geodiff couldnt work properly.

closes #1127