### PR TITLE
Range widget ui fixes

### DIFF
--- a/qgsquick/from_qgis/plugin/editor/qgsquickrange.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickrange.qml
@@ -72,7 +72,7 @@ Item {
         anchors.fill: parent
         border.color: customStyle.fields.normalColor
         border.width: 1 * QgsQuick.Utils.dp
-        color: fieldItem.enabled ? "#ffffff" : customStyle.fields.backgroundColor
+        color: customStyle.fields.backgroundColor
         radius: customStyle.fields.cornerRadius
       }
 
@@ -122,13 +122,43 @@ Item {
         inputMethodHints: Qt.ImhFormattedNumbersOnly
       }
 
-      Component.onCompleted: {
-        up.indicator.color = customStyle.fields.backgroundColor
-        up.indicator.radius = customStyle.fields.cornerRadius
-        down.indicator.radius = customStyle.fields.cornerRadius
-        down.indicator.color = customStyle.fields.backgroundColor
-      }
+      down.indicator: Rectangle {
+              x: spinbox.mirrored ? parent.width - width: 0
+              height: parent.height
+              implicitWidth: parent.height
+              implicitHeight: parent.height
+              color: customStyle.fields.backgroundColor
+              radius: customStyle.fields.cornerRadius
 
+              Text {
+                  text: "-"
+                  font.pixelSize: spinbox.font.pixelSize * 2
+                  color: fieldItem.enabled ? customStyle.fields.fontColor : customStyle.toolbutton.backgroundColorInvalid
+                  anchors.fill: parent
+                  fontSizeMode: Text.Fit
+                  horizontalAlignment: Text.AlignHCenter
+                  verticalAlignment: Text.AlignVCenter
+              }
+          }
+
+      up.indicator: Rectangle {
+              x: spinbox.mirrored ? 0 : parent.width - width
+              height: parent.height
+              implicitWidth: parent.height
+              implicitHeight: parent.height
+              color: customStyle.fields.backgroundColor
+              radius: customStyle.fields.cornerRadius
+
+              Text {
+                  text: "+"
+                  font.pixelSize: spinbox.font.pixelSize * 2
+                  color: fieldItem.enabled ? customStyle.fields.fontColor : customStyle.toolbutton.backgroundColorInvalid
+                  anchors.fill: parent
+                  fontSizeMode: Text.Fit
+                  horizontalAlignment: Text.AlignHCenter
+                  verticalAlignment: Text.AlignVCenter
+              }
+          }
     }
 
     // Slider
@@ -173,8 +203,18 @@ Item {
         width: slider.availableWidth
         height: implicitHeight
         radius: 2 * QgsQuick.Utils.dp
-        color:  fieldItem.enabled ? customStyle.fields.fontColor : customStyle.fields.backgroundColorInactive
+        color: fieldItem.enabled ? customStyle.fields.fontColor : customStyle.fields.backgroundColorInactive
       }
+
+      handle: Rectangle {
+              x: slider.leftPadding + slider.visualPosition * (slider.availableWidth - width)
+              y: slider.topPadding + slider.availableHeight / 2 - height / 2
+              implicitWidth: slider.height * 0.5
+              implicitHeight: implicitWidth
+              radius: height * 0.5
+              color: "white"
+              border.color: customStyle.fields.backgroundColorInactive
+          }
     }
   }
 

--- a/qgsquick/from_qgis/plugin/editor/qgsquickrange.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickrange.qml
@@ -132,11 +132,13 @@ Item {
 
               Text {
                   text: "-"
+                  height: parent.height
                   font.pixelSize: spinbox.font.pixelSize * 2
-                  color: fieldItem.enabled ? customStyle.fields.fontColor : customStyle.toolbutton.backgroundColorInvalid
-                  anchors.fill: parent
+                  font.bold: true
                   fontSizeMode: Text.Fit
-                  horizontalAlignment: Text.AlignHCenter
+                  color: fieldItem.enabled ? customStyle.fields.fontColor : customStyle.toolbutton.backgroundColorInvalid
+                  leftPadding: customStyle.fields.sideMargin
+                  horizontalAlignment: Text.AlignLeft
                   verticalAlignment: Text.AlignVCenter
               }
           }
@@ -151,11 +153,14 @@ Item {
 
               Text {
                   text: "+"
+                  height: parent.height
                   font.pixelSize: spinbox.font.pixelSize * 2
-                  color: fieldItem.enabled ? customStyle.fields.fontColor : customStyle.toolbutton.backgroundColorInvalid
-                  anchors.fill: parent
+                  font.bold: true
                   fontSizeMode: Text.Fit
-                  horizontalAlignment: Text.AlignHCenter
+                  color: fieldItem.enabled ? customStyle.fields.fontColor : customStyle.toolbutton.backgroundColorInvalid
+                  anchors.right: parent.right
+                  rightPadding: customStyle.fields.sideMargin
+                  horizontalAlignment: Text.AlignRight
                   verticalAlignment: Text.AlignVCenter
               }
           }
@@ -209,7 +214,7 @@ Item {
       handle: Rectangle {
               x: slider.leftPadding + slider.visualPosition * (slider.availableWidth - width)
               y: slider.topPadding + slider.availableHeight / 2 - height / 2
-              implicitWidth: slider.height * 0.5
+              implicitWidth: slider.height * 0.6 * 0.66 + (2 * border.width) // Similar to indicator QgsQuick.SwitchWidget of CheckBox widget
               implicitHeight: implicitWidth
               radius: height * 0.5
               color: "white"


### PR DESCRIPTION
Would be good to introduce a variable for custom indicator height (checkbox, slider)

Disabled form:
<img width="449" alt="Screenshot 2021-03-08 at 12 34 51" src="https://user-images.githubusercontent.com/6735606/110316589-3ceb9600-800b-11eb-9b12-665f9122eeac.png">

Enabled form:
<img width="449" alt="Screenshot 2021-03-08 at 16 10 09" src="https://user-images.githubusercontent.com/6735606/110339909-f7d65c80-8028-11eb-9788-f077c5fccb91.png">

closes #1023 