### PR TITLE
Add OGR to Linux deps

### DIFF
--- a/app/config.pri.default
+++ b/app/config.pri.default
@@ -43,6 +43,9 @@ unix:!macx:!android {
 
   PROJ_INCLUDE_DIR = $${BASE_DIR}/include
   PROJ_LIB_DIR = $${BASE_DIR}/lib
+
+  # To use OGR API
+  OGR_INCLUDE_DIR = < path to gdal.h like /usr/include/gdal >
 }
 
 macx:!android {

--- a/app/linux.pri
+++ b/app/linux.pri
@@ -95,6 +95,9 @@
     LIBS += -L$${PROJ_LIB_DIR}
     LIBS += -lproj
 
+    # GDAL
+    INCLUDEPATH += $${OGR_INCLUDE_DIR}
+
     # TESTING stuff (only desktop)
     DEFINES += "INPUT_TEST"
     QT += testlib


### PR DESCRIPTION
Linux would not compile due to a missing GDAL path. 