### PR TITLE
Unified feature form layout

### DIFF
--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -184,7 +184,7 @@ Drawer {
                   property real bottomMargin: 1 * QgsQuick.Utils.dp
                   property real height: 64 * QgsQuick.Utils.dp
                   property color fontColor: InputStyle.fontColor
-                  property int spacing: 10 * QgsQuick.Utils.dp
+                  property int spacing: 0
                   property int fontPixelSize: 24 * QgsQuick.Utils.dp
                 }
 
@@ -225,6 +225,9 @@ Drawer {
                     property real height: 54 * QgsQuick.Utils.dp
                     property int fontPixelSize: 22 * QgsQuick.Utils.dp
                     property real sideMargin: 12 * QgsQuick.Utils.dp
+                    property real outerMargin: 20 * QgsQuick.Utils.dp
+                    property int fontPointSize: 15
+                    property int labelPointSize: 12
                   }
 
                 property QtObject icons: QtObject {

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -174,6 +174,7 @@ Drawer {
             style: QgsQuick.FeatureFormStyling {
                 property color backgroundColor: "white"
                 property real backgroundOpacity: 1
+                property real titleLabelPointSize: 16
 
                 property QtObject group: QtObject {
                   property color backgroundColor: InputStyle.panelBackgroundLight
@@ -199,6 +200,7 @@ Drawer {
                   property real height: 48 * QgsQuick.Utils.dp
                   property real buttonHeight: height * 0.8
                   property real spacing: 5 * QgsQuick.Utils.dp
+                  property int tabLabelPointSize: 12
                 }
 
                 property QtObject constraint: QtObject {
@@ -224,7 +226,7 @@ Drawer {
                     property real cornerRadius: 8 * QgsQuick.Utils.dp
                     property real height: 54 * QgsQuick.Utils.dp
                     property int fontPixelSize: 22 * QgsQuick.Utils.dp
-                    property real sideMargin: 12 * QgsQuick.Utils.dp
+                    property real sideMargin: 10 * QgsQuick.Utils.dp
                     property real outerMargin: 20 * QgsQuick.Utils.dp
                     property int fontPointSize: 15
                     property int labelPointSize: 12

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -202,7 +202,7 @@ Drawer {
                 }
 
                 property QtObject constraint: QtObject {
-                  property color validColor: "black"
+                  property color validColor: InputStyle.panelBackgroundDarker
                   property color invalidColor: "#c0392b"
                   property color descriptionColor: "#e67e22"
                 }
@@ -224,6 +224,7 @@ Drawer {
                     property real cornerRadius: 8 * QgsQuick.Utils.dp
                     property real height: 54 * QgsQuick.Utils.dp
                     property int fontPixelSize: 22 * QgsQuick.Utils.dp
+                    property real sideMargin: 12 * QgsQuick.Utils.dp
                   }
 
                 property QtObject icons: QtObject {

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -204,7 +204,7 @@ Drawer {
                 }
 
                 property QtObject constraint: QtObject {
-                  property color validColor: InputStyle.panelBackgroundDarker
+                  property color validColor: InputStyle.labelColor
                   property color invalidColor: "#c0392b"
                   property color descriptionColor: "#e67e22"
                 }

--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -25,6 +25,7 @@ QtObject {
     property color panelBackgroundDark: "#B3B3B3"
     property color panelBackgroundDarker: "#575757"
     property color panelBackgroundLight: "#E6E6E6"
+    property color labelColor: "#999999"
 
     property color highlightColor: "#FD9626"
     property color softRed: "#FC9FB1"

--- a/qgsquick/from_qgis/plugin/editor/qgsquickcheckbox.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickcheckbox.qml
@@ -59,7 +59,7 @@ Item {
       verticalAlignment: Text.AlignVCenter
       anchors.left: parent.left
       anchors.verticalCenter: parent.verticalCenter
-      leftPadding: 6 * QgsQuick.Utils.dp
+      leftPadding: customStyle.fields.sideMargin
     }
 
     CheckBox {

--- a/qgsquick/from_qgis/plugin/editor/qgsquickcheckbox.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickcheckbox.qml
@@ -35,7 +35,6 @@ Item {
   anchors {
     right: parent.right
     left: parent.left
-    rightMargin: 10 * QgsQuick.Utils.dp
   }
 
   function getConfigValue(configValue, defaultValue) {
@@ -67,8 +66,8 @@ Item {
       height: customStyle.fields.height/2
       width: height * 2
       anchors.right: parent.right
-      anchors.rightMargin: fieldItem.anchors.rightMargin
       anchors.verticalCenter: parent.verticalCenter
+      anchors.rightMargin: customStyle.fields.sideMargin
       id: checkBox
       leftPadding: 0
       checked: value === fieldItem.checkedState

--- a/qgsquick/from_qgis/plugin/editor/qgsquickcheckbox.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickcheckbox.qml
@@ -52,7 +52,7 @@ Item {
 
     Text {
       text: checkBox.checked ? fieldItem.checkedState : fieldItem.uncheckedState
-      font.pixelSize: customStyle.fields.fontPixelSize
+      font.pointSize: customStyle.fields.fontPointSize
       color: customStyle.fields.fontColor
       horizontalAlignment: Text.AlignLeft
       verticalAlignment: Text.AlignVCenter

--- a/qgsquick/from_qgis/plugin/editor/qgsquickdatetime.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickdatetime.qml
@@ -35,7 +35,6 @@ Item {
     anchors {
       left: parent.left
       right: parent.right
-      rightMargin: 10 * QgsQuick.Utils.dp
     }
 
     property var timeToString: function timeToString(attrValue) {
@@ -141,7 +140,7 @@ Item {
                 anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
                 visible: fieldItem.enabled
-                anchors.rightMargin: fieldItem.anchors.rightMargin
+                anchors.rightMargin: customStyle.fields.sideMargin
 
                 MouseArea {
                     anchors.fill: parent

--- a/qgsquick/from_qgis/plugin/editor/qgsquickdatetime.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickdatetime.qml
@@ -66,7 +66,7 @@ Item {
 
                 anchors.fill: parent
                 verticalAlignment: Text.AlignVCenter
-                font.pixelSize: customStyle.fields.fontPixelSize
+                font.pointSize: customStyle.fields.fontPointSize
                 color: customStyle.fields.fontColor
                 padding: 0
                 topPadding: 10 * QgsQuick.Utils.dp

--- a/qgsquick/from_qgis/plugin/editor/qgsquickdatetime.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickdatetime.qml
@@ -72,6 +72,7 @@ Item {
                 padding: 0
                 topPadding: 10 * QgsQuick.Utils.dp
                 bottomPadding: 10 * QgsQuick.Utils.dp
+                leftPadding: customStyle.fields.sideMargin
                 background: Rectangle {
                     radius: customStyle.fields.cornerRadius
 

--- a/qgsquick/from_qgis/plugin/editor/qgsquickeditorwidgetcombobox.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickeditorwidgetcombobox.qml
@@ -47,7 +47,7 @@ ComboBox {
     height: comboBox.height * 0.8
     text: model.display
     font.weight: comboBox.currentIndex === index ? Font.DemiBold : Font.Normal
-    font.pixelSize: comboStyle.fontPixelSize
+    font.pointSize: customStyle.fields.fontPointSize
     highlighted: comboBox.highlightedIndex === index
     leftPadding: customStyle.fields.sideMargin
     onClicked: comboBox.itemClicked( model.FeatureId ? model.FeatureId : index )
@@ -56,7 +56,7 @@ ComboBox {
   contentItem: Text {
     height: comboBox.height * 0.8
     text: comboBox.displayText
-    font.pixelSize: comboStyle.fontPixelSize
+    font.pointSize: customStyle.fields.fontPointSize
     horizontalAlignment: Text.AlignLeft
     verticalAlignment: Text.AlignVCenter
     elide: Text.ElideRight

--- a/qgsquick/from_qgis/plugin/editor/qgsquickeditorwidgetcombobox.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickeditorwidgetcombobox.qml
@@ -49,7 +49,7 @@ ComboBox {
     font.weight: comboBox.currentIndex === index ? Font.DemiBold : Font.Normal
     font.pixelSize: comboStyle.fontPixelSize
     highlighted: comboBox.highlightedIndex === index
-    leftPadding: 5 * QgsQuick.Utils.dp
+    leftPadding: customStyle.fields.sideMargin
     onClicked: comboBox.itemClicked( model.FeatureId ? model.FeatureId : index )
   }
 
@@ -60,7 +60,7 @@ ComboBox {
     horizontalAlignment: Text.AlignLeft
     verticalAlignment: Text.AlignVCenter
     elide: Text.ElideRight
-    leftPadding: 5 * QgsQuick.Utils.dp
+    leftPadding: customStyle.fields.sideMargin
     color: comboStyle.fontColor
   }
 

--- a/qgsquick/from_qgis/plugin/editor/qgsquickexternalresource.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickexternalresource.qml
@@ -140,7 +140,6 @@ Item {
   anchors {
     left: parent.left
     right: parent.right
-    rightMargin: 10 * QgsQuick.Utils.dp
   }
 
   states: [

--- a/qgsquick/from_qgis/plugin/editor/qgsquickrange.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickrange.qml
@@ -21,7 +21,6 @@ import QgsQuick 0.1 as QgsQuick
 Item {
   signal valueChanged(var value, bool isNull)
 
-  property real customMargin: 10 * QgsQuick.Utils.dp
   property string widgetStyle: config["Style"] ? config["Style"] : "SpinBox"
   property int precision: config["Precision"]
   property real from: config["Min"]
@@ -37,7 +36,6 @@ Item {
   anchors {
     left: parent.left
     right: parent.right
-    rightMargin: fieldItem.customMargin
   }
 
   // background
@@ -145,7 +143,7 @@ Item {
       horizontalAlignment: Text.AlignLeft
       font.pixelSize: customStyle.fields.fontPixelSize
       color: customStyle.fields.fontColor
-      padding: fieldItem.customMargin
+      padding: 10 * QgsQuick.Utils.dp
       leftPadding: customStyle.fields.sideMargin
     }
 

--- a/qgsquick/from_qgis/plugin/editor/qgsquickrange.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickrange.qml
@@ -146,6 +146,7 @@ Item {
       font.pixelSize: customStyle.fields.fontPixelSize
       color: customStyle.fields.fontColor
       padding: fieldItem.customMargin
+      leftPadding: customStyle.fields.sideMargin
     }
 
     Slider {
@@ -158,6 +159,7 @@ Item {
       from: fieldItem.from
       to: fieldItem.to
       stepSize: fieldItem.step
+      rightPadding: customStyle.fields.sideMargin
 
       onValueChanged: {
         if (visible) {

--- a/qgsquick/from_qgis/plugin/editor/qgsquickrange.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickrange.qml
@@ -111,7 +111,7 @@ Item {
       contentItem: TextInput {
         z: 2
         text: spinbox.textFromValue(spinbox.value, spinbox.locale)
-        font.pixelSize: customStyle.fields.fontPixelSize
+        font.pointSize: customStyle.fields.fontPointSize
         color: customStyle.fields.fontColor
         selectionColor: customStyle.fields.fontColor
         selectedTextColor: "#ffffff"
@@ -141,7 +141,7 @@ Item {
       text: Number(slider.value).toFixed(precision).toLocaleString(fieldItem.locale) + fieldItem.suffix
       verticalAlignment: Text.AlignVCenter
       horizontalAlignment: Text.AlignLeft
-      font.pixelSize: customStyle.fields.fontPixelSize
+      font.pointSize: customStyle.fields.fontPointSize
       color: customStyle.fields.fontColor
       padding: 10 * QgsQuick.Utils.dp
       leftPadding: customStyle.fields.sideMargin

--- a/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
@@ -28,7 +28,7 @@ Item {
 
   id: fieldItem
   enabled: !readOnly
-  height: childrenRect.height
+  height: Math.max(textField.height, textArea.height)
   anchors {
     left: parent.left
     right: parent.right

--- a/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
@@ -42,7 +42,7 @@ Item {
     visible: height !== 0
     anchors.left: parent.left
     anchors.right: parent.right
-    font.pixelSize: customStyle.fields.fontPixelSize
+    font.pointSize: customStyle.fields.fontPointSize
     color: customStyle.fields.fontColor
 
     text: value || ''
@@ -81,7 +81,7 @@ Item {
     visible: height !== 0
     anchors.left: parent.left
     anchors.right: parent.right
-    font.pixelSize: customStyle.fields.fontPixelSize
+    font.pointSize: customStyle.fields.fontPointSize
     wrapMode: Text.Wrap
     color: customStyle.fields.fontColor
     text: value || ''

--- a/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
@@ -32,7 +32,6 @@ Item {
   anchors {
     left: parent.left
     right: parent.right
-    rightMargin: 10 * QgsQuick.Utils.dp
   }
 
   TextField {

--- a/qgsquick/from_qgis/plugin/editor/qgsquickvaluemap.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickvaluemap.qml
@@ -32,7 +32,6 @@ Item {
   anchors {
     left: parent.left
     right: parent.right
-    rightMargin: 10 * QgsQuick.Utils.dp
   }
 
   QgsQuick.EditorWidgetComboBox {

--- a/qgsquick/from_qgis/plugin/editor/qgsquickvaluerelation.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickvaluerelation.qml
@@ -44,7 +44,6 @@ Item {
   anchors {
     left: parent.left
     right: parent.right
-    rightMargin: 10 * QgsQuick.Utils.dp
   }
 
   onCurrentFeatureLayerPairChanged: {

--- a/qgsquick/from_qgis/plugin/editor/qgsquickvaluerelation.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickvaluerelation.qml
@@ -168,7 +168,7 @@ Item {
       id: textField
       anchors.fill: parent
       readOnly: true
-      font.pixelSize: customStyle.fields.fontPixelSize
+      font.pointSize: customStyle.fields.fontPointSize
       color: customStyle.fields.fontColor
       topPadding: 10 * QgsQuick.Utils.dp
       bottomPadding: 10 * QgsQuick.Utils.dp

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -280,7 +280,6 @@ Item {
               color: !tabButton.enabled ? form.style.tabs.disabledColor : tabButton.down ||
                                           tabButton.checked ? form.style.tabs.activeColor : form.style.tabs.normalColor
               font.weight: tabButton.checked ? Font.DemiBold : Font.Normal
-              font.pointSize: form.style.tabs.tabLabelPointSize
 
               horizontalAlignment: Text.AlignHCenter
               verticalAlignment: Text.AlignVCenter
@@ -429,7 +428,7 @@ Item {
           }
 
           text: ConstraintDescription ? qsTr(ConstraintDescription) : ''
-          visible: !ConstraintHardValid || !ConstraintSoftValid
+          visible: (!ConstraintHardValid || !ConstraintSoftValid) && !!ConstraintDescription
           height: visible ? undefined : 0
           wrapMode: Text.WordWrap
           color: form.style.constraint.descriptionColor

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -280,6 +280,7 @@ Item {
               color: !tabButton.enabled ? form.style.tabs.disabledColor : tabButton.down ||
                                           tabButton.checked ? form.style.tabs.activeColor : form.style.tabs.normalColor
               font.weight: tabButton.checked ? Font.DemiBold : Font.Normal
+              font.pointSize: form.style.tabs.tabLabelPointSize
 
               horizontalAlignment: Text.AlignHCenter
               verticalAlignment: Text.AlignVCenter
@@ -631,7 +632,7 @@ Item {
             qsTr( 'View feature on <i>%1</i>' ).arg(layerName)
         }
         font.bold: true
-        font.pointSize:form.style.fields.fontPointSize
+        font.pointSize:form.style.titleLabelPointSize
         elide: Label.ElideRight
         horizontalAlignment: Qt.AlignHCenter
         verticalAlignment: Qt.AlignVCenter

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -391,15 +391,16 @@ Item {
       anchors {
         left: parent.left
         right: parent.right
-        leftMargin: 12 * QgsQuick.Utils.dp
+        leftMargin: form.style.fields.sideMargin
       }
 
       Label {
         id: fieldLabel
 
         text: Name ? qsTr(Name) : ''
-        font.bold: true
         color: ConstraintSoftValid && ConstraintHardValid ? form.style.constraint.validColor : form.style.constraint.invalidColor
+        leftPadding: form.style.fields.sideMargin
+        font.pointSize: 14 // TODO
       }
 
       Label {
@@ -408,6 +409,7 @@ Item {
           left: parent.left
           right: parent.right
           top: fieldLabel.bottom
+          leftMargin: form.style.fields.sideMargin
         }
 
         text: ConstraintDescription ? qsTr(ConstraintDescription) : ''

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -391,38 +391,57 @@ Item {
       anchors {
         left: parent.left
         right: parent.right
-        leftMargin: form.style.fields.sideMargin
+        leftMargin: form.style.fields.outerMargin
+        rightMargin: form.style.fields.outerMargin
       }
 
-      Label {
-        id: fieldLabel
-
-        text: Name ? qsTr(Name) : ''
-        color: ConstraintSoftValid && ConstraintHardValid ? form.style.constraint.validColor : form.style.constraint.invalidColor
-        leftPadding: form.style.fields.sideMargin
-        font.pointSize: 14 // TODO
-      }
-
-      Label {
-        id: constraintDescriptionLabel
+      Item {
+        id: labelPlaceholder
+        height: fieldLabel.height + constraintDescriptionLabel.height + 2 * form.style.fields.sideMargin
         anchors {
           left: parent.left
           right: parent.right
-          top: fieldLabel.bottom
-          leftMargin: form.style.fields.sideMargin
+          topMargin: form.style.fields.sideMargin
+          bottomMargin: form.style.fields.sideMargin
         }
 
-        text: ConstraintDescription ? qsTr(ConstraintDescription) : ''
-        visible: !ConstraintHardValid || !ConstraintSoftValid
-        height: visible ? undefined : 0
-        wrapMode: Text.WordWrap
-        color: form.style.constraint.descriptionColor
+        Label {
+          id: fieldLabel
+
+          text: Name ? qsTr(Name) : ''
+          color: ConstraintSoftValid && ConstraintHardValid ? form.style.constraint.validColor : form.style.constraint.invalidColor
+          leftPadding: form.style.fields.sideMargin
+          font.pointSize: form.style.fields.labelPointSize
+          horizontalAlignment: Text.AlignLeft
+          verticalAlignment: Text.AlignVCenter
+          anchors.topMargin: form.style.fields.sideMargin
+          anchors.top: parent.top
+        }
+
+        Label {
+          id: constraintDescriptionLabel
+          anchors {
+            left: parent.left
+            right: parent.right
+            top: fieldLabel.bottom
+            leftMargin: form.style.fields.sideMargin
+          }
+
+          text: ConstraintDescription ? qsTr(ConstraintDescription) : ''
+          visible: !ConstraintHardValid || !ConstraintSoftValid
+          height: visible ? undefined : 0
+          wrapMode: Text.WordWrap
+          color: form.style.constraint.descriptionColor
+          horizontalAlignment: Text.AlignLeft
+          verticalAlignment: Text.AlignVCenter
+        }
+
       }
 
       Item {
         id: placeholder
         height: childrenRect.height
-        anchors { left: parent.left; right: rememberCheckboxContainer.left; top: constraintDescriptionLabel.bottom }
+        anchors { left: parent.left; right: rememberCheckboxContainer.left; top: labelPlaceholder.bottom }
 
         Loader {
           id: attributeEditorLoader
@@ -503,7 +522,7 @@ Item {
         implicitHeight: placeholder.height
 
         anchors {
-          top: constraintDescriptionLabel.bottom
+          top: labelPlaceholder.bottom
           right: parent.right
         }
 
@@ -612,7 +631,7 @@ Item {
             qsTr( 'View feature on <i>%1</i>' ).arg(layerName)
         }
         font.bold: true
-        font.pointSize: 16
+        font.pointSize:form.style.fields.fontPointSize
         elide: Label.ElideRight
         horizontalAlignment: Qt.AlignHCenter
         verticalAlignment: Qt.AlignVCenter

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
@@ -20,6 +20,7 @@ import QgsQuick 0.1 as QgsQuick
 QtObject {
   property color backgroundColor: "white"
   property real backgroundOpacity: 1
+  property real titleLabelPointSize: 16
 
   property QtObject group: QtObject {
     property color backgroundColor: "lightGray"
@@ -45,6 +46,7 @@ QtObject {
     property real height: 48 * QgsQuick.Utils.dp
     property real buttonHeight: height * 0.8
     property real spacing: 0
+    property int tabLabelPointSize: 14
   }
 
   property QtObject constraint: QtObject {

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
@@ -72,8 +72,8 @@ QtObject {
       property real height: 48 * QgsQuick.Utils.dp
       property real cornerRadius: 0 * QgsQuick.Utils.dp
       property int fontPixelSize: 48 * QgsQuick.Utils.dp
-      property real sideMargin: 12 * QgsQuick.Utils.dp
-      property real outerlMargin: 20 * QgsQuick.Utils.dp
+      property real sideMargin: 12 * QgsQuick.Utils.dp // left or right margin for a field's content
+      property real outerMargin: 20 * QgsQuick.Utils.dp // left or right margin for a whole field component
       property int fontPointSize: 16
       property int labelPointSize: 14
     }

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
@@ -70,7 +70,7 @@ QtObject {
       property real height: 48 * QgsQuick.Utils.dp
       property real cornerRadius: 0 * QgsQuick.Utils.dp
       property int fontPixelSize: 48 * QgsQuick.Utils.dp
-
+      property real sideMargin: 12 * QgsQuick.Utils.dp
     }
 
   property QtObject icons: QtObject {

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
@@ -71,6 +71,9 @@ QtObject {
       property real cornerRadius: 0 * QgsQuick.Utils.dp
       property int fontPixelSize: 48 * QgsQuick.Utils.dp
       property real sideMargin: 12 * QgsQuick.Utils.dp
+      property real outerlMargin: 20 * QgsQuick.Utils.dp
+      property int fontPointSize: 16
+      property int labelPointSize: 14
     }
 
   property QtObject icons: QtObject {


### PR DESCRIPTION
Fixes:
- better horizontal and vertical spacing of the label above the fields
- better font for labels (not bold, not completely black, maybe a bit larger than it is now)
- better padding of content inside of widgets to align them horizontally with labels
- some hardcoded values replaced by configurable variables in the form styling
- Pixel and Point values for fonts and margin used from [Rado's design](https://www.dropbox.com/home/_Projects/input/graphic%20materials/2021-02/edit%20form?preview=_input_app_Edit_Feature_3-03.png). However, all numbers are devided by 2


closes #1146 