### PR TITLE
Centered text for record toolbar

### DIFF
--- a/app/qml/RecordToolbar.qml
+++ b/app/qml/RecordToolbar.qml
@@ -74,15 +74,15 @@ Item {
             }
         }
 
-        Item {
+        Row {
             anchors.centerIn: parent
             height: extraPanelHeight
+            spacing: 0
 
             Item {
                 id: iconContainer
                 height: extraPanelHeight
                 width: extraPanelHeight
-                anchors.right: label.left
 
                 Image {
                     id: icon
@@ -109,6 +109,7 @@ Item {
                 font.bold: true
                 verticalAlignment: Text.AlignVCenter
                 horizontalAlignment: Text.AlignHCenter
+                rightPadding: extraPanelHeight/4
             }
         }
     }


### PR DESCRIPTION
closes #1161 

Might be worth to extract necessary code from TextWithIcon component and use it for all icon+text components.

before:
<img width="160" alt="Screenshot 2021-02-08 at 16 38 51" src="https://user-images.githubusercontent.com/6735606/107246688-c883fe00-6a30-11eb-852b-cb25e2de8dd0.png">

after:
<img width="144" alt="Screenshot 2021-02-08 at 16 36 52" src="https://user-images.githubusercontent.com/6735606/107246705-cde14880-6a30-11eb-8862-7dcc451bbd8a.png">

