### PR TITLE
Better selection color

### DIFF
--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -29,6 +29,7 @@ QtObject {
     property color labelColor: "#999999"
 
     property color highlightColor: "#FD9626"
+    property color panelItemHighlight: "#9ABFA0"
     property color softRed: "#FC9FB1"
     property color softOrange: "#FDD7B1"
     property color softGreen: "#32AA3A"

--- a/app/qml/LayerList.qml
+++ b/app/qml/LayerList.qml
@@ -27,7 +27,7 @@ ListView {
       Rectangle {
         id: itemContainer
         property color primaryColor: InputStyle.clrPanelMain
-        property color secondaryColor: InputStyle.fontColorBright
+        property color secondaryColor: InputStyle.panelItemHighlight
         width: listView.cellWidth
         height: listView.cellHeight
         visible: height ? true : false
@@ -38,9 +38,12 @@ ListView {
         MouseArea {
           anchors.fill: parent
           onClicked: {
+            activeIndex = index
             listItemClicked( model.layerId )
           }
         }
+
+        Component.onCompleted: if (layerName === __activeLayer.layerName) activeIndex = index
 
         ExtendedMenuItem {
             id: item
@@ -50,7 +53,7 @@ ListView {
             imageSource: iconSource ? iconSource : ""
             overlayImage: false
             highlight: highlightingAllowed && layerId === activeLayerId
-            showBorder: highlightingAllowed ? !__appSettings.defaultLayer || activeIndex - 1 !== index : true
+            showBorder: highlightingAllowed ? !__appSettings.defaultLayer || (listView.activeIndex !== index && listView.activeIndex - 1 !== index) : true
         }
     }
   }

--- a/app/qml/MapThemePanel.qml
+++ b/app/qml/MapThemePanel.qml
@@ -77,13 +77,11 @@ Drawer {
         id: delegateItem
         Rectangle {
             id: itemContainer
-            property color primaryColor: InputStyle.clrPanelMain
-            property color secondaryColor: InputStyle.fontColorBright
             width: listView.cellWidth
             height: listView.cellHeight
             anchors.leftMargin: InputStyle.panelMargin
             anchors.rightMargin: InputStyle.panelMargin
-            color: item.highlight ? secondaryColor : primaryColor
+            color: item.highlight ? InputStyle.panelItemHighlight : InputStyle.clrPanelMain
 
             MouseArea {
                 anchors.fill: parent
@@ -101,7 +99,7 @@ Drawer {
                 anchors.rightMargin: panelMargin
                 anchors.leftMargin: panelMargin
                 highlight: __mapThemesModel.activeThemeIndex === index
-                showBorder: __mapThemesModel.activeThemeIndex - 1 !== index
+                showBorder: __mapThemesModel.activeThemeIndex - 1 !== index && __mapThemesModel.activeThemeIndex !== index
             }
         }
 

--- a/app/qml/ProjectDelegateItem.qml
+++ b/app/qml/ProjectDelegateItem.qml
@@ -18,7 +18,7 @@ import "./components"
 
 Rectangle {
     id: itemContainer
-    color: itemContainer.highlight ? InputStyle.fontColorBright : itemContainer.primaryColor
+    color: itemContainer.highlight ? InputStyle.panelItemHighlight : itemContainer.primaryColor
 
     property color primaryColor: InputStyle.clrPanelMain
     property color secondaryColor: InputStyle.fontColor


### PR DESCRIPTION
Just small note about colors which were changed according the ticket: `#9abfa0` used instead of `#689d71`. However, color that was used before was actually `#679d70`. Maybe a color picker or an image itself might cause that small difference, but maybe better to have also color palette from Rado.

Also fixed border style in Layer and Theme panel.

Color changed in:
* record layers panel
<img width="438" alt="Screenshot 2021-03-10 at 12 19 18" src="https://user-images.githubusercontent.com/6735606/110621768-e319d600-819a-11eb-99df-9dbd7a478b3e.png">

* map theme panel
<img width="438" alt="Screenshot 2021-03-10 at 12 18 58" src="https://user-images.githubusercontent.com/6735606/110621792-eb721100-819a-11eb-9daa-86c49422cbe5.png">
* projects page
<img width="438" alt="Screenshot 2021-03-10 at 12 18 31" src="https://user-images.githubusercontent.com/6735606/110621813-f5940f80-819a-11eb-8ecb-87be02ebc220.png">


closes #1247 