### PR TITLE
[Refactoring] Change MerginAPI - add listByNames API and request id

### DIFF
--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -1260,9 +1260,7 @@ void MerginApi::listProjectsReplyFinished( QString requestId )
 
   r->deleteLater();
 
-  Q_UNUSED( requestId )
-  //TODO: add requestId to signal
-  emit listProjectsFinished( mRemoteProjects, mTransactionalStatus, projectCount, requestedPage );
+  emit listProjectsFinished( mRemoteProjects, mTransactionalStatus, projectCount, requestedPage, requestId );
 }
 
 void MerginApi::listProjectsByNameReplyFinished( QString requestId )
@@ -1271,10 +1269,10 @@ void MerginApi::listProjectsByNameReplyFinished( QString requestId )
   Q_ASSERT( r );
 
   /* TODO: Detect orphaned project? Project that was considered Mergin but did not get info back */
+  MerginProjectList projectList;
 
   if ( r->error() == QNetworkReply::NoError )
   {
-    MerginProjectList projectList;
     QByteArray data = r->readAll();
     QJsonDocument json = QJsonDocument::fromJson( data );
 
@@ -1297,8 +1295,7 @@ void MerginApi::listProjectsByNameReplyFinished( QString requestId )
 
   r->deleteLater();
 
-  Q_UNUSED( requestId )
-  // TODO: emit signal with projects and requestId
+  emit listProjectsByNameFinished( projectList, mTransactionalStatus, requestId );
 }
 
 

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -177,7 +177,7 @@ struct MerginProjectListEntry // TODO: replace with RemoteProject from Project_f
 
 };
 
-typedef QList<MerginProjectListEntry> MerginProjectList;
+typedef QList<MerginProjectListEntry> MerginProjectList; // TODO: replace with RemoteProject from Project_future.h
 
 typedef QHash<QString, TransactionStatus> Transactions;
 
@@ -224,9 +224,13 @@ class MerginApi: public QObject
                                       const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral(), const int page = 1 );
 
     /**
+     * Sends non-blocking GET request to the server to listProjectsByName API. Response is handled in listProjectsByNameFinished
+     * method. Projects are parsed from response JSON.
      *
-     * \param projectnames
-     * \returns unique id of a request
+     * TODO: add info when error codes will be parsed
+     *
+     * \param projectNames QStringList of project full names (namespace/name)
+     * \returns unique id of a sent request
      */
     Q_INVOKABLE QString listProjectsByName( const QStringList &projectNames = QStringList() );
 
@@ -379,13 +383,13 @@ class MerginApi: public QObject
     QString apiRoot() const;
     void setApiRoot( const QString &apiRoot );
 
-    QString merginUserName() const;
+    QString merginUserName() const; // TODO: remove (use can be replaced with userInfo->username)
 
     //! Disk usage of current logged in user in Mergin instance in Bytes
     int diskUsage() const; // TODO: remove (no use)
 
     //! Total storage limit of current logged in user in Mergin instance in Bytes
-    int storageLimit() const;
+    int storageLimit() const; // TODO: remove (no use)
 
     MerginApiStatus::VersionStatus apiVersionStatus() const;
     void setApiVersionStatus( const MerginApiStatus::VersionStatus &apiVersionStatus );
@@ -400,8 +404,9 @@ class MerginApi: public QObject
   signals:
     void apiSupportsSubscriptionsChanged();
 
-    void listProjectsFinished( const MerginProjectList &merginProjects, Transactions pendingProjects, int projectCount, int page );
+    void listProjectsFinished( const MerginProjectList &merginProjects, Transactions pendingProjects, int projectCount, int page, QString requestId );
     void listProjectsFailed();
+    void listProjectsByNameFinished( const MerginProjectList &merginProjects, Transactions pendingProjects, QString requestId );
     void syncProjectFinished( const QString &projectDir, const QString &projectFullName, bool successfully = true );
     /**
      * Emitted when sync starts/finishes or the progress changes - useful to give a clue in the GUI about the status.
@@ -553,7 +558,7 @@ class MerginApi: public QObject
     QNetworkAccessManager mManager;
     QString mApiRoot;
     LocalProjectsManager &mLocalProjects;
-    MerginProjectList mRemoteProjects;
+    MerginProjectList mRemoteProjects; // TODO: remove (no use, only in tests - TBD)
     QString mDataDir; // dir with all projects
 
     MerginUserInfo *mUserInfo; //owned by this (qml grouped-properties)

--- a/app/merginapi.h
+++ b/app/merginapi.h
@@ -166,7 +166,7 @@ struct TransactionStatus
 };
 
 
-struct MerginProjectListEntry
+struct MerginProjectListEntry // TODO: replace with RemoteProject from Project_future.h
 {
   bool isValid() const { return !projectName.isEmpty() && !projectNamespace.isEmpty(); }
 
@@ -218,9 +218,17 @@ class MerginApi: public QObject
      * \param flag If defined, it is used to filter out projects tagged as 'created' or 'shared' with a authorized user
      * \param filterTag Name of tag that fetched projects have to have.
      * \param page Requested page of projects.
+     * \returns unique id of a request
      */
-    Q_INVOKABLE void listProjects( const QString &searchExpression = QStringLiteral(),
-                                   const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral(), const int page = 1 );
+    Q_INVOKABLE QString listProjects( const QString &searchExpression = QStringLiteral(),
+                                      const QString &flag = QStringLiteral(), const QString &filterTag = QStringLiteral(), const int page = 1 );
+
+    /**
+     *
+     * \param projectnames
+     * \returns unique id of a request
+     */
+    Q_INVOKABLE QString listProjectsByName( const QStringList &projectNames = QStringList() );
 
     /**
      * Sends non-blocking POST request to the server to download/update a project with a given name. On downloadProjectReplyFinished,
@@ -374,7 +382,7 @@ class MerginApi: public QObject
     QString merginUserName() const;
 
     //! Disk usage of current logged in user in Mergin instance in Bytes
-    int diskUsage() const;
+    int diskUsage() const; // TODO: remove (no use)
 
     //! Total storage limit of current logged in user in Mergin instance in Bytes
     int storageLimit() const;
@@ -424,7 +432,8 @@ class MerginApi: public QObject
     void projectDetached();
 
   private slots:
-    void listProjectsReplyFinished();
+    void listProjectsReplyFinished( QString requestId );
+    void listProjectsByNameReplyFinished( QString requestId );
 
     // Pull slots
     void updateInfoReplyFinished();
@@ -446,8 +455,8 @@ class MerginApi: public QObject
     void pingMerginReplyFinished();
 
   private:
-    MerginProjectList parseListProjectsMetadata( const QByteArray &data );
-    MerginProjectList parseProjectJsonArray( const QJsonArray &vArray );
+    MerginProjectListEntry parseProjectMetadata( const QJsonObject &project );
+    MerginProjectList parseProjectsFromJson( const QJsonDocument &object );
     static QStringList generateChunkIdsForSize( qint64 fileSize );
     QJsonArray prepareUploadChangesJSON( const QList<MerginFile> &files );
     static QString getApiKey( const QString &serverName );


### PR DESCRIPTION
Added:
 - Mergin API `listProjectsByName` that accepts list of projects (their names) and returns project info (same as in `listProjects` API)
 - RequestId that is returned from methods calling `listProjectsByName` and `listProjects` API. In future project model will compare this Id with its own to make sure projects list are not being overwritten (#1050)

Merging to Refactoring branch.
