### PR TITLE
Borders of flickable tab component visible only if there is the tab

### DIFF
--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -425,6 +425,7 @@ Item {
       height: form.style.tabs.borderWidth
       anchors.top: flickable.top
       color: form.style.tabs.borderColor
+      visible: flickable.height
     }
 
     Rectangle {
@@ -432,6 +433,7 @@ Item {
       height: form.style.tabs.borderWidth
       anchors.bottom: flickable.bottom
       color: form.style.tabs.borderColor
+      visible: flickable.height
     }
   }
 


### PR DESCRIPTION
![Screenshot_20210310-131539](https://user-images.githubusercontent.com/6735606/110635318-3f84f180-81ab-11eb-92e4-cdfdeb23eaae.png)

Group and Tab panel have not the same height though (not introduced in this PR).

closes #1248 