### PR TITLE
Minor UI Fixes

### DIFF
--- a/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
@@ -44,6 +44,8 @@ Item {
     anchors.right: parent.right
     font.pointSize: customStyle.fields.fontPointSize
     color: customStyle.fields.fontColor
+    leftPadding: customStyle.fields.sideMargin
+    rightPadding: customStyle.fields.sideMargin
 
     text: value || ''
     inputMethodHints: field.isNumeric || widget == 'Range' ? field.precision === 0 ? Qt.ImhDigitsOnly : Qt.ImhFormattedNumbersOnly : Qt.ImhNone
@@ -86,6 +88,8 @@ Item {
     color: customStyle.fields.fontColor
     text: value || ''
     textFormat: config['UseHtml'] ? TextEdit.RichText : TextEdit.PlainText
+    leftPadding: customStyle.fields.sideMargin
+    rightPadding: customStyle.fields.sideMargin
 
     onLinkActivated: Qt.openUrlExternally(link)
 

--- a/qgsquick/from_qgis/plugin/editor/qgsquickvaluerelation.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickvaluerelation.qml
@@ -173,6 +173,7 @@ Item {
       color: customStyle.fields.fontColor
       topPadding: 10 * QgsQuick.Utils.dp
       bottomPadding: 10 * QgsQuick.Utils.dp
+      leftPadding: customStyle.fields.sideMargin
 
       MouseArea {
         anchors.fill: parent

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -371,6 +371,11 @@ Item {
             }
 
             delegate: fieldItem
+
+            footer: Rectangle {
+              opacity: 1
+              height: 15 * QgsQuick.Utils.dp
+            }
           }
         }
       }

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -523,7 +523,7 @@ Item {
         id: rememberCheckboxContainer
         visible: form.allowRememberAttribute && form.state === "Add" && EditorWidget !== "Hidden"
 
-        implicitWidth: visible ? 40 * QgsQuick.Utils.dp : 0
+        implicitWidth: visible ? 35 * QgsQuick.Utils.dp : 0
         implicitHeight: placeholder.height
 
         anchors {
@@ -538,8 +538,8 @@ Item {
 
           implicitWidth: 40 * QgsQuick.Utils.dp
           implicitHeight: width
-          x: -5 // hack to get over placeholder spacing
           y: rememberCheckboxContainer.height/2 - rememberCheckbox.height/2
+          x: (parent.width + form.style.fields.outerMargin) / 7
 
           onCheckboxClicked: RememberValue = buttonState
           checked: RememberValue ? true : false


### PR DESCRIPTION
- Centered last value checkboxes in new form layout
- Text widget and value relation widget starting position fixed
- Added space after last widget

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/22449698/109349661-9cf97400-7876-11eb-88fa-ddcdd1d75449.jpg" width="300"/></td>
    <td><img src="https://user-images.githubusercontent.com/22449698/109349156-c9f95700-7875-11eb-8e41-19dbca57460a.jpg"  width="300"/></td>
  </tr>
 </table>

Based on https://lutraconsulting.slack.com/archives/CC95JK1T9/p1614350655028200
