### PR TITLE
Not visible value map/ value relation

### DIFF
--- a/qgsquick/from_qgis/plugin/editor/qgsquickeditorwidgetcombobox.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickeditorwidgetcombobox.qml
@@ -83,7 +83,8 @@ ComboBox {
   // [/hidpi fixes]
 
   indicator: Item {
-    anchors.fill: parent
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
 
     Image {
       id: comboboxIndicatorIcon


### PR DESCRIPTION
In special scenarios value map and value relation fields did not show text. The reason was that new icons were consuming all the place in widget.

Resolves #1231 