### PR TITLE
Landscape for settings + link to Mergin Terms

### DIFF
--- a/app/inputhelp.cpp
+++ b/app/inputhelp.cpp
@@ -76,6 +76,11 @@ QString InputHelp::howToSetupProj() const
   return inputHelpRoot + "/howto/proj";
 }
 
+QString InputHelp::merginTermsLink() const
+{
+  return "https://public.cloudmergin.com/assets/mergin_terms_of_service.pdf";
+}
+
 bool InputHelp::submitReportPending() const
 {
   return mSubmitReportPending;

--- a/app/inputhelp.cpp
+++ b/app/inputhelp.cpp
@@ -31,6 +31,11 @@ InputHelp::InputHelp( MerginApi *merginApi, InputUtils *utils ):
   emit linkChanged();
 }
 
+QString InputHelp::helpRootLink() const
+{
+  return inputHelpRoot;
+}
+
 QString InputHelp::privacyPolicyLink() const
 {
   return inputHelpRoot + "/privacy";

--- a/app/inputhelp.cpp
+++ b/app/inputhelp.cpp
@@ -78,7 +78,7 @@ QString InputHelp::howToSetupProj() const
 
 QString InputHelp::merginTermsLink() const
 {
-  return "https://public.cloudmergin.com/assets/mergin_terms_of_service.pdf";
+  return QStringLiteral( "https://public.cloudmergin.com/assets/mergin_terms_of_service.pdf" );
 }
 
 bool InputHelp::submitReportPending() const

--- a/app/inputhelp.h
+++ b/app/inputhelp.h
@@ -30,6 +30,7 @@ class InputHelp: public QObject
     Q_PROPERTY( QString howToCreateNewProjectLink READ howToCreateNewProjectLink NOTIFY linkChanged )
     Q_PROPERTY( QString howToDownloadProjectLink READ howToDownloadProjectLink NOTIFY linkChanged )
     Q_PROPERTY( QString howToSetupProj READ howToSetupProj NOTIFY linkChanged )
+    Q_PROPERTY( QString merginTermsLink READ merginTermsLink NOTIFY linkChanged )
 
     Q_PROPERTY( bool submitReportPending READ submitReportPending NOTIFY submitReportPendingChanged )
 
@@ -52,6 +53,7 @@ class InputHelp: public QObject
     QString howToCreateNewProjectLink() const;
     QString howToDownloadProjectLink() const;
     QString howToSetupProj() const;
+    QString merginTermsLink() const;
 
     bool submitReportPending() const;
     /**

--- a/app/inputhelp.h
+++ b/app/inputhelp.h
@@ -22,7 +22,7 @@ class InputHelp: public QObject
     Q_OBJECT
 
     Q_PROPERTY( QString privacyPolicyLink READ privacyPolicyLink NOTIFY linkChanged )
-    Q_PROPERTY( QString helpRootLink READ helpRootLink NOTIFY linkChanged )
+    Q_PROPERTY( QString helpRootLink READ helpRootLink )
     Q_PROPERTY( QString merginSubscriptionDetailsLink READ merginSubscriptionDetailsLink NOTIFY linkChanged )
     Q_PROPERTY( QString howToEnableDigitizingLink READ howToEnableDigitizingLink NOTIFY linkChanged )
     Q_PROPERTY( QString howToEnableBrowsingDataLink READ howToEnableBrowsingDataLink NOTIFY linkChanged )
@@ -30,7 +30,7 @@ class InputHelp: public QObject
     Q_PROPERTY( QString howToCreateNewProjectLink READ howToCreateNewProjectLink NOTIFY linkChanged )
     Q_PROPERTY( QString howToDownloadProjectLink READ howToDownloadProjectLink NOTIFY linkChanged )
     Q_PROPERTY( QString howToSetupProj READ howToSetupProj NOTIFY linkChanged )
-    Q_PROPERTY( QString merginTermsLink READ merginTermsLink NOTIFY linkChanged )
+    Q_PROPERTY( QString merginTermsLink READ merginTermsLink )
 
     Q_PROPERTY( bool submitReportPending READ submitReportPending NOTIFY submitReportPendingChanged )
 

--- a/app/inputhelp.h
+++ b/app/inputhelp.h
@@ -22,6 +22,7 @@ class InputHelp: public QObject
     Q_OBJECT
 
     Q_PROPERTY( QString privacyPolicyLink READ privacyPolicyLink NOTIFY linkChanged )
+    Q_PROPERTY( QString helpRootLink READ helpRootLink NOTIFY linkChanged )
     Q_PROPERTY( QString merginSubscriptionDetailsLink READ merginSubscriptionDetailsLink NOTIFY linkChanged )
     Q_PROPERTY( QString howToEnableDigitizingLink READ howToEnableDigitizingLink NOTIFY linkChanged )
     Q_PROPERTY( QString howToEnableBrowsingDataLink READ howToEnableBrowsingDataLink NOTIFY linkChanged )
@@ -42,6 +43,7 @@ class InputHelp: public QObject
   public:
     explicit InputHelp( MerginApi *merginApi, InputUtils *utils );
 
+    QString helpRootLink() const;
     QString privacyPolicyLink() const;
     QString merginSubscriptionDetailsLink() const;
     QString howToEnableDigitizingLink() const;

--- a/app/qml/AboutPanel.qml
+++ b/app/qml/AboutPanel.qml
@@ -12,119 +12,134 @@ import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.3
 import QtQuick.Dialogs 1.2
 import QtGraphicalEffects 1.0
+import QtQuick.Window 2.12
 import QgsQuick 0.1 as QgsQuick
 import "."  // import InputStyle singleton
 
-Item {
-    property string inputLink: "https://inputapp.io/"
+Page {
+  id: root
 
-    property real fieldHeight: InputStyle.rowHeight
-    property real panelMargin: fieldHeight/4
-    property color fontColor: "white"
-    property color bgColor: InputStyle.fontColor
+  property string inputLink: "https://inputapp.io/"
+  property real fieldHeight: InputStyle.rowHeight
+  property real panelMargin: fieldHeight / 4
+  property color fontColor: "white"
+  property color bgColor: InputStyle.fontColor
+  property bool isPortraitOrientation: Screen.primaryOrientation === Qt.PortraitOrientation
 
-    function close() {
-        visible = false
+  signal close()
+
+  function setAnchors() {
+    if ( isPortraitOrientation )
+    {
+      lutraLogo.anchors.right = undefined
+      lutraLogo.anchors.horizontalCenter = content.horizontalCenter
+      lutraLogo.anchors.bottomMargin = 2 * InputStyle.panelMargin
+      lutraLogo.anchors.rightMargin = undefined
     }
+    else // landscape
+    {
+      lutraLogo.anchors.horizontalCenter = undefined
+      lutraLogo.anchors.right = content.right
+      lutraLogo.anchors.bottomMargin = InputStyle.panelMargin
+      lutraLogo.anchors.rightMargin = InputStyle.panelMargin
+    }
+  }
 
-    id: root
+  Keys.onReleased: {
+    if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+      event.accepted = true
+      close()
+    }
+  }
 
-    Pane {
-        id: pane
+  onIsPortraitOrientationChanged: setAnchors()
+  Component.onCompleted: setAnchors()
 
-        width: parent.width
-        height: parent.height
-        anchors.verticalCenter: parent.verticalCenter
+  background: Rectangle {
+    color: root.bgColor
+  }
+
+  header: PanelHeader {
+    id: header
+    height: InputStyle.rowHeightHeader
+    width: parent.width
+    color: root.bgColor
+    rowHeight: InputStyle.rowHeightHeader
+    titleText: ""
+
+    onBack: root.close()
+    withBackButton: true
+  }
+
+  Item {
+    id: content
+    anchors.fill: parent
+    anchors.bottomMargin: Qt.inputMethod.keyboardRectangle.height ? Qt.inputMethod.keyboardRectangle.height : 0
+
+    Column {
+      id: columnLayout
+      anchors.verticalCenter: parent.verticalCenter
+      width: parent.width
+
+      Image {
+        id: inputLogo
+        source: "input.svg"
+        width: content.width / 2
+        sourceSize.width: width
         anchors.horizontalCenter: parent.horizontalCenter
+      }
 
+      Text {
+        text: "v" + __version
+        font.pixelSize: InputStyle.fontPixelSizeSmall
+        anchors.horizontalCenter: parent.horizontalCenter
+        color: fontColor
+      }
 
+      Button {
+        id: inputLinkBtn
+        width: content.width - 2 * root.panelMargin
+        height: fieldHeight * 0.7
+        anchors.horizontalCenter: parent.horizontalCenter
+        onClicked: Qt.openUrlExternally(root.inputLink)
         background: Rectangle {
-            color: root.bgColor
+          color: InputStyle.fontColor
         }
 
-        PanelHeader {
-          id: header
-          height: InputStyle.rowHeightHeader
-          width: parent.width
-          color: root.bgColor
-          rowHeight: InputStyle.rowHeightHeader
-          titleText: ""
-
-          onBack: root.close()
-          withBackButton: true
+        contentItem: Text {
+          text: root.inputLink
+          font.pixelSize: InputStyle.fontPixelSizeNormal
+          color: InputStyle.highlightColor
+          horizontalAlignment: Text.AlignHCenter
+          verticalAlignment: Text.AlignVCenter
+          elide: Text.ElideRight
         }
-
-        Item {
-            id: content
-            anchors.fill: parent
-            anchors.bottomMargin: Qt.inputMethod.keyboardRectangle.height ? Qt.inputMethod.keyboardRectangle.height: 0
-
-
-            Column {
-                id: columnLayout
-                anchors.verticalCenter: parent.verticalCenter
-                width: parent.width
-
-                Image {
-                    id: inputLogo
-                    source: "input.svg"
-                    width: content.width/2
-                    sourceSize.width: width
-                    anchors.horizontalCenter: parent.horizontalCenter
-                }
-
-                Text {
-                    text: "v" + __version
-                    font.pixelSize: InputStyle.fontPixelSizeSmall
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    color: fontColor
-                }
-
-                Button {
-                    id: inputLinkBtn
-                    width: content.width - 2* root.panelMargin
-                    height: fieldHeight * 0.7
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    onClicked:Qt.openUrlExternally(root.inputLink);
-                    background: Rectangle {
-                        color: InputStyle.fontColor
-                    }
-
-                    contentItem: Text {
-                        text: root.inputLink
-                        font.pixelSize: InputStyle.fontPixelSizeNormal
-                        color: InputStyle.highlightColor
-                        horizontalAlignment: Text.AlignHCenter
-                        verticalAlignment: Text.AlignVCenter
-                        elide: Text.ElideRight
-                    }
-                }
-            }
-
-            Text {
-                id: developedText
-                text: qsTr("Developed by")
-                font.pixelSize: InputStyle.fontPixelSizeSmall
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.bottom: lutraLogo.top
-                color: fontColor
-            }
-
-            Image {
-                id: lutraLogo
-                source: "lutra_logo.svg"
-                width: inputLogo.width/2
-                sourceSize.width: width
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: InputStyle.panelMargin * 2
-            }
-
-            ColorOverlay {
-                anchors.fill: lutraLogo
-                source: lutraLogo
-                color: fontColor
-            }
-        }
+      }
     }
+
+    Text {
+      id: developedText
+      text: qsTr("Developed by")
+      font.pixelSize: InputStyle.fontPixelSizeSmall
+      anchors.horizontalCenter: lutraLogo.horizontalCenter
+      anchors.bottom: lutraLogo.top
+      color: fontColor
+    }
+
+    Image {
+      id: lutraLogo
+      source: "lutra_logo.svg"
+      width: inputLogo.width / 2
+      sourceSize.width: width
+      anchors.horizontalCenter: parent.horizontalCenter
+      anchors.bottom: parent.bottom
+      anchors.bottomMargin: InputStyle.panelMargin * 2
+    }
+
+    ColorOverlay {
+      anchors.fill: lutraLogo
+      source: lutraLogo
+      color: fontColor
+    }
+  }
 }

--- a/app/qml/LogPanel.qml
+++ b/app/qml/LogPanel.qml
@@ -14,96 +14,82 @@ import QtQuick.Dialogs 1.2
 import QtGraphicalEffects 1.0
 import QgsQuick 0.1 as QgsQuick
 import "."  // import InputStyle singleton
+import "./components"
 
 Item {
-    id: root
-    property string text: "(no-entries)"
+  id: root
+  property string text: "(no-entries)"
 
-    function close() {
-        visible = false
+  signal close
+
+  Keys.onReleased: {
+    if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+      event.accepted = true
+      close()
+    }
+  }
+
+  Page {
+    id: pane
+
+    width: parent.width
+    height: parent.height
+    anchors.verticalCenter: parent.verticalCenter
+    anchors.horizontalCenter: parent.horizontalCenter
+    clip: true
+
+    background: Rectangle {
+      color: "white"
     }
 
-    Pane {
-        id: pane
+    header: PanelHeader {
+      id: header
+      height: InputStyle.rowHeightHeader
+      width: parent.width
+      color: "white"
+      rowHeight: InputStyle.rowHeightHeader
+      titleText: qsTr("Diagnostic Log")
 
+      onBack: root.close()
+      withBackButton: true
+    }
+
+    Flickable {
+      id: flickableItem
+      clip: true
+      anchors.horizontalCenter: parent.horizontalCenter
+      width: root.width - InputStyle.panelMargin
+      height: parent.height
+      contentHeight: txt.height
+      contentWidth: width
+      maximumFlickVelocity: __androidUtils.isAndroid ? InputStyle.scrollVelocityAndroid : maximumFlickVelocity
+
+      Text {
+        id: txt
+        text: "<style>" + "a:link { color: " + InputStyle.highlightColor
+              + "; text-decoration: underline; }" + "p.odd { color: "
+              + InputStyle.fontColorBright + "; }" + "</style>" + root.text
+        font.pixelSize: InputStyle.fontPixelSizeNormal
+        color: InputStyle.fontColor
+        textFormat: Text.RichText
+        wrapMode: Text.WordWrap
         width: parent.width
-        height: parent.height
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        clip: true
+      }
 
-        background: Rectangle {
-            color: "white"
-        }
-
-        PanelHeader {
-          id: header
-          height: InputStyle.rowHeightHeader
-          width: parent.width
-          color: "white"
-          rowHeight: InputStyle.rowHeightHeader
-          titleText: qsTr("Diagnostic Log")
-
-          onBack: root.close()
-          withBackButton: true
-        }
-
-        Flickable {
-          id: flickableItem
-          anchors.top: header.bottom
-          clip: true
-          anchors.horizontalCenter: parent.horizontalCenter
-          width: root.width - 2 * InputStyle.rowHeightHeader
-          height: parent.height - 2 * InputStyle.rowHeightHeader - InputStyle.panelSpacing
-          contentHeight: txt.height
-          contentWidth: width
-
-            Text {
-              id: txt
-              text: "<style>" +
-                      "a:link { color: " + InputStyle.highlightColor + "; text-decoration: underline; }" +
-                      "p.odd { color: " + InputStyle.fontColorBright + "; }" +
-                    "</style>"
-
-                    + root.text
-              font.pixelSize: InputStyle.fontPixelSizeNormal
-              color: InputStyle.fontColor
-              textFormat: Text.RichText
-              wrapMode: Text.WordWrap
-              width: parent.width
-            }
-
-            ScrollBar.vertical: ScrollBar { id: vbar }
-        }
-
-        Button {
-          anchors.bottom: parent.bottom
-          id: sendButton
-          width: root.width - 2 * InputStyle.rowHeightHeader
-          anchors.horizontalCenter: parent.horizontalCenter
-
-          height: InputStyle.rowHeightHeader
-          text: __inputHelp.submitReportPending ? qsTr("Sending...") : qsTr("Send Log to Developers")
-          font.pixelSize: InputStyle.fontPixelSizeTitle
-
-          background: Rectangle {
-            color: InputStyle.fontColor
-          }
-
-          onClicked: {
-            if (!__inputHelp.submitReportPending)
-              __inputHelp.submitReport();
-          }
-
-          contentItem: Text {
-            text: sendButton.text
-            font: sendButton.font
-            opacity: enabled ? 1.0 : 0.3
-            color: "white"
-            horizontalAlignment: Text.AlignHCenter
-            verticalAlignment: Text.AlignVCenter
-            elide: Text.ElideRight
-          }
-        }
+      ScrollBar.vertical: ScrollBar { }
     }
+
+    footer: DelegateButton {
+      id: sendButton
+
+      width: root.width
+      height: InputStyle.rowHeightHeader
+      text: __inputHelp.submitReportPending ? qsTr("Sending...") : qsTr("Send Log to Developers")
+
+      onClicked: {
+        if (!__inputHelp.submitReportPending)
+          __inputHelp.submitReport()
+      }
+    }
+  }
 }

--- a/app/qml/LogPanel.qml
+++ b/app/qml/LogPanel.qml
@@ -84,7 +84,7 @@ Item {
 
       width: root.width
       height: InputStyle.rowHeightHeader
-      text: __inputHelp.submitReportPending ? qsTr("Sending...") : qsTr("Send Log to Developers")
+      text: __inputHelp.submitReportPending ? qsTr("Sending...") : qsTr("Send to Developers")
 
       onClicked: {
         if (!__inputHelp.submitReportPending)

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -7,9 +7,9 @@
  *                                                                         *
  ***************************************************************************/
 
-import QtQuick 2.7
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.3
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
 import QtGraphicalEffects 1.0
 import lc 1.0
 import "."  // import InputStyle singleton

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -257,7 +257,7 @@ Item {
 
           // Privacy Policy
           PanelItem {
-            text: qsTr("Privacy Policy")
+            text: qsTr("Privacy policy")
             MouseArea {
               anchors.fill: parent
               onClicked: Qt.openUrlExternally(__inputHelp.privacyPolicyLink)
@@ -266,7 +266,7 @@ Item {
 
           // Terms of Service
           PanelItem {
-            text: qsTr("Mergin Terms of Service")
+            text: qsTr("Mergin terms of service")
             MouseArea {
               anchors.fill: parent
               onClicked: Qt.openUrlExternally(__inputHelp.merginTermsLink)
@@ -275,7 +275,7 @@ Item {
 
           // Debug/Logging
           PanelItem {
-            text: qsTr("Diagnostic Log")
+            text: qsTr("Diagnostic log")
             MouseArea {
               anchors.fill: parent
               onClicked: stackview.push(logPanelComponent, {text: __inputHelp.fullLog(true, 200000)})

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -8,277 +8,288 @@
  ***************************************************************************/
 
 import QtQuick 2.7
-import QtQuick.Controls 2.2
+import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.3
 import QtGraphicalEffects 1.0
 import lc 1.0
 import "."  // import InputStyle singleton
 import "./components"
 
-Page {
+Item {
+  id: root
 
-    property real rowHeight: InputStyle.rowHeight
-    property string defaultLayer: __appSettings.defaultLayer
-    property color gpsIndicatorColor: InputStyle.softRed
+  visible: false
+  property real rowHeight: InputStyle.rowHeight
+  property string defaultLayer: __appSettings.defaultLayer
+  property color gpsIndicatorColor: InputStyle.softRed
 
-    id: settingsPanel
-    visible: false
-    padding: 0
-    focus: true
+  Keys.onReleased: {
+    if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+      event.accepted = true
 
-    background: Rectangle {
+      if (stackview.depth > 1) {
+        // hide about or log panel
+        stackview.pop(null)
+      }
+      else
+        root.visible = false
+    }
+  }
+
+  StackView {
+    id: stackview
+
+    anchors.fill: parent
+    initialItem: settingsContentComponent
+  }
+
+  Component {
+    id: settingsContentComponent
+
+    Page {
+      id: settingsPanel
+      padding: 0
+
+      background: Rectangle {
         anchors.fill: parent
         color: InputStyle.clrPanelMain
-    }
-
-    Keys.onReleased: {
-      if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
-        event.accepted = true;
-
-        if (aboutPanel.visible) { // hide about panel
-          aboutPanel.visible = false;
-        }
-        else if (logPanel.visible) {
-          logPanel.visible = false
-        }
-        else if (settingsPanel.visible) {
-          settingsPanel.visible = false;
-        }
       }
-    }
 
-    PanelHeader {
+      header: PanelHeader {
         id: header
-        height: settingsPanel.rowHeight
+        height: root.rowHeight
         width: parent.width
         color: InputStyle.clrPanelMain
         rowHeight: InputStyle.rowHeightHeader
         titleText: qsTr("Settings")
 
-        onBack: settingsPanel.visible = false;
-    }
+        onBack: root.visible = false
+      }
 
-    Rectangle {
-        id: settingsList
-        anchors.top: header.bottom
-        anchors.right: parent.right
-        anchors.left: parent.left
-        anchors.bottom: parent.bottom
-        anchors.margins: 0
-        color: InputStyle.panelBackgroundDark
-        width: parent.width
-        height: parent.height
+      ScrollView {
+        id: scrollPage
+        width: settingsPanel.width
+        height: settingsPanel.height - header.height
+        contentWidth: availableWidth // to only scroll vertically
+        spacing: InputStyle.panelSpacing
+
+        background: Rectangle {
+          anchors.fill: parent
+          color: InputStyle.panelBackgroundDark
+        }
 
         Column {
-            id: settingListContent
-            anchors.fill: parent
-            spacing: 1
+          id: settingListContent
+          anchors.fill: parent
+          spacing: 1
 
-             // Header "GPS"
-            PanelItem {
-                color: InputStyle.panelBackgroundLight
-                text: qsTr("GPS")
-                bold: true
-            }
-
-            PanelItem {
-                height: settingsPanel.rowHeight
-                width: parent.width
-                color: InputStyle.clrPanelMain
-                text: qsTr("Follow GPS with map")
-
-                SettingsSwitch {
-                  id: autoCenterMapSwitch
-
-                  checked: __appSettings.autoCenterMapChecked
-                  onCheckedChanged: __appSettings.autoCenterMapChecked = checked
-                }
-
-                MouseArea {
-                  anchors.fill: parent
-                  onClicked: autoCenterMapSwitch.toggle()
-                }
-            }
-
-            PanelItem {
-                height: settingsPanel.rowHeight
-                width: parent.width
-                color: InputStyle.clrPanelMain
-                text: qsTr("GPS accuracy")
-
-                Row {
-                    id: widget
-                    property real indicatorSize: {
-                        var size = height/3
-                        size % 2 === 0 ? size : size + 1
-                    }
-                    width: indicatorSize * 4
-                    anchors.top: parent.top
-                    anchors.topMargin: 0
-                    anchors.bottom: parent.bottom
-                    anchors.bottomMargin: 0
-                    anchors.right: parent.right
-                    anchors.rightMargin: InputStyle.panelMargin
-                    spacing: InputStyle.panelSpacing
-
-                    RoundIndicator {
-                        width: widget.indicatorSize
-                        height: width
-                        anchors.margins: height/3
-                        color: InputStyle.panelBackgroundLight
-                        anchors.verticalCenter: parent.verticalCenter
-                        visible: false // disabled due no manual GPS on/off support
-                    }
-
-                    RoundIndicator {
-                        width: widget.indicatorSize
-                        height: width
-                        color: InputStyle.softRed
-                        isActive: color === gpsIndicatorColor
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-
-                    RoundIndicator {
-                        width: widget.indicatorSize
-                        height: width
-                        color: InputStyle.softOrange
-                        isActive: color === gpsIndicatorColor
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-
-                    RoundIndicator {
-                        width: widget.indicatorSize
-                        height: width
-                        color: InputStyle.softGreen
-                        isActive: color === gpsIndicatorColor
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-                }
-            }
-
-            PanelItem {
-                height: settingsPanel.rowHeight
-                width: parent.width
-                text: qsTr("Accuracy threshold")
-
-                NumberSpin {
-                    value: __appSettings.gpsAccuracyTolerance
-                    suffix: " m"
-                    onValueChanged: __appSettings.gpsAccuracyTolerance = value
-                    height: InputStyle.fontPixelSizeNormal
-                    rowHeight: parent.height
-                    anchors.verticalCenter: parent.verticalCenter
-                    width: height * 6
-                    anchors.right: parent.right
-                    anchors.rightMargin: InputStyle.panelMargin
-                }
-            }
-
-            // Header "Recording"
-            PanelItem {
-                color: InputStyle.panelBackgroundLight
-                text: qsTr("Recording")
-                bold: true
-            }
-
-            PanelItem {
-                height: settingsPanel.rowHeight
-                width: parent.width
-                text: qsTr("Line rec. interval")
-
-                NumberSpin {
-                    id: spinRecordingInterval
-                    value: __appSettings.lineRecordingInterval
-                    minValue: 1
-                    maxValue: 30
-                    suffix: " s"
-                    onValueChanged: __appSettings.lineRecordingInterval = spinRecordingInterval.value
-                    height: InputStyle.fontPixelSizeNormal
-                    rowHeight: parent.height
-                    anchors.verticalCenter: parent.verticalCenter
-                    width: height * 6
-                    anchors.right: parent.right
-                    anchors.rightMargin: InputStyle.panelMargin
-                }
-            }
-
-
-            PanelItem {
-                height: settingsPanel.rowHeight
-                width: parent.width
-                color: InputStyle.clrPanelMain
-                text: qsTr("Reuse last value option")
-
-                SettingsSwitch {
-                  id: rememberValuesSwitch
-
-                  checked: __appSettings.reuseLastEnteredValues
-                  onCheckedChanged: __appSettings.reuseLastEnteredValues = checked
-                }
-
-                MouseArea {
-                  anchors.fill: parent
-                  onClicked: rememberValuesSwitch.toggle()
-                }
-            }
-
-            // Delimeter
-            PanelItem {
-                color: InputStyle.panelBackgroundLight
-                text: ""
-                height: settingsPanel.rowHeight/3
-            }
-
-            // App info
-           PanelItem {
-               text: qsTr("About")
-               MouseArea {
-                   anchors.fill: parent
-                   onClicked: aboutPanel.visible = true
-               }
-           }
-
-           // Help
+          // Header "GPS"
           PanelItem {
-              text: qsTr("Help")
-              MouseArea {
-                  anchors.fill: parent
-                  onClicked: Qt.openUrlExternally("https://help.inputapp.io/");
+            color: InputStyle.panelBackgroundLight
+            text: qsTr("GPS")
+            bold: true
+          }
+
+          PanelItem {
+            height: root.rowHeight
+            width: parent.width
+            color: InputStyle.clrPanelMain
+            text: qsTr("Follow GPS with map")
+
+            SettingsSwitch {
+              id: autoCenterMapSwitch
+
+              checked: __appSettings.autoCenterMapChecked
+              onCheckedChanged: __appSettings.autoCenterMapChecked = checked
+            }
+
+            MouseArea {
+              anchors.fill: parent
+              onClicked: autoCenterMapSwitch.toggle()
+            }
+          }
+
+          PanelItem {
+            height: root.rowHeight
+            width: parent.width
+            color: InputStyle.clrPanelMain
+            text: qsTr("GPS accuracy")
+
+            Row {
+              id: widget
+              property real indicatorSize: {
+                var size = height / 3
+                size % 2 === 0 ? size : size + 1
               }
+              width: indicatorSize * 4
+              anchors.top: parent.top
+              anchors.topMargin: 0
+              anchors.bottom: parent.bottom
+              anchors.bottomMargin: 0
+              anchors.right: parent.right
+              anchors.rightMargin: InputStyle.panelMargin
+              spacing: InputStyle.panelSpacing
+
+              RoundIndicator {
+                width: widget.indicatorSize
+                height: width
+                anchors.margins: height / 3
+                color: InputStyle.panelBackgroundLight
+                anchors.verticalCenter: parent.verticalCenter
+                visible: false // disabled due no manual GPS on/off support
+              }
+
+              RoundIndicator {
+                width: widget.indicatorSize
+                height: width
+                color: InputStyle.softRed
+                isActive: color === root.gpsIndicatorColor
+                anchors.verticalCenter: parent.verticalCenter
+              }
+
+              RoundIndicator {
+                width: widget.indicatorSize
+                height: width
+                color: InputStyle.softOrange
+                isActive: color === root.gpsIndicatorColor
+                anchors.verticalCenter: parent.verticalCenter
+              }
+
+              RoundIndicator {
+                width: widget.indicatorSize
+                height: width
+                color: InputStyle.softGreen
+                isActive: color === root.gpsIndicatorColor
+                anchors.verticalCenter: parent.verticalCenter
+              }
+            }
+          }
+
+          PanelItem {
+            height: root.rowHeight
+            width: parent.width
+            text: qsTr("Accuracy threshold")
+
+            NumberSpin {
+              value: __appSettings.gpsAccuracyTolerance
+              suffix: " m"
+              onValueChanged: __appSettings.gpsAccuracyTolerance = value
+              height: InputStyle.fontPixelSizeNormal
+              rowHeight: parent.height
+              anchors.verticalCenter: parent.verticalCenter
+              width: height * 6
+              anchors.right: parent.right
+              anchors.rightMargin: InputStyle.panelMargin
+            }
+          }
+
+          // Header "Recording"
+          PanelItem {
+            color: InputStyle.panelBackgroundLight
+            text: qsTr("Recording")
+            bold: true
+          }
+
+          PanelItem {
+            height: root.rowHeight
+            width: parent.width
+            text: qsTr("Line rec. interval")
+
+            NumberSpin {
+              id: spinRecordingInterval
+              value: __appSettings.lineRecordingInterval
+              minValue: 1
+              maxValue: 30
+              suffix: " s"
+              onValueChanged: __appSettings.lineRecordingInterval = spinRecordingInterval.value
+              height: InputStyle.fontPixelSizeNormal
+              rowHeight: parent.height
+              anchors.verticalCenter: parent.verticalCenter
+              width: height * 6
+              anchors.right: parent.right
+              anchors.rightMargin: InputStyle.panelMargin
+            }
+          }
+
+          PanelItem {
+            height: root.rowHeight
+            width: parent.width
+            color: InputStyle.clrPanelMain
+            text: qsTr("Reuse last value option")
+
+            SettingsSwitch {
+              id: rememberValuesSwitch
+
+              checked: __appSettings.reuseLastEnteredValues
+              onCheckedChanged: __appSettings.reuseLastEnteredValues = checked
+            }
+
+            MouseArea {
+              anchors.fill: parent
+              onClicked: rememberValuesSwitch.toggle()
+            }
+          }
+
+          // Delimeter
+          PanelItem {
+            color: InputStyle.panelBackgroundLight
+            text: ""
+            height: root.rowHeight / 3
+          }
+
+          // App info
+          PanelItem {
+            text: qsTr("About")
+            MouseArea {
+              anchors.fill: parent
+              onClicked: stackview.push(aboutPanelComponent)
+            }
           }
 
           // Help
           PanelItem {
-             text: qsTr("Privacy Policy")
-             MouseArea {
-                 anchors.fill: parent
-                 onClicked: Qt.openUrlExternally(__inputHelp.privacyPolicyLink);
-             }
+            text: qsTr("Help")
+            MouseArea {
+              anchors.fill: parent
+              onClicked: Qt.openUrlExternally(__inputHelp.helpRootLink)
+            }
           }
 
-           // Debug/Logging
+          // Privacy Policy
           PanelItem {
-              text: qsTr("Diagnostic Log")
-              MouseArea {
-                  anchors.fill: parent
-                  onClicked: {
-                    logPanel.text = __inputHelp.fullLog(true, 200000) //0.2MB
-                    logPanel.visible = true
-                  }
-              }
+            text: qsTr("Privacy Policy")
+            MouseArea {
+              anchors.fill: parent
+              onClicked: Qt.openUrlExternally(__inputHelp.privacyPolicyLink)
+            }
+          }
+
+          // Debug/Logging
+          PanelItem {
+            text: qsTr("Diagnostic Log")
+            MouseArea {
+              anchors.fill: parent
+              onClicked: stackview.push(logPanelComponent, {text: __inputHelp.fullLog(true, 200000)})
+            }
           }
         }
+      }
     }
+  }
 
+  Component {
+    id: aboutPanelComponent
     AboutPanel {
-        id: aboutPanel
-        anchors.fill: parent
-        visible: false
+      onClose: stackview.pop(null)
+      Component.onCompleted: forceActiveFocus()
     }
+  }
 
+  Component {
+    id: logPanelComponent
     LogPanel {
-        id: logPanel
-        anchors.fill: parent
-        visible: false
+      onClose: stackview.pop(null)
+      Component.onCompleted: forceActiveFocus()
     }
+  }
 }

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -264,6 +264,15 @@ Item {
             }
           }
 
+          // Terms of Service
+          PanelItem {
+            text: qsTr("Mergin Terms of Service")
+            MouseArea {
+              anchors.fill: parent
+              onClicked: Qt.openUrlExternally(__inputHelp.merginTermsLink)
+            }
+          }
+
           // Debug/Logging
           PanelItem {
             text: qsTr("Diagnostic Log")


### PR DESCRIPTION
 - Added scrolling for settings for both landscape and portrait mode
 - Fixed visual overlap of about page when in landscape
 - Fixed some UI in log panel (see video)
 - Now using stackview in settings like:
     - It starts with Item that holds `StackView` 
     - Initial item of Stackview is component settingsContent that holds all settings items
     - When one clicks on about / log panel, corresponding page is pushed to stack (this also results to lazy loading of Logs list)
     - When that page closes, stackview is cleared to only contain `initialItem`
     - Visibility of settings is handled by setting `visible` state of the root `Item`
 - Added link for [Mergin Terms of Service](https://public.cloudmergin.com/assets/mergin_terms_of_service.pdf) - Resolves #1239 

Resolves #1234 
Resolves #1125 

Previous visual overlap of About page in landscape (not reported): 
<img src="https://user-images.githubusercontent.com/22449698/110469998-9cfd3d80-80da-11eb-9c38-c026c32eed2d.jpg" width=500>

https://user-images.githubusercontent.com/22449698/110469995-9b337a00-80da-11eb-8af7-f6932a5c9a1e.mp4