### PR TITLE
Fix photo widget width

### DIFF
--- a/qgsquick/from_qgis/plugin/components/qgsquickicontextitem.qml
+++ b/qgsquick/from_qgis/plugin/components/qgsquickicontextitem.qml
@@ -26,21 +26,24 @@ Item {
   property string labelText
 
   id: root
-  width: text.paintedWidth
-  height: root.iconSize + text.paintedHeight
 
   ColumnLayout {
     anchors.fill: parent
-    spacing: 20 * QgsQuick.Utils.dp
+    spacing: 2 * QgsQuick.Utils.dp
 
     Item {
       id: iconContainer
-      implicitHeight: 15 * QgsQuick.Utils.dp
-      Layout.alignment: Qt.AlignHCenter
+
+      Layout.fillHeight: true
+      Layout.preferredHeight: root.height / 2
+      Layout.preferredWidth: root.width
 
       Image {
         id: icon
-        x: -width/2
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottom: parent.bottom
+
         source: root.iconSource
         width: root.iconSize
         height: root.iconSize
@@ -58,16 +61,21 @@ Item {
 
     Item {
       id: textContainer
-      implicitHeight: 15 * QgsQuick.Utils.dp
 
+      Layout.fillHeight: true
+      Layout.preferredHeight: root.height / 2
+      Layout.preferredWidth: root.width
 
       Text {
         id: text
-        height: root.iconSize
+
         text: root.labelText
         font.pointSize: root.fontPointSize
+        width: parent.width
         color: root.fontColor
-        Layout.alignment: Qt.AlignHCenter
+        horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.WordWrap
+        maximumLineCount: 3
       }
     }
   }

--- a/qgsquick/from_qgis/plugin/editor/qgsquickexternalresource.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquickexternalresource.qml
@@ -250,14 +250,8 @@ Item {
     anchors.margins: fieldItem.textMargin
     visible: fieldItem.state === "notSet"
 
-    anchors.horizontalCenter: parent.horizontalCenter
-    anchors.verticalCenter: parent.verticalCenter
-
     RowLayout {
-      width: parent.width
-      height: photoButton.height * 2
-      anchors.horizontalCenter: parent.horizontalCenter
-      anchors.verticalCenter: parent.verticalCenter
+      anchors.fill: parent
 
       QgsQuick.IconTextItem {
         id: photoButton
@@ -266,10 +260,11 @@ Item {
         iconSource: fieldItem.cameraIcon
         iconSize: buttonsContainer.itemHeight
         labelText: qsTr("Take a photo")
-
         visible: !readOnly && fieldItem.state !== " valid"
-        height: buttonsContainer.itemHeight * 1.5
-        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+
+        Layout.preferredHeight: parent.height
+        Layout.fillWidth: true
+        Layout.preferredWidth: ( parent.width - lineContainer.width ) / 2
 
         MouseArea {
           anchors.fill: parent
@@ -285,13 +280,15 @@ Item {
 
       Item {
         id: lineContainer
-        height: parent.height
         visible: !readOnly && fieldItem.state !== " valid"
+        Layout.fillWidth: true
+        Layout.preferredHeight: parent.height
+        Layout.preferredWidth: line.width * 2
 
         Rectangle {
           id: line
 
-          height: parent.height
+          height: parent.height * 0.7
           color: customStyle.fields.fontColor
           width: 1.5 * QgsQuick.Utils.dp
           anchors.centerIn: parent
@@ -307,8 +304,10 @@ Item {
         labelText: qsTr("From gallery")
 
         visible: !readOnly && fieldItem.state !== " valid"
-        height: buttonsContainer.itemHeight * 1.5
-        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+
+        Layout.preferredHeight: parent.height
+        Layout.fillWidth: true
+        Layout.preferredWidth: ( parent.width - lineContainer.width ) / 2
 
         MouseArea {
           anchors.fill: parent


### PR DESCRIPTION
Replaced using `paintedWidth` that causes icon with text to shrink/expand based on text width. We are now using better Layouts.


<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/22449698/110473494-e3549b80-80de-11eb-8687-69b76a51379b.jpg" width="250"/></td>
    <td><img src="https://user-images.githubusercontent.com/22449698/111531163-75eedd80-8764-11eb-96df-56cc17cdbd32.jpg"  width="250"/> <img src="https://user-images.githubusercontent.com/22449698/111531400-c36b4a80-8764-11eb-83af-c9bdf980cb5d.jpg"  width="250"/></td>
  </tr>
 </table>

Resolves #1244 