### PR TITLE
Add vertical space before group header

### DIFF
--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -221,7 +221,7 @@ Drawer {
                   property real bottomMargin: 1 * QgsQuick.Utils.dp
                   property real height: 64 * QgsQuick.Utils.dp
                   property color fontColor: InputStyle.fontColor
-                  property int spacing: 0
+                  property int spacing: InputStyle.formSpacing
                   property int fontPixelSize: 24 * QgsQuick.Utils.dp
                 }
 

--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -58,6 +58,7 @@ QtObject {
     property real cornerRadius: 8 * QgsQuick.Utils.dp
     property real innerFieldMargin: 10 * QgsQuick.Utils.dp  // TODO rename fieldMargin
     property real outerFieldMargin: 20 * QgsQuick.Utils.dp  // TODO change for PanelMargin
+    property real formSpacing: 10 * QgsQuick.Utils.dp
 
     property real refWidth: 640
     property real refHeight: 1136

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -453,7 +453,8 @@ Item {
     Item {
       id: fieldContainer
       visible: Type === 'field'
-      height: childrenRect.height
+      // We also need to set height to zero if Type is not field otherwise children created blank space in form
+      height: Type === 'field' ? childrenRect.height : 0
 
       anchors {
         left: parent.left

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -378,7 +378,7 @@ Item {
 
                 Rectangle {
                   width: parent.width
-                  height: form.style.group.height
+                  height: section === "" ? 0 : form.style.group.height
                   color: form.style.group.marginColor
                   anchors.bottom: parent.bottom
                   

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -374,13 +374,13 @@ Item {
               Item {
                 id: headerContainer
                 width: parent.width
-                height: section === "" ? 0 : form.style.group.height + 2 * form.style.fields.sideMargin // fields use sideMargin twice for top margin
+                height: section === "" ? 0 : form.style.group.height + form.style.group.spacing // add space after section header
 
                 Rectangle {
                   width: parent.width
                   height: section === "" ? 0 : form.style.group.height
                   color: form.style.group.marginColor
-                  anchors.bottom: parent.bottom
+                  anchors.top: parent.top
                   
                   Rectangle {
                     anchors.fill: parent
@@ -417,9 +417,9 @@ Item {
 
             delegate: fieldItem
 
-            footer: Rectangle {
+            header: Rectangle {
               opacity: 1
-              height: 15 * QgsQuick.Utils.dp
+              height: form.style.group.spacing
             }
           }
         }
@@ -465,7 +465,7 @@ Item {
 
       Item {
         id: labelPlaceholder
-        height: fieldLabel.height + constraintDescriptionLabel.height + 2 * form.style.fields.sideMargin
+        height: fieldLabel.height + constraintDescriptionLabel.height + form.style.fields.sideMargin
         anchors {
           left: parent.left
           right: parent.right
@@ -482,7 +482,6 @@ Item {
           font.pointSize: form.style.fields.labelPointSize
           horizontalAlignment: Text.AlignLeft
           verticalAlignment: Text.AlignVCenter
-          anchors.topMargin: form.style.fields.sideMargin
           anchors.top: parent.top
         }
 

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -370,28 +370,35 @@ Item {
             section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
             section.delegate: Component {
 
-            // section header: group box name
-            Rectangle {
+              // section header: group box name
+              Item {
+                id: headerContainer
                 width: parent.width
-                height: section === "" ? 0 : form.style.group.height
-                color: form.style.group.marginColor
+                height: section === "" ? 0 : form.style.group.height + 2 * form.style.fields.sideMargin // fields use sideMargin twice for top margin
 
                 Rectangle {
-                  anchors.fill: parent
-                  anchors {
-                    leftMargin: form.style.group.leftMargin
-                    rightMargin: form.style.group.rightMargin
-                    topMargin: form.style.group.topMargin
-                    bottomMargin: form.style.group.bottomMargin
-                  }
-                  color: form.style.group.backgroundColor
-
-                  Text {
-                    anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
-                    font.bold: true
-                    font.pixelSize: form.style.group.fontPixelSize
-                    text: section
-                    color: form.style.group.fontColor
+                  width: parent.width
+                  height: form.style.group.height
+                  color: form.style.group.marginColor
+                  anchors.bottom: parent.bottom
+                  
+                  Rectangle {
+                    anchors.fill: parent
+                    anchors {
+                      leftMargin: form.style.group.leftMargin
+                      rightMargin: form.style.group.rightMargin
+                      topMargin: form.style.group.topMargin
+                      bottomMargin: form.style.group.bottomMargin
+                    }
+                    color: form.style.group.backgroundColor
+                    
+                    Text {
+                      anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+                      font.bold: true
+                      font.pixelSize: form.style.group.fontPixelSize
+                      text: section
+                      color: form.style.group.fontColor
+                    }
                   }
                 }
               }


### PR DESCRIPTION
Added vertical space before group header. It is now wrapped in container that has `topMargin` same as fieldName.

<img src="https://user-images.githubusercontent.com/22449698/111491704-6065bd80-873c-11eb-9497-06c621f0d7a9.jpg" width=300>

Closes #1230 
