### PR TITLE
Relocated save button from Feature form toolbar to header

### DIFF
--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -155,6 +155,7 @@ Drawer {
             Text {
                 id: saveButtonText
                 text: qsTr("Save")
+                visible: featureForm.state === "Edit" || featureForm.state === "Add"
                 enabled: featureForm.model.constraintsHardValid
                 color: enabled ? InputStyle.highlightColor : "red"
                 font.pixelSize: InputStyle.fontPixelSizeNormal
@@ -349,11 +350,11 @@ Drawer {
           title: qsTr( "Uncommited changes" )
           text: qsTr( "Do you want to save changes?" )
           icon: StandardIcon.Warning
-          standardButtons: StandardButton.Ok | StandardButton.No | StandardButton.Cancel
+          standardButtons: StandardButton.Yes | StandardButton.No | StandardButton.Cancel
 
           //! Using onButtonClicked instead of onAccepted,onRejected which have been called twice
           onButtonClicked: {
-              if (clickedButton === StandardButton.Ok) {
+              if (clickedButton === StandardButton.Yes) {
                 featureForm.save()
               }
               else if (clickedButton === StandardButton.No) {

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -347,7 +347,7 @@ Drawer {
         MessageDialog {
           id: saveChangesDialog
           visible: false
-          title: qsTr( "Uncommited changes" )
+          title: qsTr( "Unsaved changes" )
           text: qsTr( "Do you want to save changes?" )
           icon: StandardIcon.Warning
           standardButtons: StandardButton.Yes | StandardButton.No | StandardButton.Cancel

--- a/app/qml/FeatureToolbar.qml
+++ b/app/qml/FeatureToolbar.qml
@@ -14,11 +14,8 @@ import "."  // import InputStyle singleton
 Item {
     property int itemSize: toolbar.height * 0.8
     property bool isFeaturePoint: false
-    property bool saveBtnEnabled: true
 
     signal editClicked()
-    signal saveClicked()
-    signal addPhotoClicked()
     signal deleteClicked()
     signal editGeometryClicked()
 
@@ -90,22 +87,6 @@ Item {
                     toolbar.deleteClicked()
                 }
             }
-        }
-
-        Item {
-            width: parent.width/parent.children.length
-            height: parent.height
-
-            MainPanelButton {
-
-                width: toolbar.itemSize
-                text: qsTr("Save")
-                imageSource: InputStyle.checkIcon
-                enabled: toolbar.saveBtnEnabled
-
-                onActivated: toolbar.saveClicked()
-            }
-
         }
 
         Item {

--- a/app/qml/PanelHeader.qml
+++ b/app/qml/PanelHeader.qml
@@ -17,8 +17,11 @@ Rectangle {
 
     property real rowHeight
     property string titleText: ""
+    property string backText: qsTr("Back")
     property bool withBackButton: true
     property bool backTextVisible: true
+    property bool backIconVisible: true
+    property color fontBtnColor: InputStyle.fontColorBright
 
     signal back()
 
@@ -33,7 +36,7 @@ Rectangle {
 
         Image {
             id: image
-            height: InputStyle.fontPixelSizeNormal
+            height: backIconVisible ? InputStyle.fontPixelSizeNormal : 0
             width: height
             source: "back.svg"
             sourceSize.width: width
@@ -43,18 +46,20 @@ Rectangle {
             anchors.topMargin: anchors.bottomMargin
             anchors.left: parent.left
             anchors.verticalCenter: parent.verticalCenter
+            visible: false
         }
 
         ColorOverlay {
             anchors.fill: image
             source: image
             color: InputStyle.fontColorBright
+            visible: header.backIconVisible
         }
 
         Text {
             id: backButtonText
-            text: qsTr("Back")
-            color: InputStyle.fontColorBright
+            text: header.backText
+            color: header.fontBtnColor
             font.pixelSize: InputStyle.fontPixelSizeNormal
             height: header.rowHeight
             verticalAlignment: Text.AlignVCenter
@@ -63,7 +68,7 @@ Rectangle {
             anchors.right: parent.right
             anchors.bottom: parent.bottom
             anchors.top: parent.top
-            anchors.leftMargin: header.rowHeight/4
+            anchors.leftMargin: backIconVisible ? header.rowHeight/4 : 0
             visible: ((title.contentWidth + backButton.width * 2) > header.width) || !backTextVisible ? false : true
         }
 

--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
@@ -18,6 +18,7 @@
 #include "qgsvectorlayer.h"
 
 #include "qgsquickattributemodel.h"
+#include "qgsvectorlayereditbuffer.h"
 
 QgsQuickAttributeModel::QgsQuickAttributeModel( QObject *parent )
   : QAbstractListModel( parent )
@@ -348,6 +349,11 @@ void QgsQuickAttributeModel::create()
   commit();
 
   emit featureCreated( mFeatureLayerPair.featureRef() );
+}
+
+bool QgsQuickAttributeModel::hasAnyChanges()
+{
+  return mFeatureLayerPair.feature().id() < 0 || mFeatureLayerPair.layer()->editBuffer()->isFeatureAttributesChanged( mFeatureLayerPair.feature().id() );
 }
 
 bool QgsQuickAttributeModel::commit()

--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
@@ -353,7 +353,7 @@ void QgsQuickAttributeModel::create()
 
 bool QgsQuickAttributeModel::hasAnyChanges()
 {
-  return mFeatureLayerPair.feature().id() < 0 || mFeatureLayerPair.layer()->editBuffer()->isFeatureAttributesChanged( mFeatureLayerPair.feature().id() );
+  return FID_IS_NULL( mFeatureLayerPair.feature().id() ) || mFeatureLayerPair.layer()->editBuffer()->isFeatureAttributesChanged( mFeatureLayerPair.feature().id() );
 }
 
 bool QgsQuickAttributeModel::commit()

--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.h
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.h
@@ -112,6 +112,9 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Adds feature from featureLayerPair to the layer
     Q_INVOKABLE void create();
 
+    //! Returns true if a current feature is new or has uncomitted attribute changes. Geometry change is omitted.
+    Q_INVOKABLE bool hasAnyChanges();
+
     /**
      * Suppress layer's QgsEditFormConfig
      *

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -193,6 +193,10 @@ Item {
     saved()
   }
 
+  function hasAnyChanges() {
+    return form.model.attributeModel.hasAnyChanges()
+  }
+
   /**
     * Forward change about remembering values to model
     */


### PR DESCRIPTION
* save button turned red if hard constrain are not met (similar to how was it before when save button was disabled in this case)
* added check if a feature has been changed - either if is newly created or edit buffer has uncommitted changes for the feature. Note that saving geometry is committed immediately after geometry edit, therefore was omitted for this function. This also effects attributes changed before geometry has been changed and committed.
* Cancel discard changes
* Save saves all changes
* Back button throws a dialog to choose action

Feel free to comment on how checking uncommitted changes should work or any uix related issues.

<img width="375" alt="Screenshot 2021-02-25 at 14 34 37" src="https://user-images.githubusercontent.com/6735606/109161863-d6978580-7777-11eb-922e-324a70a7984d.png">

closes #384
closed #445