### PR TITLE
Feature form tab styling

### DIFF
--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -233,10 +233,12 @@ Drawer {
                   property color normalBackgroundColor: InputStyle.panelBackgroundLight
                   property color activeBackgroundColor: InputStyle.panelBackgroundLight
                   property color disabledBackgroundColor: InputStyle.panelBackgroundDark
-                  property real height: InputStyle.rowHeight
+                  property real height: InputStyle.rowHeight * 0.9
                   property real buttonHeight: height
                   property real spacing: 0
                   property int tabLabelPointSize: 12
+                  property real borderWidth: 1 * QgsQuick.Utils.dp
+                  property color borderColor: InputStyle.labelColor
                 }
 
                 property QtObject constraint: QtObject {

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -229,13 +229,13 @@ Drawer {
                   property color normalColor: InputStyle.fontColor
                   property color activeColor: InputStyle.fontColor
                   property color disabledColor: InputStyle.fontColor
-                  property color backgroundColor: InputStyle.panelBackgroundDark
+                  property color backgroundColor: InputStyle.panelBackgroundLight
                   property color normalBackgroundColor: InputStyle.panelBackgroundLight
-                  property color activeBackgroundColor: "#FFFFFF"
+                  property color activeBackgroundColor: InputStyle.panelBackgroundLight
                   property color disabledBackgroundColor: InputStyle.panelBackgroundDark
-                  property real height: 48 * QgsQuick.Utils.dp
-                  property real buttonHeight: height * 0.8
-                  property real spacing: 5 * QgsQuick.Utils.dp
+                  property real height: InputStyle.rowHeight
+                  property real buttonHeight: height
+                  property real spacing: 0
                   property int tabLabelPointSize: 12
                 }
 

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -262,6 +262,8 @@ Item {
       anchors {
         left: parent.left
         right: parent.right
+        leftMargin: form.style.fields.outerMargin
+        rightMargin: form.style.fields.outerMargin
       }
       height: form.model.hasTabs ? tabRow.height : 0
 
@@ -312,7 +314,10 @@ Item {
               text: tabButton.text
               color: !tabButton.enabled ? form.style.tabs.disabledColor : tabButton.down ||
                                           tabButton.checked ? form.style.tabs.activeColor : form.style.tabs.normalColor
-              font.weight: tabButton.checked ? Font.DemiBold : Font.Normal
+              font.weight: Font.DemiBold
+              font.underline: tabButton.checked ? true : false
+              font.pointSize: form.style.tabs.tabLabelPointSize
+              opacity: tabButton.checked ? 1 : 0.5
 
               horizontalAlignment: Text.AlignHCenter
               verticalAlignment: Text.AlignVCenter
@@ -412,6 +417,21 @@ Item {
           }
         }
       }
+    }
+
+    // Borders
+    Rectangle {
+      width: parent.width
+      height: form.style.tabs.borderWidth
+      anchors.top: flickable.top
+      color: form.style.tabs.borderColor
+    }
+
+    Rectangle {
+      width: parent.width
+      height: form.style.tabs.borderWidth
+      anchors.bottom: flickable.bottom
+      color: form.style.tabs.borderColor
     }
   }
 

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
@@ -74,8 +74,8 @@ QtObject {
       property int fontPixelSize: 48 * QgsQuick.Utils.dp
       property real sideMargin: 12 * QgsQuick.Utils.dp // left or right margin for a field's content
       property real outerMargin: 20 * QgsQuick.Utils.dp // left or right margin for a whole field component
-      property int fontPointSize: 16 * QgsQuick.Utils.dp
-      property int labelPointSize: 14 * QgsQuick.Utils.dp
+      property int fontPointSize: 16
+      property int labelPointSize: 14
     }
 
   property QtObject icons: QtObject {

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureformstyling.qml
@@ -47,6 +47,8 @@ QtObject {
     property real buttonHeight: height * 0.8
     property real spacing: 0
     property int tabLabelPointSize: 14
+    property real borderWidth: 0 * QgsQuick.Utils.dp
+    property color borderColor: "#999999"
   }
 
   property QtObject constraint: QtObject {


### PR DESCRIPTION
* border tab has the same color as labels (color picker shows me some weird color from the design image on dropbox - #7A7368)
* from a design, the tab toolbar's height seems to be the same as the one header has. However, now is set to 90% of the rowHeight. This ratio is rather random though, couldn't find any reference about its height.

Generally, fonts have to be adjusted to Rado's design.

closes #1151 
![IMG_863AAC526DB3-1](https://user-images.githubusercontent.com/6735606/109823416-338fb180-7c38-11eb-9926-3f8ab1ab2540.jpeg)
