### PR TITLE
Reset features list model when project is reloaded

### DIFF
--- a/qgsquick/from_qgis/qgsquickfeatureslistmodel.cpp
+++ b/qgsquick/from_qgis/qgsquickfeatureslistmodel.cpp
@@ -21,6 +21,7 @@ QgsQuickFeaturesListModel::QgsQuickFeaturesListModel( QObject *parent )
   : QAbstractListModel( parent ),
     mCurrentLayer( nullptr )
 {
+  QObject::connect( QgsProject::instance(), &QgsProject::cleared, this, &QgsQuickFeaturesListModel::emptyData );
 }
 
 QgsQuickFeaturesListModel::~QgsQuickFeaturesListModel() = default;

--- a/qgsquick/from_qgis/qgsquickfeatureslistmodel.cpp
+++ b/qgsquick/from_qgis/qgsquickfeatureslistmodel.cpp
@@ -21,6 +21,7 @@ QgsQuickFeaturesListModel::QgsQuickFeaturesListModel( QObject *parent )
   : QAbstractListModel( parent ),
     mCurrentLayer( nullptr )
 {
+  // avoid dangling pointers to mCurrentLayer/mCurrentFeature when switching projects
   QObject::connect( QgsProject::instance(), &QgsProject::cleared, this, &QgsQuickFeaturesListModel::emptyData );
 }
 


### PR DESCRIPTION
Another dangling pointer found. `mCurrentLayer` and `mCurrentFeature` not being reset when project gets reloaded.

Added handler for `QgsProject::cleared` signal, is this good approach @wonder-sk?