### PR TITLE
Write image direction angle to EXIF when capturing pictures on Android

### DIFF
--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -66,4 +66,8 @@ android {
     aaptOptions {
         noCompress 'rcc'
     }
+    compileOptions {
+	sourceCompatibility 1.8
+	targetCompatibility 1.8
+    }
 }

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -22,6 +22,7 @@ apply plugin: 'com.android.application'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'com.android.support:support-v4:28.0.0'
+    implementation "androidx.exifinterface:exifinterface:1.3.1"
 }
 
 android {

--- a/app/android/src/uk/co/lutraconsulting/CameraActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/CameraActivity.java
@@ -8,7 +8,12 @@ import java.io.FileInputStream;
 import java.io.OutputStream;
 import java.io.FileOutputStream;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
+// TODO revise imports
 import android.os.Bundle;
 import android.os.Environment;
 import android.net.Uri;
@@ -21,11 +26,9 @@ import android.content.SharedPreferences;
 import android.content.Context;
 import android.content.Intent;
 import android.widget.LinearLayout;
-import android.widget.TextView;
-import android.widget.ImageView;
 import android.widget.Button;
-import android.view.View;
-import android.view.View.OnClickListener;
+//import android.view.View.OnClickListener;
+//import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.util.Log;
 import android.graphics.drawable.ColorDrawable;
@@ -34,20 +37,52 @@ import android.graphics.Bitmap;
 import android.support.v4.content.FileProvider;
 
 import androidx.exifinterface.media.ExifInterface;
+// Sensors
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
 
-public class CameraActivity extends Activity{
+public class CameraActivity extends Activity implements SensorEventListener {
     private static final String TAG = "Camera Activity";
     private static final int CAMERA_CODE = 102;
+    // GPS EXIF TAGS // TODO use correct tags
+    private static final String GPS_BEARING_TAG = "GPSDestBearing";
+    private static final String GPS_LON_TAG = "GPSDestLongitude";
+    private static final String GPS_LAT_TAG = "GPSDestLatitude";
+    private static final String GPS_DATE_TAG = "GPSDateStamp";
+
     private String targetPath;
     private File cameraFile;
+
+    // Sensors
+    int SENSOR_DELAY = 1000000; // time in us, so 1000000 is second // suggested: SensorManager.SENSOR_DELAY_NORMAL;
+    private SensorManager mSensorManager;
+    private Sensor mSensorAccelerometer;
+    private Sensor mSensorMagnetometer;
+
+    // Current data from accelerometer & magnetometer.  The arrays hold values
+    // for X, Y, and Z.
+    private float[] mAccelerometerData = new float[3];
+    private float[] mMagnetometerData = new float[3];
+    // stores time -> azimuth (degree) for a whole run of the activity
+    private HashMap<Long, Double> azimuthData = new HashMap<Long, Double>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         Log.d(TAG, "onCreate()");
         super.onCreate(savedInstanceState);
 
+        // Init sensors
+        mSensorManager = (SensorManager) getSystemService(
+                Context.SENSOR_SERVICE);
+        mSensorAccelerometer = mSensorManager.getDefaultSensor(
+                Sensor.TYPE_ACCELEROMETER);
+        mSensorMagnetometer = mSensorManager.getDefaultSensor(
+                Sensor.TYPE_MAGNETIC_FIELD);
+
         targetPath = getIntent().getExtras().getString("targetPath");
-        Log.d(TAG, "targetPath: "+ targetPath);
+        Log.d(TAG, "targetPath: " + targetPath);
 
         Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         if (takePictureIntent.resolveActivity(getPackageManager()) != null) {
@@ -61,8 +96,8 @@ public class CameraActivity extends Activity{
             // Continue only if the File was successfully created
             if (photoFile != null) {
                 Uri photoURI = FileProvider.getUriForFile(this,
-                                                          "uk.co.lutraconsulting.fileprovider",
-                                                          photoFile);
+                        "uk.co.lutraconsulting.fileprovider",
+                        photoFile);
 
                 takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI);
                 takePictureIntent.putExtra("__RESULT__", "takePictureIntent__RESULT__");
@@ -75,9 +110,98 @@ public class CameraActivity extends Activity{
             }
         }
 
-        //throw new IOException("Tralalal!#@#$@JAVA");
-
         return;
+    }
+
+    /**
+     * Listeners for the sensors are registered in this callback so that
+     * they can be unregistered in onStop().
+     */
+    @Override
+    protected void onStart() {
+        super.onStart();
+
+        // Listeners for the sensors are registered in this callback and
+        // can be unregistered in onStop().
+        //
+        // Check to ensure sensors are available before registering listeners.
+        // Both listeners are registered with a "normal" amount of delay
+        // (SENSOR_DELAY_NORMAL).
+        if (mSensorAccelerometer != null) {
+            mSensorManager.registerListener(this, mSensorAccelerometer,
+                    SENSOR_DELAY);
+        }
+        if (mSensorMagnetometer != null) {
+            mSensorManager.registerListener(this, mSensorMagnetometer,
+                    SENSOR_DELAY);
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        // Unregister all sensor listeners in this callback so they don't
+        // continue to use resources when the app is stopped.
+        // mSensorManager.unregisterListener(this);
+    }
+
+    @Override
+    public void onSensorChanged(SensorEvent sensorEvent) {
+        // The sensor type (as defined in the Sensor class).
+        int sensorType = sensorEvent.sensor.getType();
+
+        // The sensorEvent object is reused across calls to onSensorChanged().
+        // clone() gets a copy so the data doesn't change out from under us
+        switch (sensorType) {
+            case Sensor.TYPE_ACCELEROMETER:
+                mAccelerometerData = sensorEvent.values.clone();
+                break;
+            case Sensor.TYPE_MAGNETIC_FIELD:
+                mMagnetometerData = sensorEvent.values.clone();
+                break;
+            default:
+                return;
+        }
+        // Compute the rotation matrix: merges and translates the data
+        // from the accelerometer and magnetometer, in the device coordinate
+        // system, into a matrix in the world's coordinate system.
+        //
+        // The second argument is an inclination matrix, which isn't
+        // used in this example.
+        float[] rotationMatrix = new float[9];
+        boolean rotationOK = SensorManager.getRotationMatrix(rotationMatrix,
+                null, mAccelerometerData, mMagnetometerData);
+
+        // Remap the matrix based on current device/activity rotation. // TODO
+        float[] rotationMatrixAdjusted = new float[9];
+        rotationMatrixAdjusted = rotationMatrix.clone();
+
+        // Get the orientation of the device (azimuth, pitch, roll) based
+        // on the rotation matrix. Output units are radians.
+        float orientationValues[] = new float[3];
+        if (rotationOK) {
+            SensorManager.getOrientation(rotationMatrixAdjusted,
+                    orientationValues);
+        }
+
+        // Pull out the individual values from the array.
+        float azimuth = orientationValues[0];
+        float pitch = orientationValues[1];
+        float roll = orientationValues[2];
+
+        // angle in degree [0 - 360] degree
+        double degrees = (Math.toDegrees(orientationValues[0]) + 360) % 360;
+        azimuthData.put(System.currentTimeMillis(), degrees);
+        Log.d(TAG, "!! onSensorChanged: " + degrees + "|" + azimuth + "," + pitch + "," + roll);
+    }
+
+
+    /**
+     * Must be implemented to satisfy the SensorEventListener interface;
+     * unused in this app.
+     */
+    @Override
+    public void onAccuracyChanged(Sensor sensor, int i) {
     }
 
     private File createImageFile(String targetPath) throws IOException {
@@ -86,132 +210,221 @@ public class CameraActivity extends Activity{
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "JPEG_" + timeStamp + "_";
 
-        cameraFile = File.createTempFile(imageFileName,  /* prefix */
-                                         ".jpg",         /* suffix */
-                                         getCacheDir()      /* directory */
-                                         );
+        cameraFile = File.createTempFile(
+                imageFileName, /* prefix */
+                ".jpg", /* suffix */
+                getCacheDir() /* directory */
+        );
 
         // Save a file: path for use with ACTION_VIEW intents
         currentPhotoPath = cameraFile.getAbsolutePath();
-        Log.d(TAG, "currentPhotoPath: "+currentPhotoPath);
+        Log.d(TAG, "currentPhotoPath: " + currentPhotoPath);
         return cameraFile;
-    }
-
-    public static String getExitInfo(String targetPath) {
-        // Create an image file name
-        String info = "trlala";
-
-        return info;
     }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         Log.d(TAG, "onActivityResult()");
-        Log.d(TAG, "request: "+requestCode);
-        Log.d(TAG, "resultCode: "+resultCode);
-        if (requestCode == CAMERA_CODE && resultCode == Activity.RESULT_OK) {
+        Log.d(TAG, "request: " + requestCode);
+        Log.d(TAG, "resultCode: " + resultCode);
+        if (requestCode == CAMERA_CODE && resultCode == Activity.RESULT_OK)
+            mSensorManager.unregisterListener(this);
 
-            Log.d(TAG, "tmp exists: "+cameraFile.exists());
-            Log.d(TAG, "tmp path: "+cameraFile.getAbsolutePath());
-            Log.d(TAG, "EXIF test: "+ targetPath);
+        Log.d(TAG, "tmp exists: " + cameraFile.exists());
+        Log.d(TAG, "tmp path: " + cameraFile.getAbsolutePath());
+        Log.d(TAG, "EXIF test: " + targetPath);
 
+        try {
+            long captureTime = cameraFile.lastModified();
+            Log.d(TAG, "CAPTURE TIME: " + cameraFile.lastModified());
+            double degrees = getAzimuthByTime(captureTime);
+            writeExifAttribute(cameraFile.getAbsolutePath(), degrees);
+            readExif(cameraFile.getAbsolutePath());
 
-            try{
-                readExif(cameraFile.getAbsolutePath());
-                copyFile(cameraFile, new File(targetPath, cameraFile.getName()));
-                if (data == null) {
-                    data = getIntent();
-                }
-                data.putExtra("__RESULT__", cameraFile.getAbsolutePath());
-                setResult(Activity.RESULT_OK, data);
+            // TODO clear data
+            azimuthData.clear();
 
-            }catch(IOException e){
-                Intent intent = this.getIntent();
-                if (data == null) {
-                    data = getIntent();
-                }
-                data.putExtra("__RESULT__", e.getMessage());
-                setResult(Activity.RESULT_CANCELED, data);
+            copyFile(cameraFile, new File(targetPath, cameraFile.getName()));
+            if (data == null) {
+                data = getIntent();
             }
+            data.putExtra("__RESULT__", cameraFile.getAbsolutePath());
+            setResult(Activity.RESULT_OK, data);
 
-            // TODO: after copy, verify if is correctly copied and then remove the old one
-
+        } catch (IOException e) {
+            Intent intent = this.getIntent();
+            if (data == null) {
+                data = getIntent();
+            }
+            data.putExtra("__RESULT__", e.getMessage());
+            setResult(Activity.RESULT_CANCELED, data);
         }
+
+        // TODO: after copy, verify if is correctly copied and then remove the old one
         finish();
     }
 
+    private double getAzimuthByTime(long time) {
+        List<Double> result = azimuthData.entrySet().stream()
+                .filter(x -> Math.abs(x.getKey() - time) <= SENSOR_DELAY)
+                .map(x->x.getValue())
+                .collect(Collectors.toList());
+        if (result.isEmpty()) return -1;
+        return result.get(0);
+    }
+
     private void copyFile(File src, File dst) throws IOException {
-        Log.d(TAG, "Copied file: "+src.getAbsolutePath()+" to file: "+dst.getAbsolutePath());
+        Log.d(TAG, "Copied file: " + src.getAbsolutePath() + " to file: " + dst.getAbsolutePath());
         InputStream in = null;
         OutputStream out = null;
 
         try {
             in = new FileInputStream(src);
             out = new FileOutputStream(dst);
-                // Transfer bytes from in to out
-                byte[] buf = new byte[1024];
-                int len;
-                while ((len = in.read(buf)) > 0) {
-                    out.write(buf, 0, len);
+            // Transfer bytes from in to out
+            byte[] buf = new byte[1024];
+            int len;
+            while ((len = in.read(buf)) > 0) {
+                out.write(buf, 0, len);
             }
-        } catch(IOException e) {
+        } catch (IOException e) {
             throw new IOException("Cannot copy a photo to working directory.");
-        }
-        finally {
-          if (in != null)
-            in.close();
-          if (out != null)
-            out.close();
+        } finally {
+            if (in != null)
+                in.close();
+            if (out != null)
+                out.close();
         }
 
     }
 
+    // TODO make more generic
+    private void writeExifAttribute(String src, double exifOrientation) throws IOException {
+        Log.d(TAG, "WriteExif: " + src + " to file: ");
+        Uri uri; // the URI you've received from the other app
+        InputStream in = null;
+        try {
+            ExifInterface exifInterface = new ExifInterface(src);
+            Log.d(TAG, "Set attribute:");
+            exifInterface.setAttribute("GPSDestBearing", calculateRational(exifOrientation));
+            exifInterface.setAttribute("GPSDestBearingRef", "M"); // TODO
+            exifInterface.saveAttributes();
+        } catch (IOException e) {
+            Log.d(TAG, "WriteExif ERROR: " + e.getMessage());
+            // Handle any errors
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }
+    }
 
-  private void readExif(String src) throws IOException {
-      Log.d(TAG, "readExif: "+src+" to file: ");
-      Uri uri; // the URI you've received from the other app
-      InputStream in = null;
-      try {
-          //in = getContentResolver().openInputStream(uri);
-          in = new FileInputStream(src);
-          ExifInterface exifInterface = new ExifInterface(in);
-          String date = exifInterface.getAttribute("GPSDateStamp");
-          String lat = exifInterface.getAttribute("GPSDestLatitude");
-          String lon = exifInterface.getAttribute("GPSDestLongitude");
-          String lat2 = exifInterface.getAttribute("GPSLatitude");
-          String lon2 = exifInterface.getAttribute("GPSLongitude");
-          String dir = exifInterface.getAttribute("GPSImgDirection");
-          String dir2 = exifInterface.getAttribute("M");
-          String dir3 = exifInterface.getAttribute("T");
-          String dir4 = exifInterface.getAttribute("GPSTrack");
-          String dir5 = exifInterface.getAttribute("GPSDestBearing");
-          String dir6 = exifInterface.getAttribute("GPSBearing");
-          String gpsInfo = exifInterface.getAttribute("GPSSatellites");
+    // TODO
+    private void readExif(String src) throws IOException {
+        Log.d(TAG, "readExif: " + src + " to file: ");
+        Uri uri; // the URI you've received from the other app
+        InputStream in = null;
+        try {
+            in = new FileInputStream(src);
+            ExifInterface exifInterface = new ExifInterface(in);
+            String date = exifInterface.getAttribute("GPSDateStamp");
+            String lat = exifInterface.getAttribute("GPSDestLatitude");
+            String lon = exifInterface.getAttribute("GPSDestLongitude");
+            String lat2 = exifInterface.getAttribute("GPSLatitude");
+            String lon2 = exifInterface.getAttribute("GPSLongitude");
+            String dir = exifInterface.getAttribute("GPSImgDirection");
+            String dir2 = exifInterface.getAttribute("M");
+            String dir3 = exifInterface.getAttribute("T");
+            String dir4 = exifInterface.getAttribute("GPSTrack");
+            String dir5 = exifInterface.getAttribute("GPSDestBearing");
+            String dir5Ref = exifInterface.getAttribute("GPSDestBearingRef");
+            String dir6 = exifInterface.getAttribute("GPSBearing");
+            String gpsInfo = exifInterface.getAttribute("GPSSatellites");
 
-          Log.d(TAG, "readExif LAT: " + lat2);
-          Log.d(TAG, "readExif LON: " + lon2);
-          Log.d(TAG, "readExif DIR: " + dir + "," + dir2 + "," + dir3  + "," + dir4 + "," + dir5 + "," + dir6);
-          Log.d(TAG, "readExif INFO: " + gpsInfo );
+            Log.d(TAG, "readExif LAT: " + lat2);
+            Log.d(TAG, "readExif LON: " + lon2);
+            Log.d(TAG, "readExif DIR: " + dir + "," + dir2 + "," + dir3 + "," + dir4 + "," + dir5 + "," + dir6);
+            Log.d(TAG, "readExif INFO: " + gpsInfo);
+            Log.d(TAG, "readExif TEST: " + dir5 + "|" + dir5Ref);
 
 
-          Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSImgDirectionRef") );
-          Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSTrackRef") );
-          Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSDestBearingRef") );
+            Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSImgDirectionRef"));
+            Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSTrackRef"));
+            Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSDestBearingRef"));
 
-           Log.d(TAG, "readExif: "+src+" to file: ");
-          // Now you can extract any Exif tag you want
-          // Assuming the image is a JPEG or supported raw format
-      } catch (IOException e) {
-          // Handle any errors
-      } finally {
-          if (in != null) {
-              try {
-                  in.close();
-              } catch (IOException ignored) {}
-          }
-      }
+            Log.d(TAG, "readExif: " + src + " to file: ");
+            // Now you can extract any Exif tag you want
+            // Assuming the image is a JPEG or supported raw format
+        } catch (IOException e) {
+            // Handle any errors
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }
+    }
 
-  }
+    public static HashMap<String, String> getEXIFdata(String filepath) {
+        List<String> exifTags = new ArrayList<String>();
+        exifTags.add(GPS_BEARING_TAG);
+        exifTags.add(GPS_LAT_TAG);
+        exifTags.add(GPS_LON_TAG);
+        exifTags.add(GPS_DATE_TAG);
+
+        return getEXIFdata(filepath, exifTags);
+    }
+
+    // Test
+    public static String getEXIFAttribute(String filepath, String tag) {
+        Log.d(TAG, "getEXIFAttribute: " + filepath + " - " + tag);
+        return tag;
+    }
+
+    public static HashMap<String, String> getEXIFdata(String filepath, List<String> exifTags) {
+        Log.d(TAG, "getEXIFdata: " + filepath + " to file: ");
+        Uri uri; // the URI you've received from the other app
+        InputStream in = null;
+        HashMap<String, String> result = new HashMap<String, String>();
+
+        // TODO if exigTags empty
+        try {
+            in = new FileInputStream(filepath);
+            ExifInterface exifInterface = new ExifInterface(in);
+            for (String tag : exifTags) {
+                String value = exifInterface.getAttribute(tag);
+                result.put(tag, value);
+                Log.d(TAG, "getEXIFdata: " + tag + " -> " + value);
+            }
+        } catch (IOException e) {
+            // Handle any errors
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }
+        return result;
+    }
+
+    private static String calculateRational(double d) {
+
+        double rounded = Math.round(d * 100)/100; // TODO proper precision
+        String aString = Double.toString(rounded);
+        String[] fraction = aString.split("\\.");
+
+        int denominator = (int)Math.pow(10, fraction[1].length());
+        int numerator = Integer.parseInt(fraction[0] + "" + fraction[1]);
+
+        Log.d(TAG, "calculateRational: " + numerator + "/" + denominator + "==" + d);
+        return numerator + "/" + denominator;
+    }
 
 }
-

--- a/app/android/src/uk/co/lutraconsulting/CameraActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/CameraActivity.java
@@ -266,7 +266,7 @@ public class CameraActivity extends Activity implements SensorEventListener {
     }
 
     private double toDegrees(double value) {
-        return (Math.toDegrees(value) + 360) % 360;
+        return normalizeDegree(Math.toDegrees(value) + 360);
     }
 
     // Angle of the device according to surface (camera pointing to surface has 0 degree)
@@ -309,9 +309,7 @@ public class CameraActivity extends Activity implements SensorEventListener {
     }
 
     private double normalizeDegree(double degree) {
-        while (degree > 360)
-            degree = degree - 360;
-        return degree;
+        return degree % 360;
     }
 
     private void copyFile(File src, File dst) throws IOException {

--- a/app/android/src/uk/co/lutraconsulting/CameraActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/CameraActivity.java
@@ -36,7 +36,7 @@ import android.provider.MediaStore;
 import android.graphics.Bitmap;
 import android.support.v4.content.FileProvider;
 
-import androidx.exifinterface.media.ExifInterface;
+import uk.co.lutraconsulting.EXIFUtils;
 // Sensors
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
@@ -236,10 +236,9 @@ public class CameraActivity extends Activity implements SensorEventListener {
 
         try {
             long captureTime = cameraFile.lastModified();
-            Log.d(TAG, "CAPTURE TIME: " + cameraFile.lastModified());
             double degrees = getAzimuthByTime(captureTime);
-            writeExifAttribute(cameraFile.getAbsolutePath(), degrees);
-            readExif(cameraFile.getAbsolutePath());
+            EXIFUtils.writeExifGpsDirection(cameraFile.getAbsolutePath(), degrees);
+            EXIFUtils.getExifGpsAttributes(cameraFile.getAbsolutePath());
 
             // TODO clear data
             azimuthData.clear();
@@ -297,134 +296,4 @@ public class CameraActivity extends Activity implements SensorEventListener {
         }
 
     }
-
-    // TODO make more generic
-    private void writeExifAttribute(String src, double exifOrientation) throws IOException {
-        Log.d(TAG, "WriteExif: " + src + " to file: ");
-        Uri uri; // the URI you've received from the other app
-        InputStream in = null;
-        try {
-            ExifInterface exifInterface = new ExifInterface(src);
-            Log.d(TAG, "Set attribute:");
-            exifInterface.setAttribute("GPSDestBearing", calculateRational(exifOrientation));
-            exifInterface.setAttribute("GPSDestBearingRef", "M"); // TODO
-            exifInterface.saveAttributes();
-        } catch (IOException e) {
-            Log.d(TAG, "WriteExif ERROR: " + e.getMessage());
-            // Handle any errors
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException ignored) {
-                }
-            }
-        }
-    }
-
-    // TODO
-    private void readExif(String src) throws IOException {
-        Log.d(TAG, "readExif: " + src + " to file: ");
-        Uri uri; // the URI you've received from the other app
-        InputStream in = null;
-        try {
-            in = new FileInputStream(src);
-            ExifInterface exifInterface = new ExifInterface(in);
-            String date = exifInterface.getAttribute("GPSDateStamp");
-            String lat = exifInterface.getAttribute("GPSDestLatitude");
-            String lon = exifInterface.getAttribute("GPSDestLongitude");
-            String lat2 = exifInterface.getAttribute("GPSLatitude");
-            String lon2 = exifInterface.getAttribute("GPSLongitude");
-            String dir = exifInterface.getAttribute("GPSImgDirection");
-            String dir2 = exifInterface.getAttribute("M");
-            String dir3 = exifInterface.getAttribute("T");
-            String dir4 = exifInterface.getAttribute("GPSTrack");
-            String dir5 = exifInterface.getAttribute("GPSDestBearing");
-            String dir5Ref = exifInterface.getAttribute("GPSDestBearingRef");
-            String dir6 = exifInterface.getAttribute("GPSBearing");
-            String gpsInfo = exifInterface.getAttribute("GPSSatellites");
-
-            Log.d(TAG, "readExif LAT: " + lat2);
-            Log.d(TAG, "readExif LON: " + lon2);
-            Log.d(TAG, "readExif DIR: " + dir + "," + dir2 + "," + dir3 + "," + dir4 + "," + dir5 + "," + dir6);
-            Log.d(TAG, "readExif INFO: " + gpsInfo);
-            Log.d(TAG, "readExif TEST: " + dir5 + "|" + dir5Ref);
-
-
-            Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSImgDirectionRef"));
-            Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSTrackRef"));
-            Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSDestBearingRef"));
-
-            Log.d(TAG, "readExif: " + src + " to file: ");
-            // Now you can extract any Exif tag you want
-            // Assuming the image is a JPEG or supported raw format
-        } catch (IOException e) {
-            // Handle any errors
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException ignored) {
-                }
-            }
-        }
-    }
-
-    public static HashMap<String, String> getEXIFdata(String filepath) {
-        List<String> exifTags = new ArrayList<String>();
-        exifTags.add(GPS_BEARING_TAG);
-        exifTags.add(GPS_LAT_TAG);
-        exifTags.add(GPS_LON_TAG);
-        exifTags.add(GPS_DATE_TAG);
-
-        return getEXIFdata(filepath, exifTags);
-    }
-
-    // Test
-    public static String getEXIFAttribute(String filepath, String tag) {
-        Log.d(TAG, "getEXIFAttribute: " + filepath + " - " + tag);
-        return tag;
-    }
-
-    public static HashMap<String, String> getEXIFdata(String filepath, List<String> exifTags) {
-        Log.d(TAG, "getEXIFdata: " + filepath + " to file: ");
-        Uri uri; // the URI you've received from the other app
-        InputStream in = null;
-        HashMap<String, String> result = new HashMap<String, String>();
-
-        // TODO if exigTags empty
-        try {
-            in = new FileInputStream(filepath);
-            ExifInterface exifInterface = new ExifInterface(in);
-            for (String tag : exifTags) {
-                String value = exifInterface.getAttribute(tag);
-                result.put(tag, value);
-                Log.d(TAG, "getEXIFdata: " + tag + " -> " + value);
-            }
-        } catch (IOException e) {
-            // Handle any errors
-        } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException ignored) {
-                }
-            }
-        }
-        return result;
-    }
-
-    private static String calculateRational(double d) {
-
-        double rounded = Math.round(d * 100)/100; // TODO proper precision
-        String aString = Double.toString(rounded);
-        String[] fraction = aString.split("\\.");
-
-        int denominator = (int)Math.pow(10, fraction[1].length());
-        int numerator = Integer.parseInt(fraction[0] + "" + fraction[1]);
-
-        Log.d(TAG, "calculateRational: " + numerator + "/" + denominator + "==" + d);
-        return numerator + "/" + denominator;
-    }
-
 }

--- a/app/android/src/uk/co/lutraconsulting/CameraActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/CameraActivity.java
@@ -34,27 +34,8 @@ public class CameraActivity extends Activity {
     private String targetPath;
     private File cameraFile;
 
-    // Sensors
-    int DATA_FREQUENCY = 1000; // in ms // TODO CHANGE
-    int SENSOR_DELAY = SensorManager.SENSOR_DELAY_NORMAL; // 200-300ms, value in micoseconds
     private SensorManager mSensorManager;
     private OrientationSensor orientationSensor;
-
-//    private Sensor mSensorAccelerometer;
-//    private Sensor mSensorMagnetometer;
-//
-//    float[] mGravity;
-//    float[] mGeomagnetic;
-//
-//    // time in ms of last data insertion
-//    long lastRecorderData;
-//
-//    // Current data from accelerometer & magnetometer.  The arrays hold values
-//    // for X, Y, and Z.
-//    private float[] mAccelerometerData = new float[3];
-//    private float[] mMagnetometerData = new float[3];
-//    // stores time (milliseconds) -> azimuth (degrees) for a whole run of the activity
-//    private HashMap<Long, Integer> azimuthData = new HashMap<Long, Integer>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -65,7 +46,7 @@ public class CameraActivity extends Activity {
         mSensorManager = (SensorManager) getSystemService(
                 Context.SENSOR_SERVICE);
         orientationSensor = new OrientationSensor(mSensorManager, null);
-        orientationSensor.Register(this, SENSOR_DELAY);
+        orientationSensor.Register(this, SensorManager.SENSOR_DELAY_NORMAL);
 
         targetPath = getIntent().getExtras().getString("targetPath");
         Log.d(TAG, "targetPath: " + targetPath);
@@ -152,8 +133,9 @@ public class CameraActivity extends Activity {
     }
 
     private void extendGPSExifData(long captureTime) {
-        int degrees = getValueByTime(orientationSensor.m_azimuth_data, captureTime);
-        EXIFUtils.writeExifGpsDirection(cameraFile.getAbsolutePath(), degrees);
+        int bearing = getValueByTime(orientationSensor.m_azimuth_data, captureTime);
+        String bearing_ref = "M"; // stands for Magnetic North since we use magnetic sensor
+        EXIFUtils.writeExifGpsDirection(cameraFile.getAbsolutePath(), bearing, bearing_ref);
         orientationSensor.m_azimuth_data.clear();
     }
 

--- a/app/android/src/uk/co/lutraconsulting/CameraActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/CameraActivity.java
@@ -54,9 +54,6 @@ public class CameraActivity extends Activity implements SensorEventListener {
     private float[] mMagnetometerData = new float[3];
     // stores time -> azimuth (degree) for a whole run of the activity
     private HashMap<Long, Double> azimuthData = new HashMap<Long, Double>();
-    private HashMap<Long, Double> pitchData = new HashMap<Long, Double>();
-    private HashMap<Long, Double> rollData = new HashMap<Long, Double>();
-    private HashMap<Long, Double> cameraAngleData = new HashMap<Long, Double>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -172,12 +169,7 @@ public class CameraActivity extends Activity implements SensorEventListener {
 
         // Store sensor values
         double normDegrees = adjustDegreesToScreenOrientation(degrees);
-        double cameraAngle = adjustCameraAngleOrientation(pitchDegrees, rollDegrees);
-
         azimuthData.put(System.currentTimeMillis(), normDegrees);
-        pitchData.put(System.currentTimeMillis(), pitchDegrees);
-        rollData.put(System.currentTimeMillis(), rollDegrees);
-        cameraAngleData.put(System.currentTimeMillis(), cameraAngle);
     }
 
 
@@ -239,21 +231,12 @@ public class CameraActivity extends Activity implements SensorEventListener {
             // TODO: after copy, verify if is correctly copied and then remove the old one
         }
         finish();
-
-        // TODO
         azimuthData.clear();
-        pitchData.clear();
-        rollData.clear();
-        cameraAngleData.clear();
     }
 
     private void extendGPSExifData(long captureTime) {
         double degrees = getValueByTime(azimuthData, captureTime);
-        double cameraAngle = getValueByTime(cameraAngleData, captureTime);
-        double pitch = getValueByTime(pitchData, captureTime);
-        double roll = getValueByTime(rollData, captureTime);
-
-        EXIFUtils.writeExifGpsDirection(cameraFile.getAbsolutePath(), degrees, cameraAngle, pitch, roll);
+        EXIFUtils.writeExifGpsDirection(cameraFile.getAbsolutePath(), degrees);
     }
 
     private double getValueByTime(HashMap<Long, Double> data, long time) {
@@ -286,25 +269,6 @@ public class CameraActivity extends Activity implements SensorEventListener {
                 return normalizeDegree(degrees + 270);
             }
             default: return degrees;
-        }
-    }
-
-    private double adjustCameraAngleOrientation(double pitch, double roll) {
-        Display display = ((WindowManager) getApplicationContext().getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
-        switch (display.getRotation()) {
-            case Surface.ROTATION_0: {
-                return (360 - pitch);
-            }
-            case Surface.ROTATION_90: {
-                return (360 - roll);
-            }
-            case Surface.ROTATION_180: {
-                return pitch;
-            }
-            case Surface.ROTATION_270: {
-                return roll;
-            }
-            default: return pitch;
         }
     }
 

--- a/app/android/src/uk/co/lutraconsulting/CameraActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/CameraActivity.java
@@ -23,6 +23,7 @@ import android.provider.MediaStore;
 import android.graphics.Bitmap;
 import android.support.v4.content.FileProvider;
 import android.hardware.SensorManager;
+import android.hardware.camera2.CameraManager;
 
 import uk.co.lutraconsulting.EXIFUtils;
 import uk.co.lutraconsulting.OrientationSensor;
@@ -133,9 +134,14 @@ public class CameraActivity extends Activity {
     }
 
     private void extendGPSExifData(long captureTime) {
-        int bearing = getValueByTime(orientationSensor.m_azimuth_data, captureTime);
-        String bearing_ref = "M"; // stands for Magnetic North since we use magnetic sensor
-        EXIFUtils.writeExifGpsDirection(cameraFile.getAbsolutePath(), bearing, bearing_ref);
+        int direction = getValueByTime(orientationSensor.m_azimuth_data, captureTime);
+        if (direction < 0) {
+            Log.d(TAG, "Skipping writing to EXIF, have no data from sensor");
+            return;
+        }
+
+        String direction_ref = "M"; // stands for Magnetic North since we use magnetic sensor
+        EXIFUtils.writeExifGpsDirection(cameraFile.getAbsolutePath(), direction, direction_ref);
         orientationSensor.m_azimuth_data.clear();
     }
 

--- a/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
+++ b/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
@@ -17,145 +17,101 @@ import android.util.Log;
 
 public class EXIFUtils
 {
-  private static final String TAG = "EXIF Utils";
-  // GPS EXIF TAGS
-  private static final String GPS_BEARING_TAG = "GPSDestBearing";
-  private static final String GPS_BEARING_REF_TAG = "GPSDestBearingRef";
-  private static final String GPS_LON_TAG = "GPSLongitude";
-  private static final String GPS_LAT_TAG = "GPSLatitude";
-  private static final String GPS_DATE_TAG = "GPSDateStamp";
+    private static final String TAG = "EXIF Utils";
+    private static final int DEGREE_PRECISION = 2;
+    // GPS EXIF TAGS
+    private static final String GPS_BEARING_TAG = "GPSDestBearing";
+    private static final String GPS_BEARING_REF_TAG = "GPSDestBearingRef";
+    private static final String GPS_LON_TAG = "GPSLongitude";
+    private static final String GPS_LAT_TAG = "GPSLatitude";
+    private static final String GPS_DATE_TAG = "GPSDateStamp";
 
-  public static void writeExifGpsDirection(String src, double exifOrientation) {
-    HashMap<String, String> attributes = new HashMap<String, String>();
-    attributes.put(GPS_BEARING_TAG, calculateRational(exifOrientation));
-    attributes.put(GPS_BEARING_REF_TAG, "M");
-    writeExifAttributes(src, attributes);
-  }
-
-  public static void writeExifAttributes(String src, HashMap<String, String> attributes) {
-    Log.d(TAG, "WriteExif: " + src + " to file: ");
-    InputStream in = null;
-    try {
-      ExifInterface exifInterface = new ExifInterface(src);
-      Log.d(TAG, "Set attributes:");
-      for (String key: attributes.keySet()) {
-        exifInterface.setAttribute(key, attributes.get(key));
-      }
-      exifInterface.saveAttributes();
-    } catch (IOException e) {
-      Log.d(TAG, "WriteExif ERROR: " + e.getMessage());
-      // Handle any errors
-    } finally {
-      if (in != null) {
-        try {
-          in.close();
-        } catch (IOException ignored) {
+    public static void writeExifGpsDirection(String src, double exifOrientation) {
+        if (exifOrientation >= 0 && exifOrientation <= 360) {
+            HashMap<String, String> attributes = new HashMap<String, String>();
+            attributes.put(GPS_BEARING_TAG, calculateRational(exifOrientation));
+            attributes.put(GPS_BEARING_REF_TAG, "M");
+            writeExifAttributes(src, attributes);
         }
-      }
     }
-  }
 
-  // TODO
-  public static void readExif(String src) throws IOException {
-    Log.d(TAG, "readExif: " + src + " to file: ");
-    InputStream in = null;
-    try {
-      in = new FileInputStream(src);
-      ExifInterface exifInterface = new ExifInterface(in);
-      String date = exifInterface.getAttribute("GPSDateStamp");
-      String lat = exifInterface.getAttribute("GPSDestLatitude");
-      String lon = exifInterface.getAttribute("GPSDestLongitude");
-      String lat2 = exifInterface.getAttribute("GPSLatitude");
-      String lon2 = exifInterface.getAttribute("GPSLongitude");
-      String dir = exifInterface.getAttribute("GPSImgDirection");
-      String dir2 = exifInterface.getAttribute("M");
-      String dir3 = exifInterface.getAttribute("T");
-      String dir4 = exifInterface.getAttribute("GPSTrack");
-      String dir5 = exifInterface.getAttribute("GPSDestBearing");
-      String dir5Ref = exifInterface.getAttribute("GPSDestBearingRef");
-      String dir6 = exifInterface.getAttribute("GPSBearing");
-      String gpsInfo = exifInterface.getAttribute("GPSSatellites");
-
-      Log.d(TAG, "readExif LAT: " + lat2);
-      Log.d(TAG, "readExif LON: " + lon2);
-      Log.d(TAG, "readExif DIR: " + dir + "," + dir2 + "," + dir3 + "," + dir4 + "," + dir5 + "," + dir6);
-      Log.d(TAG, "readExif INFO: " + gpsInfo);
-      Log.d(TAG, "readExif TEST: " + dir5 + "|" + dir5Ref);
-
-
-      Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSImgDirectionRef"));
-      Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSTrackRef"));
-      Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSDestBearingRef"));
-
-      Log.d(TAG, "readExif: " + src + " to file: ");
-      // Now you can extract any Exif tag you want
-      // Assuming the image is a JPEG or supported raw format
-    } catch (IOException e) {
-      // Handle any errors
-    } finally {
-      if (in != null) {
+    public static void writeExifAttributes(String src, HashMap<String, String> attributes) {
+        Log.d(TAG, "WriteExif: " + src + " to file: ");
+        InputStream in = null;
         try {
-          in.close();
-        } catch (IOException ignored) {
+            ExifInterface exifInterface = new ExifInterface(src);
+            for (String key: attributes.keySet()) {
+                exifInterface.setAttribute(key, attributes.get(key));
+            }
+            exifInterface.saveAttributes();
+        } catch (IOException e) {
+            // Handle any errors
+            Log.d(TAG, "WriteExif ERROR: " + e.getMessage());
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException ignored) {
+                }
+            }
         }
-      }
     }
-  }
 
-  public static HashMap<String, String> getExifGpsAttributes(String filepath) {
-    List<String> exifTags = new ArrayList<String>();
-    exifTags.add(GPS_BEARING_TAG);
-    exifTags.add(GPS_LAT_TAG);
-    exifTags.add(GPS_LON_TAG);
-    exifTags.add(GPS_DATE_TAG);
+    public static HashMap<String, String> getExifGpsAttributes(String filepath) {
+        List<String> exifTags = new ArrayList<String>();
+        exifTags.add(GPS_BEARING_TAG);
+        exifTags.add(GPS_LAT_TAG);
+        exifTags.add(GPS_LON_TAG);
+        exifTags.add(GPS_DATE_TAG);
 
-    return getEXIFdata(filepath, exifTags);
-  }
+        return getEXIFdata(filepath, exifTags);
+    }
 
-  public static String getEXIFAttribute(String filepath, String tag) {
-    Log.d(TAG, "getEXIFAttribute: " + filepath + " - " + tag);
-    List<String> exifTags = new ArrayList<String>();
-    exifTags.add(tag);
-    return getEXIFdata(filepath, exifTags).get(tag);
-  }
+    public static String getEXIFAttribute(String filepath, String tag) {
+        Log.d(TAG, "getEXIFAttribute: " + filepath + " - " + tag);
+        List<String> exifTags = new ArrayList<String>();
+        exifTags.add(tag);
+        return getEXIFdata(filepath, exifTags).get(tag);
+    }
 
-  public static HashMap<String, String> getEXIFdata(String filepath, List<String> exifTags) {
-    Log.d(TAG, "getEXIFdata: " + filepath + " to file: ");
-    InputStream in = null;
-    HashMap<String, String> result = new HashMap<String, String>();
+    public static HashMap<String, String> getEXIFdata(String filepath, List<String> exifTags) {
+        Log.d(TAG, "getEXIFdata: " + filepath + " to file: ");
+        InputStream in = null;
+        HashMap<String, String> result = new HashMap<String, String>();
 
-    // TODO if exigTags empty
-    try {
-      in = new FileInputStream(filepath);
-      ExifInterface exifInterface = new ExifInterface(in);
-      for (String tag : exifTags) {
-        String value = exifInterface.getAttribute(tag);
-        result.put(tag, value);
-        Log.d(TAG, "getEXIFdata: " + tag + " -> " + value);
-      }
-    } catch (IOException e) {
-      // Handle any errors
-    } finally {
-      if (in != null) {
+        if (exifTags.isEmpty()) return result;
+
         try {
-          in.close();
-        } catch (IOException ignored) {
+            in = new FileInputStream(filepath);
+            ExifInterface exifInterface = new ExifInterface(in);
+            for (String tag : exifTags) {
+                String value = exifInterface.getAttribute(tag);
+                result.put(tag, value);
+                Log.d(TAG, "getEXIFdata: " + tag + " -> " + value);
+            }
+        } catch (IOException e) {
+            // Handle any errors
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException ignored) {
+                }
+            }
         }
-      }
+        return result;
     }
-    return result;
-  }
 
-  private static String calculateRational(double d) {
+    // Converts double value to rational string representation
+    private static String calculateRational(double d) {
 
-    double rounded = Math.round(d * 100)/100; // TODO proper precision
-    String aString = Double.toString(rounded);
-    String[] fraction = aString.split("\\.");
+        double precision_multiplier = Math.pow(10, DEGREE_PRECISION);
+        double rounded = Math.round(d * precision_multiplier)/precision_multiplier;
+        String[] fraction = Double.toString(rounded).split("\\.");
 
-    int denominator = (int)Math.pow(10, fraction[1].length());
-    int numerator = Integer.parseInt(fraction[0] + "" + fraction[1]);
+        int denominator = (int)Math.pow(10, fraction[1].length());
+        int numerator = Integer.parseInt(fraction[0] + "" + fraction[1]);
 
-    Log.d(TAG, "calculateRational: " + numerator + "/" + denominator + "==" + d);
-    return numerator + "/" + denominator;
-  }
+        return numerator + "/" + denominator;
+    }
 }

--- a/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
+++ b/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
@@ -1,0 +1,161 @@
+package uk.co.lutraconsulting;
+
+import android.os.Bundle;
+import androidx.exifinterface.media.ExifInterface;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.FileInputStream;
+import java.io.OutputStream;
+import java.io.FileOutputStream;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import android.util.Log;
+
+public class EXIFUtils
+{
+  private static final String TAG = "EXIF Utils";
+  // GPS EXIF TAGS
+  private static final String GPS_BEARING_TAG = "GPSDestBearing";
+  private static final String GPS_BEARING_REF_TAG = "GPSDestBearingRef";
+  private static final String GPS_LON_TAG = "GPSLongitude";
+  private static final String GPS_LAT_TAG = "GPSLatitude";
+  private static final String GPS_DATE_TAG = "GPSDateStamp";
+
+  public static void writeExifGpsDirection(String src, double exifOrientation) {
+    HashMap<String, String> attributes = new HashMap<String, String>();
+    attributes.put(GPS_BEARING_TAG, calculateRational(exifOrientation));
+    attributes.put(GPS_BEARING_REF_TAG, "M");
+    writeExifAttributes(src, attributes);
+  }
+
+  public static void writeExifAttributes(String src, HashMap<String, String> attributes) {
+    Log.d(TAG, "WriteExif: " + src + " to file: ");
+    InputStream in = null;
+    try {
+      ExifInterface exifInterface = new ExifInterface(src);
+      Log.d(TAG, "Set attributes:");
+      for (String key: attributes.keySet()) {
+        exifInterface.setAttribute(key, attributes.get(key));
+      }
+      exifInterface.saveAttributes();
+    } catch (IOException e) {
+      Log.d(TAG, "WriteExif ERROR: " + e.getMessage());
+      // Handle any errors
+    } finally {
+      if (in != null) {
+        try {
+          in.close();
+        } catch (IOException ignored) {
+        }
+      }
+    }
+  }
+
+  // TODO
+  public static void readExif(String src) throws IOException {
+    Log.d(TAG, "readExif: " + src + " to file: ");
+    InputStream in = null;
+    try {
+      in = new FileInputStream(src);
+      ExifInterface exifInterface = new ExifInterface(in);
+      String date = exifInterface.getAttribute("GPSDateStamp");
+      String lat = exifInterface.getAttribute("GPSDestLatitude");
+      String lon = exifInterface.getAttribute("GPSDestLongitude");
+      String lat2 = exifInterface.getAttribute("GPSLatitude");
+      String lon2 = exifInterface.getAttribute("GPSLongitude");
+      String dir = exifInterface.getAttribute("GPSImgDirection");
+      String dir2 = exifInterface.getAttribute("M");
+      String dir3 = exifInterface.getAttribute("T");
+      String dir4 = exifInterface.getAttribute("GPSTrack");
+      String dir5 = exifInterface.getAttribute("GPSDestBearing");
+      String dir5Ref = exifInterface.getAttribute("GPSDestBearingRef");
+      String dir6 = exifInterface.getAttribute("GPSBearing");
+      String gpsInfo = exifInterface.getAttribute("GPSSatellites");
+
+      Log.d(TAG, "readExif LAT: " + lat2);
+      Log.d(TAG, "readExif LON: " + lon2);
+      Log.d(TAG, "readExif DIR: " + dir + "," + dir2 + "," + dir3 + "," + dir4 + "," + dir5 + "," + dir6);
+      Log.d(TAG, "readExif INFO: " + gpsInfo);
+      Log.d(TAG, "readExif TEST: " + dir5 + "|" + dir5Ref);
+
+
+      Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSImgDirectionRef"));
+      Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSTrackRef"));
+      Log.d(TAG, "readExif REF: " + exifInterface.getAttribute("GPSDestBearingRef"));
+
+      Log.d(TAG, "readExif: " + src + " to file: ");
+      // Now you can extract any Exif tag you want
+      // Assuming the image is a JPEG or supported raw format
+    } catch (IOException e) {
+      // Handle any errors
+    } finally {
+      if (in != null) {
+        try {
+          in.close();
+        } catch (IOException ignored) {
+        }
+      }
+    }
+  }
+
+  public static HashMap<String, String> getExifGpsAttributes(String filepath) {
+    List<String> exifTags = new ArrayList<String>();
+    exifTags.add(GPS_BEARING_TAG);
+    exifTags.add(GPS_LAT_TAG);
+    exifTags.add(GPS_LON_TAG);
+    exifTags.add(GPS_DATE_TAG);
+
+    return getEXIFdata(filepath, exifTags);
+  }
+
+  public static String getEXIFAttribute(String filepath, String tag) {
+    Log.d(TAG, "getEXIFAttribute: " + filepath + " - " + tag);
+    List<String> exifTags = new ArrayList<String>();
+    exifTags.add(tag);
+    return getEXIFdata(filepath, exifTags).get(tag);
+  }
+
+  public static HashMap<String, String> getEXIFdata(String filepath, List<String> exifTags) {
+    Log.d(TAG, "getEXIFdata: " + filepath + " to file: ");
+    InputStream in = null;
+    HashMap<String, String> result = new HashMap<String, String>();
+
+    // TODO if exigTags empty
+    try {
+      in = new FileInputStream(filepath);
+      ExifInterface exifInterface = new ExifInterface(in);
+      for (String tag : exifTags) {
+        String value = exifInterface.getAttribute(tag);
+        result.put(tag, value);
+        Log.d(TAG, "getEXIFdata: " + tag + " -> " + value);
+      }
+    } catch (IOException e) {
+      // Handle any errors
+    } finally {
+      if (in != null) {
+        try {
+          in.close();
+        } catch (IOException ignored) {
+        }
+      }
+    }
+    return result;
+  }
+
+  private static String calculateRational(double d) {
+
+    double rounded = Math.round(d * 100)/100; // TODO proper precision
+    String aString = Double.toString(rounded);
+    String[] fraction = aString.split("\\.");
+
+    int denominator = (int)Math.pow(10, fraction[1].length());
+    int numerator = Integer.parseInt(fraction[0] + "" + fraction[1]);
+
+    Log.d(TAG, "calculateRational: " + numerator + "/" + denominator + "==" + d);
+    return numerator + "/" + denominator;
+  }
+}

--- a/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
+++ b/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
@@ -25,14 +25,19 @@ public class EXIFUtils
     private static final String GPS_LON_TAG = "GPSLongitude";
     private static final String GPS_LAT_TAG = "GPSLatitude";
     private static final String GPS_DATE_TAG = "GPSDateStamp";
+    // Experimental TAGS
+    private static final String CAMERA_ELEVATION_TAG = "CameraElevationAngle";
+    private static final String GPS_ROLL_TAG = "GPSRoll";
+    private static final String GPS_PITCH_TAG = "GPSPitch";
 
-    public static void writeExifGpsDirection(String src, double exifOrientation) {
-        if (exifOrientation >= 0 && exifOrientation <= 360) {
-            HashMap<String, String> attributes = new HashMap<String, String>();
-            attributes.put(GPS_BEARING_TAG, calculateRational(exifOrientation));
-            attributes.put(GPS_BEARING_REF_TAG, "M");
-            writeExifAttributes(src, attributes);
-        }
+    public static void writeExifGpsDirection(String src, double exifOrientation, double cameraAngle, double pitch, double roll) {
+        HashMap<String, String> attributes = new HashMap<String, String>();
+        attributes.put(CAMERA_ELEVATION_TAG, calculateRational(cameraAngle));
+        attributes.put(GPS_PITCH_TAG, calculateRational(pitch));
+        attributes.put(GPS_ROLL_TAG, calculateRational(roll));
+        attributes.put(GPS_BEARING_TAG, calculateRational(exifOrientation));
+        attributes.put(GPS_BEARING_REF_TAG, "M");
+        writeExifAttributes(src, attributes);
     }
 
     public static void writeExifAttributes(String src, HashMap<String, String> attributes) {
@@ -63,6 +68,10 @@ public class EXIFUtils
         exifTags.add(GPS_LAT_TAG);
         exifTags.add(GPS_LON_TAG);
         exifTags.add(GPS_DATE_TAG);
+
+        exifTags.add(GPS_PITCH_TAG);
+        exifTags.add(GPS_ROLL_TAG);
+        exifTags.add(CAMERA_ELEVATION_TAG);
 
         return getEXIFdata(filepath, exifTags);
     }

--- a/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
+++ b/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
@@ -26,9 +26,9 @@ public class EXIFUtils
     private static final String GPS_LAT_TAG = "GPSLatitude";
     private static final String GPS_DATE_TAG = "GPSDateStamp";
 
-    public static void writeExifGpsDirection(String src, double exifOrientation) {
+    public static void writeExifGpsDirection(String src, int exifOrientation) {
         HashMap<String, String> attributes = new HashMap<String, String>();
-        attributes.put(GPS_BEARING_TAG, calculateRational(exifOrientation));
+        attributes.put(GPS_BEARING_TAG, exifOrientation + "/1"); // has to be in rational format
         attributes.put(GPS_BEARING_REF_TAG, "M");
         writeExifAttributes(src, attributes);
     }
@@ -97,18 +97,5 @@ public class EXIFUtils
             }
         }
         return result;
-    }
-
-    // Converts double value to rational string representation
-    private static String calculateRational(double d) {
-
-        double precision_multiplier = Math.pow(10, DEGREE_PRECISION);
-        double rounded = Math.round(d * precision_multiplier)/precision_multiplier;
-        String[] fraction = Double.toString(rounded).split("\\.");
-
-        int denominator = (int)Math.pow(10, fraction[1].length());
-        int numerator = Integer.parseInt(fraction[0] + "" + fraction[1]);
-
-        return numerator + "/" + denominator;
     }
 }

--- a/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
+++ b/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
@@ -26,10 +26,10 @@ public class EXIFUtils
     private static final String GPS_LAT_TAG = "GPSLatitude";
     private static final String GPS_DATE_TAG = "GPSDateStamp";
 
-    public static void writeExifGpsDirection(String src, int exifOrientation) {
+    public static void writeExifGpsDirection(String src, int bearing, String bearing_ref) {
         HashMap<String, String> attributes = new HashMap<String, String>();
-        attributes.put(GPS_BEARING_TAG, exifOrientation + "/1"); // has to be in rational format
-        attributes.put(GPS_BEARING_REF_TAG, "M");
+        attributes.put(GPS_BEARING_TAG, bearing + "/1"); // has to be in rational format
+        attributes.put(GPS_BEARING_REF_TAG, bearing_ref);
         writeExifAttributes(src, attributes);
     }
 
@@ -40,6 +40,7 @@ public class EXIFUtils
             ExifInterface exifInterface = new ExifInterface(src);
             for (String key: attributes.keySet()) {
                 exifInterface.setAttribute(key, attributes.get(key));
+                Log.d(TAG, "Set attribute: " + key + " -> " + attributes.get(key));
             }
             exifInterface.saveAttributes();
         } catch (IOException e) {

--- a/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
+++ b/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
@@ -32,7 +32,7 @@ public class EXIFUtils
      * @param direction_ref Either "M" as Magnetic North or "T" as True North
      */
     public static void writeExifGpsDirection(String src, int direction, String direction_ref) {
-        if (direction >= 0 || direction <= 359) {
+        if (direction >= 0 && direction <= 359) {
             HashMap<String, String> attributes = new HashMap<String, String>();
             attributes.put(GPS_DIRECTION_TAG, direction + "/1"); // has to be in rational format
             attributes.put(GPS_DIRECTION_REF_TAG, direction_ref);

--- a/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
+++ b/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
@@ -25,16 +25,9 @@ public class EXIFUtils
     private static final String GPS_LON_TAG = "GPSLongitude";
     private static final String GPS_LAT_TAG = "GPSLatitude";
     private static final String GPS_DATE_TAG = "GPSDateStamp";
-    // Experimental TAGS
-    private static final String CAMERA_ELEVATION_TAG = "CameraElevationAngle";
-    private static final String GPS_ROLL_TAG = "GPSRoll";
-    private static final String GPS_PITCH_TAG = "GPSPitch";
 
-    public static void writeExifGpsDirection(String src, double exifOrientation, double cameraAngle, double pitch, double roll) {
+    public static void writeExifGpsDirection(String src, double exifOrientation) {
         HashMap<String, String> attributes = new HashMap<String, String>();
-        attributes.put(CAMERA_ELEVATION_TAG, calculateRational(cameraAngle));
-        attributes.put(GPS_PITCH_TAG, calculateRational(pitch));
-        attributes.put(GPS_ROLL_TAG, calculateRational(roll));
         attributes.put(GPS_BEARING_TAG, calculateRational(exifOrientation));
         attributes.put(GPS_BEARING_REF_TAG, "M");
         writeExifAttributes(src, attributes);
@@ -68,11 +61,6 @@ public class EXIFUtils
         exifTags.add(GPS_LAT_TAG);
         exifTags.add(GPS_LON_TAG);
         exifTags.add(GPS_DATE_TAG);
-
-        exifTags.add(GPS_PITCH_TAG);
-        exifTags.add(GPS_ROLL_TAG);
-        exifTags.add(CAMERA_ELEVATION_TAG);
-
         return getEXIFdata(filepath, exifTags);
     }
 

--- a/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
+++ b/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
@@ -26,7 +26,7 @@ public class EXIFUtils
     private static final String GPS_DATE_TAG = "GPSDateStamp";
 
     /**
-     * Writes EXIF data related to bering.
+     * Writes image direction to EXIF metadata.
      * @param src Absolute path of a file
      * @param direction [0-359] degrees (0=North, 90=East, ...)
      * @param direction_ref Either "M" as Magnetic North or "T" as True North
@@ -38,12 +38,12 @@ public class EXIFUtils
             attributes.put(GPS_DIRECTION_REF_TAG, direction_ref);
             writeExifAttributes(src, attributes);
         } else {
-            Log.d(TAG, "Skipped writing bearing (" + direction + ") - it is out of the range");
+            Log.d(TAG, "Skipped writing direction (" + direction + ") - it is out of the range");
         }
     }
 
     /**
-     * Writes EXIF data.
+     * Writes given attributes to EXIF metadata.
      * @param src Absolute path of a file
      * @param attributes Map of exif tag -> value to be written into EXIF
      */

--- a/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
+++ b/app/android/src/uk/co/lutraconsulting/EXIFUtils.java
@@ -18,21 +18,35 @@ import android.util.Log;
 public class EXIFUtils
 {
     private static final String TAG = "EXIF Utils";
-    private static final int DEGREE_PRECISION = 2;
     // GPS EXIF TAGS
-    private static final String GPS_BEARING_TAG = "GPSDestBearing";
-    private static final String GPS_BEARING_REF_TAG = "GPSDestBearingRef";
+    private static final String GPS_DIRECTION_TAG = "GPSImgDirection";
+    private static final String GPS_DIRECTION_REF_TAG = "GPSImgDirectionRef";
     private static final String GPS_LON_TAG = "GPSLongitude";
     private static final String GPS_LAT_TAG = "GPSLatitude";
     private static final String GPS_DATE_TAG = "GPSDateStamp";
 
-    public static void writeExifGpsDirection(String src, int bearing, String bearing_ref) {
-        HashMap<String, String> attributes = new HashMap<String, String>();
-        attributes.put(GPS_BEARING_TAG, bearing + "/1"); // has to be in rational format
-        attributes.put(GPS_BEARING_REF_TAG, bearing_ref);
-        writeExifAttributes(src, attributes);
+    /**
+     * Writes EXIF data related to bering.
+     * @param src Absolute path of a file
+     * @param direction [0-359] degrees (0=North, 90=East, ...)
+     * @param direction_ref Either "M" as Magnetic North or "T" as True North
+     */
+    public static void writeExifGpsDirection(String src, int direction, String direction_ref) {
+        if (direction >= 0 || direction <= 359) {
+            HashMap<String, String> attributes = new HashMap<String, String>();
+            attributes.put(GPS_DIRECTION_TAG, direction + "/1"); // has to be in rational format
+            attributes.put(GPS_DIRECTION_REF_TAG, direction_ref);
+            writeExifAttributes(src, attributes);
+        } else {
+            Log.d(TAG, "Skipped writing bearing (" + direction + ") - it is out of the range");
+        }
     }
 
+    /**
+     * Writes EXIF data.
+     * @param src Absolute path of a file
+     * @param attributes Map of exif tag -> value to be written into EXIF
+     */
     public static void writeExifAttributes(String src, HashMap<String, String> attributes) {
         Log.d(TAG, "WriteExif: " + src + " to file: ");
         InputStream in = null;
@@ -58,13 +72,19 @@ public class EXIFUtils
 
     public static HashMap<String, String> getExifGpsAttributes(String filepath) {
         List<String> exifTags = new ArrayList<String>();
-        exifTags.add(GPS_BEARING_TAG);
+        exifTags.add(GPS_DIRECTION_TAG);
         exifTags.add(GPS_LAT_TAG);
         exifTags.add(GPS_LON_TAG);
         exifTags.add(GPS_DATE_TAG);
         return getEXIFdata(filepath, exifTags);
     }
 
+    /**
+     * Reads and returns EXIF values for given file and for given EXIF Tag.
+     * @param filepath Absolute path of a file
+     * @param tag String EXIF tag to be read
+     * @return String EXIF value for given parameters
+     */
     public static String getEXIFAttribute(String filepath, String tag) {
         Log.d(TAG, "getEXIFAttribute: " + filepath + " - " + tag);
         List<String> exifTags = new ArrayList<String>();
@@ -72,6 +92,12 @@ public class EXIFUtils
         return getEXIFdata(filepath, exifTags).get(tag);
     }
 
+    /**
+     * Reads and returns EXIF values for given file and for given EXIF Tags.
+     * @param filepath Absolute path of a file
+     * @param exifTags List of EXIF tags to read
+     * @return Map of EXIF tag -> values
+     */
     public static HashMap<String, String> getEXIFdata(String filepath, List<String> exifTags) {
         Log.d(TAG, "getEXIFdata: " + filepath + " to file: ");
         InputStream in = null;

--- a/app/android/src/uk/co/lutraconsulting/OrientationSensor.java
+++ b/app/android/src/uk/co/lutraconsulting/OrientationSensor.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 public class OrientationSensor implements SensorEventListener {
 
     public final static int SENSOR_UNAVAILABLE = -1;
-    public final static int DATA_FREQUENCY = 500; // in ms
+    public final static int DATA_FREQUENCY = 100; // in ms
     private static final String TAG = "Orientation sensor";
 
     // references to other objects

--- a/app/android/src/uk/co/lutraconsulting/OrientationSensor.java
+++ b/app/android/src/uk/co/lutraconsulting/OrientationSensor.java
@@ -6,6 +6,7 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.view.Surface;
+import android.util.Log;
 
 import java.util.HashMap;
 
@@ -19,6 +20,7 @@ public class OrientationSensor implements SensorEventListener {
 
     public final static int SENSOR_UNAVAILABLE = -1;
     public final static int DATA_FREQUENCY = 500; // in ms
+    private static final String TAG = "Orientation sensor";
 
     // references to other objects
     SensorManager m_sm;
@@ -171,6 +173,8 @@ public class OrientationSensor implements SensorEventListener {
                 double azimuth_degrees = (Math.toDegrees(m_azimuth_radians) + 360) % 360;
                 m_azimuth_data.put(System.currentTimeMillis(), (int) azimuth_degrees);
             }
+        } else {
+            Log.d(TAG, "Sensors are not available");
         }
         if (m_parent != null) m_parent.onSensorChanged(evnt);
     }

--- a/app/android/src/uk/co/lutraconsulting/OrientationSensor.java
+++ b/app/android/src/uk/co/lutraconsulting/OrientationSensor.java
@@ -1,0 +1,191 @@
+package uk.co.lutraconsulting;
+
+import android.app.Activity;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+import android.view.Surface;
+
+import java.util.HashMap;
+
+/**
+ * Sensor reads data from gravity and magnetic sensor and calculates azimuth. It is converted to degree and the value is
+ * stored with DATA_FREQUENCY in a map. The calculation takes into account device rotation (screen orientation and tilt).
+ * Implementation taken from:
+ * https://stackoverflow.com/questions/16317599/android-compass-that-can-compensate-for-tilt-and-pitch
+ */
+public class OrientationSensor implements SensorEventListener {
+
+    public final static int SENSOR_UNAVAILABLE = -1;
+    public final static int DATA_FREQUENCY = 500; // in ms
+
+    // references to other objects
+    SensorManager m_sm;
+    SensorEventListener m_parent;   // non-null if this class should call its parent after onSensorChanged(...) and onAccuracyChanged(...) notifications
+    Activity m_activity;            // current activity for call to getWindowManager().getDefaultDisplay().getRotation()
+    // stores time (milliseconds) -> azimuth (degrees) for a whole run of the activity
+    HashMap<Long, Integer> m_azimuth_data = new HashMap<Long, Integer>();
+    // time in ms of last data insertion
+    long lastRecorderData;
+
+    // raw inputs from Android sensors
+    float m_Norm_Gravity;           // length of raw gravity vector received in onSensorChanged(...).  NB: should be about 10
+    float[] m_NormGravityVector;    // Normalised gravity vector, (i.e. length of this vector is 1), which points straight up into space
+    float m_Norm_MagField;          // length of raw magnetic field vector received in onSensorChanged(...).
+    float[] m_NormMagFieldValues;   // Normalised magnetic field vector, (i.e. length of this vector is 1)
+
+    // accuracy specifications. SENSOR_UNAVAILABLE if unknown, otherwise SensorManager.SENSOR_STATUS_UNRELIABLE, SENSOR_STATUS_ACCURACY_LOW, SENSOR_STATUS_ACCURACY_MEDIUM or SENSOR_STATUS_ACCURACY_HIGH
+    int m_GravityAccuracy;          // accuracy of gravity sensor
+    int m_MagneticFieldAccuracy;    // accuracy of magnetic field sensor
+
+    // values calculated once gravity and magnetic field vectors are available
+    float[] m_NormEastVector;       // normalised cross product of raw gravity vector with magnetic field values, points east
+    float[] m_NormNorthVector;      // Normalised vector pointing to magnetic north
+    boolean m_OrientationOK;        // set true if m_azimuth_radians and m_pitch_radians have successfully been calculated following a call to onSensorChanged(...)
+    float m_azimuth_radians;        // angle of the device from magnetic north
+    float m_pitch_radians;          // tilt angle of the device from the horizontal.  m_pitch_radians = 0 if the device if flat, m_pitch_radians = Math.PI/2 means the device is upright.
+    float m_pitch_axis_radians;     // angle which defines the axis for the rotation m_pitch_radians
+
+    public OrientationSensor(SensorManager sm, SensorEventListener parent) {
+        m_sm = sm;
+        m_parent = parent;
+        m_activity = null;
+        m_NormGravityVector = m_NormMagFieldValues = null;
+        m_NormEastVector = new float[3];
+        m_NormNorthVector = new float[3];
+        m_OrientationOK = false;
+    }
+
+    public int Register(Activity activity, int sensorSpeed) {
+        m_activity = activity;  // current activity required for call to getWindowManager().getDefaultDisplay().getRotation()
+        m_NormGravityVector = new float[3];
+        m_NormMagFieldValues = new float[3];
+        m_OrientationOK = false;
+        int count = 0;
+        Sensor SensorGravity = m_sm.getDefaultSensor(Sensor.TYPE_GRAVITY);
+        if (SensorGravity != null) {
+            m_sm.registerListener(this, SensorGravity, sensorSpeed);
+            m_GravityAccuracy = SensorManager.SENSOR_STATUS_ACCURACY_HIGH;
+            count++;
+        } else {
+            m_GravityAccuracy = SENSOR_UNAVAILABLE;
+        }
+        Sensor SensorMagField = m_sm.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
+        if (SensorMagField != null) {
+            m_sm.registerListener(this, SensorMagField, sensorSpeed);
+            m_MagneticFieldAccuracy = SensorManager.SENSOR_STATUS_ACCURACY_HIGH;
+            count++;
+        } else {
+            m_MagneticFieldAccuracy = SENSOR_UNAVAILABLE;
+        }
+        return count;
+    }
+
+    public void Unregister() {
+        m_activity = null;
+        m_NormGravityVector = m_NormMagFieldValues = null;
+        m_OrientationOK = false;
+        m_sm.unregisterListener(this);
+    }
+
+    @Override
+    public void onSensorChanged(SensorEvent evnt) {
+        // ignores any update if is within DATA_FREQUENCY time
+        long currentTime = System.currentTimeMillis();
+        if (currentTime - lastRecorderData <= DATA_FREQUENCY) {
+            return;
+        }
+        lastRecorderData = currentTime;
+
+        int SensorType = evnt.sensor.getType();
+        switch (SensorType) {
+            case Sensor.TYPE_GRAVITY:
+                if (m_NormGravityVector == null) m_NormGravityVector = new float[3];
+                System.arraycopy(evnt.values, 0, m_NormGravityVector, 0, m_NormGravityVector.length);
+                m_Norm_Gravity = (float) Math.sqrt(m_NormGravityVector[0] * m_NormGravityVector[0] + m_NormGravityVector[1] * m_NormGravityVector[1] + m_NormGravityVector[2] * m_NormGravityVector[2]);
+                for (int i = 0; i < m_NormGravityVector.length; i++) m_NormGravityVector[i] /= m_Norm_Gravity;
+                break;
+            case Sensor.TYPE_MAGNETIC_FIELD:
+                if (m_NormMagFieldValues == null) m_NormMagFieldValues = new float[3];
+                System.arraycopy(evnt.values, 0, m_NormMagFieldValues, 0, m_NormMagFieldValues.length);
+                m_Norm_MagField = (float) Math.sqrt(m_NormMagFieldValues[0] * m_NormMagFieldValues[0] + m_NormMagFieldValues[1] * m_NormMagFieldValues[1] + m_NormMagFieldValues[2] * m_NormMagFieldValues[2]);
+                for (int i = 0; i < m_NormMagFieldValues.length; i++) m_NormMagFieldValues[i] /= m_Norm_MagField;
+                break;
+        }
+        if (m_NormGravityVector != null && m_NormMagFieldValues != null) {
+            // first calculate the horizontal vector that points due east
+            float East_x = m_NormMagFieldValues[1] * m_NormGravityVector[2] - m_NormMagFieldValues[2] * m_NormGravityVector[1];
+            float East_y = m_NormMagFieldValues[2] * m_NormGravityVector[0] - m_NormMagFieldValues[0] * m_NormGravityVector[2];
+            float East_z = m_NormMagFieldValues[0] * m_NormGravityVector[1] - m_NormMagFieldValues[1] * m_NormGravityVector[0];
+            float norm_East = (float) Math.sqrt(East_x * East_x + East_y * East_y + East_z * East_z);
+            if (m_Norm_Gravity * m_Norm_MagField * norm_East < 0.1f) {  // Typical values are  > 100.
+                m_OrientationOK = false; // device is close to free fall (or in space?), or close to magnetic north pole.
+            } else {
+                m_NormEastVector[0] = East_x / norm_East;
+                m_NormEastVector[1] = East_y / norm_East;
+                m_NormEastVector[2] = East_z / norm_East;
+
+                // next calculate the horizontal vector that points due north
+                float M_dot_G = (m_NormGravityVector[0] * m_NormMagFieldValues[0] + m_NormGravityVector[1] * m_NormMagFieldValues[1] + m_NormGravityVector[2] * m_NormMagFieldValues[2]);
+                float North_x = m_NormMagFieldValues[0] - m_NormGravityVector[0] * M_dot_G;
+                float North_y = m_NormMagFieldValues[1] - m_NormGravityVector[1] * M_dot_G;
+                float North_z = m_NormMagFieldValues[2] - m_NormGravityVector[2] * M_dot_G;
+                float norm_North = (float) Math.sqrt(North_x * North_x + North_y * North_y + North_z * North_z);
+                m_NormNorthVector[0] = North_x / norm_North;
+                m_NormNorthVector[1] = North_y / norm_North;
+                m_NormNorthVector[2] = North_z / norm_North;
+
+                // take account of screen rotation away from its natural rotation
+                int rotation = m_activity.getWindowManager().getDefaultDisplay().getRotation();
+                float screen_adjustment = 0;
+                switch (rotation) {
+                    case Surface.ROTATION_0:
+                        screen_adjustment = 0;
+                        break;
+                    case Surface.ROTATION_90:
+                        screen_adjustment = (float) Math.PI / 2;
+                        break;
+                    case Surface.ROTATION_180:
+                        screen_adjustment = (float) Math.PI;
+                        break;
+                    case Surface.ROTATION_270:
+                        screen_adjustment = 3 * (float) Math.PI / 2;
+                        break;
+                }
+                // NB: the rotation matrix has now effectively been calculated. It consists of the three vectors m_NormEastVector[], m_NormNorthVector[] and m_NormGravityVector[]
+
+                // calculate all the required angles from the rotation matrix
+                // NB: see https://math.stackexchange.com/questions/381649/whats-the-best-3d-angular-co-ordinate-system-for-working-with-smartfone-apps
+                float sin = m_NormEastVector[1] - m_NormNorthVector[0], cos = m_NormEastVector[0] + m_NormNorthVector[1];
+                m_azimuth_radians = (float) (sin != 0 && cos != 0 ? Math.atan2(sin, cos) : 0);
+                m_pitch_radians = (float) Math.acos(m_NormGravityVector[2]);
+                sin = -m_NormEastVector[1] - m_NormNorthVector[0];
+                cos = m_NormEastVector[0] - m_NormNorthVector[1];
+                float aximuth_plus_two_pitch_axis_radians = (float) (sin != 0 && cos != 0 ? Math.atan2(sin, cos) : 0);
+                m_pitch_axis_radians = (float) (aximuth_plus_two_pitch_axis_radians - m_azimuth_radians) / 2;
+                m_azimuth_radians += screen_adjustment;
+                m_pitch_axis_radians += screen_adjustment;
+                m_OrientationOK = true;
+
+                double azimuth_degrees = (Math.toDegrees(m_azimuth_radians) + 360) % 360;
+                m_azimuth_data.put(System.currentTimeMillis(), (int) azimuth_degrees);
+            }
+        }
+        if (m_parent != null) m_parent.onSensorChanged(evnt);
+    }
+
+    @Override
+    public void onAccuracyChanged(Sensor sensor, int accuracy) {
+        int SensorType = sensor.getType();
+        switch (SensorType) {
+            case Sensor.TYPE_GRAVITY:
+                m_GravityAccuracy = accuracy;
+                break;
+            case Sensor.TYPE_MAGNETIC_FIELD:
+                m_MagneticFieldAccuracy = accuracy;
+                break;
+        }
+        if (m_parent != null) m_parent.onAccuracyChanged(sensor, accuracy);
+    }
+}

--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -76,8 +76,8 @@ bool AndroidUtils::checkAndAcquirePermissions( const QString &permissionString )
 QString AndroidUtils::getExifInfo( const QString &filePath )
 {
   QAndroidJniObject jFilePath = QAndroidJniObject::fromString( filePath );
-  QAndroidJniObject jTag = QAndroidJniObject::fromString( "TODO" );
-  QAndroidJniObject attribute = QAndroidJniObject::callStaticObjectMethod( "uk.co.lutraconsulting.CameraActivity",
+  QAndroidJniObject jTag = QAndroidJniObject::fromString( "GPSDestBearing" ); // TODO
+  QAndroidJniObject attribute = QAndroidJniObject::callStaticObjectMethod( "uk.co.lutraconsulting.EXIFUtils",
                                 "getEXIFAttribute",
                                 "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
                                 jFilePath.object<jstring>(),

--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -73,6 +73,18 @@ bool AndroidUtils::checkAndAcquirePermissions( const QString &permissionString )
   return true;
 }
 
+QString AndroidUtils::getExifInfo( const QString &filePath )
+{
+  QAndroidJniObject jFilePath = QAndroidJniObject::fromString( filePath );
+  QAndroidJniObject jTag = QAndroidJniObject::fromString( "TODO" );
+  QAndroidJniObject attribute = QAndroidJniObject::callStaticObjectMethod( "uk.co.lutraconsulting.CameraActivity",
+                                "getEXIFAttribute",
+                                "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+                                jFilePath.object<jstring>(),
+                                jTag.object<jstring>() );
+  return attribute.toString();
+}
+
 bool AndroidUtils::checkPermission( const QString &permissionString )
 {
 #ifdef ANDROID
@@ -226,6 +238,8 @@ void AndroidUtils::handleActivityResult( int receiverRequestCode, int resultCode
     QString absolutePath = absolutePathJNI.toString();
 
     QString selectedImagePath = "file://" + absolutePath;
+    getExifInfo( absolutePath );
+
     emit imageSelected( absolutePath );
   }
   else

--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -73,11 +73,11 @@ bool AndroidUtils::checkAndAcquirePermissions( const QString &permissionString )
   return true;
 }
 
-QString AndroidUtils::getExifInfo( const QString &filePath )
+QString AndroidUtils::getExifInfo( const QString &filePath, const QString &tag )
 {
 #ifdef ANDROID
   QAndroidJniObject jFilePath = QAndroidJniObject::fromString( filePath );
-  QAndroidJniObject jTag = QAndroidJniObject::fromString( "GPSDestBearing" ); // TODO
+  QAndroidJniObject jTag = QAndroidJniObject::fromString( tag );
   QAndroidJniObject attribute = QAndroidJniObject::callStaticObjectMethod( "uk.co.lutraconsulting.EXIFUtils",
                                 "getEXIFAttribute",
                                 "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
@@ -242,7 +242,6 @@ void AndroidUtils::handleActivityResult( int receiverRequestCode, int resultCode
     QString absolutePath = absolutePathJNI.toString();
 
     QString selectedImagePath = "file://" + absolutePath;
-    getExifInfo( absolutePath );
 
     emit imageSelected( absolutePath );
   }

--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -75,6 +75,7 @@ bool AndroidUtils::checkAndAcquirePermissions( const QString &permissionString )
 
 QString AndroidUtils::getExifInfo( const QString &filePath )
 {
+#ifdef ANDROID
   QAndroidJniObject jFilePath = QAndroidJniObject::fromString( filePath );
   QAndroidJniObject jTag = QAndroidJniObject::fromString( "GPSDestBearing" ); // TODO
   QAndroidJniObject attribute = QAndroidJniObject::callStaticObjectMethod( "uk.co.lutraconsulting.EXIFUtils",
@@ -83,6 +84,9 @@ QString AndroidUtils::getExifInfo( const QString &filePath )
                                 jFilePath.object<jstring>(),
                                 jTag.object<jstring>() );
   return attribute.toString();
+#else
+  return QString();
+#endif
 }
 
 bool AndroidUtils::checkPermission( const QString &permissionString )

--- a/app/androidutils.h
+++ b/app/androidutils.h
@@ -34,6 +34,9 @@ class AndroidUtils: public QObject
     static void requirePermissions();
     static bool checkAndAcquirePermissions( const QString &permissionString );
 
+    //! Calls getEXIFAttribute from Java
+    static QString getExifInfo( const QString &filePath );
+
     Q_INVOKABLE bool requestStoragePermission();
     bool requestCameraPermission();
 

--- a/app/androidutils.h
+++ b/app/androidutils.h
@@ -34,8 +34,13 @@ class AndroidUtils: public QObject
     static void requirePermissions();
     static bool checkAndAcquirePermissions( const QString &permissionString );
 
-    //! Calls getEXIFAttribute from Java
-    static QString getExifInfo( const QString &filePath );
+    /**
+     * Reads EXIF and returns value for given parameters.
+     * @param filePath Absolute path to a file
+     * @param tag EXIF string tag
+     * @return String value of EXIF attribute for given parameters. Note that rational numbers are still in rational string format.
+     */
+    static QString getExifInfo( const QString &filePath, const QString &tag );
 
     Q_INVOKABLE bool requestStoragePermission();
     bool requestCameraPermission();


### PR DESCRIPTION
Writes azimuth direction as EXIF GPSImgDirection attribute.

Azimuth is read from sensors and stored with a timestamp. When the camera activity is finished, the proper azimuth value is fetched according the capture photo file timestamp. Note that we use temporary photo file created by a camera, not the copied that is used as value for a field. This suppose to ensure to get a timestamp of the event when user actually hits the capture button.

The azimuth degree takes into consideration device screen rotation and tilt. The value is written with flag `GpsImgDirection`.

LIMITATIONS:
- currently only rear camera is supported for a correct result
- may take sometime ~1s to init sensors at the beginning of capturing

This is not ideal solution, but couldn't get onCapture listener working in reasonable time.

Also contains functions to write EXIF attributes.