### PR TITLE
[Refactoring] Structure - new classes

### DIFF
--- a/app/layersproxymodel.cpp
+++ b/app/layersproxymodel.cpp
@@ -14,7 +14,7 @@
 #include "qgsproject.h"
 #include "qgslayertree.h"
 
-LayersProxyModel::LayersProxyModel( LayersModel *model, ModelTypes modelType ) :
+LayersProxyModel::LayersProxyModel( LayersModel *model, LayerModelTypes modelType ) :
   mModelType( modelType ),
   mModel( model )
 {

--- a/app/layersproxymodel.h
+++ b/app/layersproxymodel.h
@@ -18,7 +18,7 @@
 
 #include "layersmodel.h"
 
-enum ModelTypes
+enum LayerModelTypes
 {
   ActiveLayerSelection,
   BrowseDataLayerSelection,
@@ -30,7 +30,7 @@ class LayersProxyModel : public QgsMapLayerProxyModel
     Q_OBJECT
 
   public:
-    LayersProxyModel( LayersModel *model, ModelTypes modelType = ModelTypes::AllLayers );
+    LayersProxyModel( LayersModel *model, LayerModelTypes modelType = LayerModelTypes::AllLayers );
 
     bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
 
@@ -63,7 +63,7 @@ class LayersProxyModel : public QgsMapLayerProxyModel
     //! filters if input layer is visible in current map theme
     bool layerVisible( QgsMapLayer *layer ) const;
 
-    ModelTypes mModelType;
+    LayerModelTypes mModelType;
     LayersModel *mModel;
 
     /**

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -367,8 +367,8 @@ int main( int argc, char *argv[] )
 
   // layer models
   LayersModel lm;
-  LayersProxyModel browseLpm( &lm, ModelTypes::BrowseDataLayerSelection );
-  LayersProxyModel recordingLpm( &lm, ModelTypes::ActiveLayerSelection );
+  LayersProxyModel browseLpm( &lm, LayerModelTypes::BrowseDataLayerSelection );
+  LayersProxyModel recordingLpm( &lm, LayerModelTypes::ActiveLayerSelection );
 
   ActiveLayer al;
   Loader loader( mtm, as, al );

--- a/app/merginprojectmodel.h
+++ b/app/merginprojectmodel.h
@@ -84,7 +84,7 @@ class MerginProjectModel: public QAbstractListModel
     int filterWriter() const; // TODO: remove, no use
     void setFilterWriter( int filterWriter );
 
-    QString searchExpression() const;
+    QString searchExpression() const; // TODO: remove, search will be in proxy model
     void setSearchExpression( const QString &searchExpression );
 
     int lastPage() const;

--- a/app/merginprojectmodel.h
+++ b/app/merginprojectmodel.h
@@ -78,10 +78,10 @@ class MerginProjectModel: public QAbstractListModel
     */
     void updateModel( const MerginProjectList &merginProjects, QHash<QString, TransactionStatus> pendingProjects, int expectedProjectCount, int page );
 
-    int filterCreator() const;
+    int filterCreator() const; // TODO: remove, no use
     void setFilterCreator( int filterCreator );
 
-    int filterWriter() const;
+    int filterWriter() const; // TODO: remove, no use
     void setFilterWriter( int filterWriter );
 
     QString searchExpression() const;

--- a/app/models/projectsmodel_future.cpp
+++ b/app/models/projectsmodel_future.cpp
@@ -1,0 +1,52 @@
+#include "projectsmodel_future.h"
+
+
+ProjectsModel_future::ProjectsModel_future(
+  MerginApi *merginApi,
+  ProjectModelTypes modelType,
+  LocalProjectsManager &localProjectsManager,
+  QObject *parent ) :
+  QAbstractListModel( parent ),
+  mBackend( merginApi ),
+  mLocalProjectsManager( localProjectsManager ),
+  mModelType( modelType )
+{
+  // TODO: connect to signals from LocalProjectsManager and MerginAPI
+}
+
+void ProjectsModel_future::listProjects()
+{
+  mLastRequestId = mBackend->listProjects( "", modelTypeToFlag(), "", mPopulatedPage );
+}
+
+void ProjectsModel_future::mergeProjects()
+{
+  QList<LocalProjectInfo> localProjects = mLocalProjectsManager.projects();
+}
+
+void ProjectsModel_future::listProjectsFinished()
+{
+  mergeProjects();
+}
+
+void ProjectsModel_future::projectSyncFinished()
+{
+
+}
+
+void ProjectsModel_future::projectSyncProgressChanged()
+{
+
+}
+
+QString ProjectsModel_future::modelTypeToFlag() const
+{
+  switch ( mModelType ) {
+    case MyProjectsModel:
+      return QStringLiteral( "created" );
+    case SharedProjectsModel:
+      return QStringLiteral( "shared" );
+    default:
+      return QStringLiteral( "" );
+  }
+}

--- a/app/models/projectsmodel_future.h
+++ b/app/models/projectsmodel_future.h
@@ -1,0 +1,84 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef PROJECTSMODEL_FUTURE_H
+#define PROJECTSMODEL_FUTURE_H
+
+#include <QAbstractListModel>
+#include <memory>
+
+#include "localprojectsmanager.h"
+#include "project_future.h"
+#include "merginapi.h"
+
+/**
+ * \brief The ProjectModelTypes enum
+ */
+enum ProjectModelTypes
+{
+  LocalProjectsModel = 0,
+  MyProjectsModel,
+  SharedProjectsModel,
+  ExploreProjectsModel,
+  RecentProjectsModel
+};
+
+/**
+ * \brief The ProjectsModel_future class
+ */
+class ProjectsModel_future : public QAbstractListModel
+{
+    Q_OBJECT
+
+  public:
+
+    enum Roles
+    {
+      Project = Qt::UserRole + 1
+    };
+    Q_ENUMS( Roles )
+
+    ProjectsModel_future( MerginApi *merginApi, ProjectModelTypes modelType, LocalProjectsManager &localProjectsManager, QObject *parent = nullptr );
+    ~ProjectsModel_future() override {};
+
+    // Needed methods from QAbstractListModel
+//    Q_INVOKABLE QVariant data( const QModelIndex &index, int role ) const override;
+//    Q_INVOKABLE QModelIndex index( int row, int column = 0, const QModelIndex &parent = QModelIndex() ) const override;
+//    QHash<int, QByteArray> roleNames() const override;
+//    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
+
+    //! Called to list projects, either fetch more or get first
+    Q_INVOKABLE void listProjects();
+
+    //! Method detecting local project for remote projects
+    void mergeProjects();
+
+  public slots:
+    void listProjectsFinished();
+    void projectSyncFinished();
+    void projectSyncProgressChanged();
+
+  private:
+
+    QString modelTypeToFlag() const;
+
+    MerginApi *mBackend;
+    LocalProjectsManager &mLocalProjectsManager;
+    QList<Project_future> mProjects;
+
+    ProjectModelTypes mModelType;
+
+    //! For pagination
+    int mPopulatedPage = -1;
+
+    //! For processing only my requests
+    QString mLastRequestId;
+};
+
+#endif // PROJECTSMODEL_FUTURE_H

--- a/app/models/projectsproxymodel_future.cpp
+++ b/app/models/projectsproxymodel_future.cpp
@@ -1,0 +1,14 @@
+#include "projectsproxymodel_future.h"
+
+ProjectsProxyModel_future::ProjectsProxyModel_future( ProjectModelTypes modelType, QObject *parent ) :
+  QSortFilterProxyModel( parent ),
+  mModelType( modelType )
+{
+
+}
+
+bool ProjectsProxyModel_future::filterAcceptsRow( int, const QModelIndex & ) const
+{
+  // return true if it passes search filter
+  return true;
+}

--- a/app/models/projectsproxymodel_future.h
+++ b/app/models/projectsproxymodel_future.h
@@ -1,0 +1,27 @@
+#ifndef PROJECTSPROXYMODEL_FUTURE_H
+#define PROJECTSPROXYMODEL_FUTURE_H
+
+#include <QObject>
+#include <QSortFilterProxyModel>
+
+#include "projectsmodel_future.h"
+
+/**
+ * @brief The ProjectsProxyModel_future class
+ */
+class ProjectsProxyModel_future : public QSortFilterProxyModel
+{
+    Q_OBJECT
+  public:
+    explicit ProjectsProxyModel_future( ProjectModelTypes modelType, QObject *parent = nullptr );
+    ~ProjectsProxyModel_future() override {};
+
+  protected:
+    bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const override;
+//    bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
+
+  private:
+    ProjectModelTypes mModelType;
+};
+
+#endif // PROJECTSPROXYMODEL_FUTURE_H

--- a/app/project_future.cpp
+++ b/app/project_future.cpp
@@ -1,0 +1,6 @@
+#include "project_future.h"
+
+Project_future::Project_future( QObject *parent ) : QObject( parent )
+{
+
+}

--- a/app/project_future.h
+++ b/app/project_future.h
@@ -1,0 +1,56 @@
+#ifndef PROJECT_FUTURE_H
+#define PROJECT_FUTURE_H
+
+#include <QObject>
+#include <QDateTime>
+
+enum ProjectStatus_future
+{
+  _NoVersion,  //!< the project is not available locally
+  _UpToDate,   //!< both server and local copy are in sync with no extra modifications
+  _OutOfDate,  //!< server has newer version than what is available locally (but the project is not modified locally)
+  _Modified,    //!< there are some local modifications in the project that need to be pushed (note: also server may have newer version)
+  _NonProjectItem      //!< only for mock projects, acts like a hook to enable extra functionality for models working with projects .
+  // TODO: replace _NonProjectItem with footer property in ListView
+  // TODO2: add orphaned state?
+};
+Q_ENUMS( ProjectStatus_future )
+
+struct RemoteProject
+{
+  QString projectName;
+  QString projectNamespace;
+
+  QString projectIdentifier() { return QString(); };
+
+  QDateTime serverUpdated; // available latest version of project files on server // TODO: maybe we do not need this at all
+
+  bool pending = false;
+  ProjectStatus_future status = ProjectStatus_future::_NoVersion;
+  qreal progress = 0;
+};
+
+
+struct MerginProject_deprecated
+{
+  QString projectName;
+  QString projectNamespace;
+  QString projectDir;  // full path to the project directory
+  QDateTime clientUpdated; // client's version of project files
+  QDateTime serverUpdated; // available latest version of project files on server
+  bool pending = false; // if there is a pending request for downlaod/update a project
+  ProjectStatus_future status = ProjectStatus_future::_NoVersion;
+  qreal progress = 0;  // progress in case of pending download/upload (values [0..1])
+};
+
+
+class Project_future : public QObject
+{
+    Q_OBJECT
+  public:
+  explicit Project_future( QObject *parent = nullptr );
+  ~Project_future() override {}
+
+};
+
+#endif // PROJECT_FUTURE_H

--- a/app/sources.pri
+++ b/app/sources.pri
@@ -30,6 +30,9 @@ variablesmanager.cpp \
 ios/iosimagepicker.cpp \
 ios/iosutils.cpp \
 inputprojutils.cpp \
+models/projectsproxymodel_future.cpp \
+models/projectsmodel_future.cpp \
+project_future.cpp \
 
 exists(merginsecrets.cpp) {
   message("Using production Mergin API_KEYS")
@@ -70,6 +73,9 @@ variablesmanager.h \
 ios/iosimagepicker.h \
 ios/iosutils.h \
 inputprojutils.h \
+models/projectsproxymodel_future.h \
+models/projectsmodel_future.h \
+project_future.h \
 
 contains(DEFINES, INPUT_TEST) {
 


### PR DESCRIPTION
Added classes with suffix `_future` for the sake of time (so that old version is still working). 

I though we could start separating code to subfolders - at least models from start, what do you think?

There are basically three classes, it might look messy right now, but the idea is:
 - `ProjectsModel_future` will contain QList of `Project_future` (either struct or object)
 - `ProjectProxyModel_future` handles search
 - `MerginApi` will have no idea about `projectModels` nor (probably) `localProjectManager`, it will just emit signals
 - `Project_future` can be a GUI type (registered for QML) and offer all necessary information 