### PR TITLE
Reset old references on project reload

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -738,6 +738,11 @@ ApplicationWindow {
         target: __loader
         onLoadingStarted: projectLoadingScreen.visible = true
         onLoadingFinished: projectLoadingScreen.visible = false
+        onProjectReloaded: {
+          // clear all previous references to old project
+          highlight.featureLayerPair = null
+          digitizingHighlight.featureLayerPair = null
+        }
     }
 
     ProjectLoadingScreen {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -739,7 +739,8 @@ ApplicationWindow {
         onLoadingStarted: projectLoadingScreen.visible = true
         onLoadingFinished: projectLoadingScreen.visible = false
         onProjectReloaded: {
-          // clear all previous references to old project
+          // clear all previous references to old project (if we don't clear references to the previous project,
+          // highlights may end up with dangling pointers to map layers and cause crashes)
           highlight.featureLayerPair = null
           digitizingHighlight.featureLayerPair = null
         }


### PR DESCRIPTION
There were leftover references to old project when new one was loaded. This led to application crash on different places.

Resolves #1204 