### PR TITLE
Fix of downloading a file containing a special character

### DIFF
--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -82,7 +82,7 @@ void MerginApi::listProjects( const QString &searchExpression, const QString &fl
   }
   if ( !searchExpression.isEmpty() )
   {
-    query.addQueryItem( "name", searchExpression );
+    query.addQueryItem( "name", searchExpression.toUtf8().toPercentEncoding() );
   }
   if ( !flag.isEmpty() )
   {

--- a/app/merginapi.cpp
+++ b/app/merginapi.cpp
@@ -121,7 +121,8 @@ void MerginApi::downloadNextItem( const QString &projectFullName )
 
   QUrl url( mApiRoot + QStringLiteral( "/v1/project/raw/" ) + projectFullName );
   QUrlQuery query;
-  query.addQueryItem( "file", item.filePath );
+  // Handles special chars in a filePath (e.g prevents to convert "+" sign into a space)
+  query.addQueryItem( "file", item.filePath.toUtf8().toPercentEncoding() );
   query.addQueryItem( "version", QStringLiteral( "v%1" ).arg( item.version ) );
   if ( item.downloadDiff )
     query.addQueryItem( "diff", "true" );

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -37,6 +37,7 @@ class TestMerginApi: public QObject
 
     void testListProject();
     void testDownloadProject();
+    void testDownloadProjectSpecChars();
     void testCancelDownloadProject();
     void testCreateProjectTwice();
     void testDeleteNonExistingProject();


### PR DESCRIPTION
The reason was that `+` was converted into a space.
[https://doc.qt.io/qt-5/qurlquery.html#handling-of-spaces-and-plus](https://doc.qt.io/qt-5/qurlquery.html#handling-of-spaces-and-plus)

Simply, `item.filePath.replace("+", "%2b")` was needed. Fixed by using toPercentEncoding() on `file` query parameter.
A test added as well.

NOTES
* maybe better to check if the same issue may occur elsewhere. So far found with search query on explore page (fix included in this PR).
* better notification - server is returning just filename as error message in a case, when filepath is not existing (or filename has been decoded).
[Mergin #638](https://gitlab.cloud.lutraconsulting.co.uk/mergin/mergin/-/issues/638)

closes #1246 