### PR TITLE
Fix sed error when running update_all_versions.bash

### DIFF
--- a/scripts/update_all_versions.bash
+++ b/scripts/update_all_versions.bash
@@ -17,23 +17,23 @@ echo "using version $MAJOR.$MINOR.$BUILD"
 IOS_FILE=$DIR/../app/ios/Info.plist
 echo "patching $IOS_FILE"
 
-sed -i .orig -E "s|<string>[0-9]+\\.[0-9]+\\.[0-9]+<\\/string>|<string>$VERSION<\\/string>|g" $IOS_FILE
+sed -i.orig -E "s|<string>[0-9]+\\.[0-9]+\\.[0-9]+<\\/string>|<string>$VERSION<\\/string>|g" $IOS_FILE
 rm -f $IOS_FILE.orig
 
 # android: app/version.pri
 ANDROID_FILE=$DIR/../app/version.pri
 echo "patching $ANDROID_FILE"
-sed -i .orig -E "s|VERSION_MAJOR = [0-9]+|VERSION_MAJOR = $MAJOR|g" $ANDROID_FILE
-sed -i .orig -E "s|VERSION_MINOR = [0-9]+|VERSION_MINOR = $MINOR|g" $ANDROID_FILE
-sed -i .orig -E "s|VERSION_FIX   = [0-9]+|VERSION_FIX   = $BUILD|g" $ANDROID_FILE
+sed -i.orig -E "s|VERSION_MAJOR = [0-9]+|VERSION_MAJOR = $MAJOR|g" $ANDROID_FILE
+sed -i.orig -E "s|VERSION_MINOR = [0-9]+|VERSION_MINOR = $MINOR|g" $ANDROID_FILE
+sed -i.orig -E "s|VERSION_FIX   = [0-9]+|VERSION_FIX   = $BUILD|g" $ANDROID_FILE
 rm -f $ANDROID_FILE.orig
 
 # win: scripts/version.cmd
 WIN_FILE=$DIR/version.cmd
 echo "patching $WIN_FILE"
-sed -i .orig -E "s|VERSIONMAJOR=[0-9]+|VERSIONMAJOR=$MAJOR|g" $WIN_FILE
-sed -i .orig -E "s|VERSIONMINOR=[0-9]+|VERSIONMINOR=$MINOR|g" $WIN_FILE
-sed -i .orig -E "s|VERSIONBUILD=[0-9]+|VERSIONBUILD=$BUILD|g" $WIN_FILE
+sed -i.orig -E "s|VERSIONMAJOR=[0-9]+|VERSIONMAJOR=$MAJOR|g" $WIN_FILE
+sed -i.orig -E "s|VERSIONMINOR=[0-9]+|VERSIONMINOR=$MINOR|g" $WIN_FILE
+sed -i.orig -E "s|VERSIONBUILD=[0-9]+|VERSIONBUILD=$BUILD|g" $WIN_FILE
 rm -f $WIN_FILE.orig
 
 echo "patching done"


### PR DESCRIPTION
It looks like `sed` on linux does not like the space between `-i` and its value:
```
sed: -e expression #1, char 1: unknown command: `.'
```
This fixes it. @PeterPetrik can you check if the script still works for you on :apple: ?