### PR TITLE
Applies default values on update

### DIFF
--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
@@ -336,6 +336,47 @@ void QgsQuickAttributeModel::resetAttributes()
   endResetModel();
 }
 
+void QgsQuickAttributeModel::updateDefaultValuesAttributes()
+{
+  if ( !mFeatureLayerPair.layer() )
+    return;
+
+  QgsExpressionContext expressionContext = mFeatureLayerPair.layer()->createExpressionContext();
+  expressionContext.setFeature( mFeatureLayerPair.feature() );
+  QgsFields fields = mFeatureLayerPair.layer()->fields();
+
+  beginResetModel();
+  for ( int i = 0; i < fields.count(); ++i )
+  {
+    QgsDefaultValue defaultDefinition = fields.at( i ).defaultValueDefinition();
+    if ( !defaultDefinition.expression().isEmpty() && defaultDefinition.applyOnUpdate() )
+    {
+      QgsExpression exp( fields.at( i ).defaultValueDefinition().expression() );
+      exp.prepare( &expressionContext );
+      if ( exp.hasParserError() )
+        QgsMessageLog::logMessage( tr( "Default value expression for %1:%2 has parser error: %3" ).arg(
+                                     mFeatureLayerPair.layer()->name(),
+                                     fields.at( i ).name(),
+                                     exp.parserErrorString() ),
+                                   QStringLiteral( "QgsQuick" ),
+                                   Qgis::Warning );
+
+      QVariant value = exp.evaluate( &expressionContext );
+
+      if ( exp.hasEvalError() )
+        QgsMessageLog::logMessage( tr( "Default value expression for %1:%2 has evaluation error: %3" ).arg(
+                                     mFeatureLayerPair.layer()->name(),
+                                     fields.at( i ).name(),
+                                     exp.evalErrorString() ),
+                                   QStringLiteral( "QgsQuick" ),
+                                   Qgis::Warning );
+      else
+        mFeatureLayerPair.featureRef().setAttribute( i, value );
+    }
+  }
+  endResetModel();
+}
+
 void QgsQuickAttributeModel::create()
 {
   if ( !mFeatureLayerPair.layer() )

--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.h
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.h
@@ -125,9 +125,12 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Resets remembered attributes
     Q_INVOKABLE virtual void resetAttributes();
 
-    //! Updates attributes according their default value definition.
-    //! Only for attributes with defined default value definition and flag `applyOnUpdate`.
-    Q_INVOKABLE void updateDefaultValuesAttributes();
+    /**
+     * Updates attributes according their default value definition.
+     * Only for attributes with defined default value definition and flag `applyOnUpdate`.
+     * @param editedField QgsField reference of last edited field which triggers update attributes.
+     */
+    Q_INVOKABLE void updateDefaultValuesAttributes( const QgsField &editedField );
 
     //! Gives information whether field with given index is remembered or not
     bool isFieldRemembered( const int fieldIndex ) const;

--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.h
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.h
@@ -125,6 +125,10 @@ class QUICK_EXPORT QgsQuickAttributeModel : public QAbstractListModel
     //! Resets remembered attributes
     Q_INVOKABLE virtual void resetAttributes();
 
+    //! Updates attributes according their default value definition.
+    //! Only for attributes with defined default value definition and flag `applyOnUpdate`.
+    Q_INVOKABLE void updateDefaultValuesAttributes();
+
     //! Gives information whether field with given index is remembered or not
     bool isFieldRemembered( const int fieldIndex ) const;
 

--- a/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
@@ -75,7 +75,7 @@ Item {
     }
 
     onTextChanged: {
-      valueChanged( text, text == '' )
+      valueChanged( text, text == undefined )
     }
   }
 

--- a/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
@@ -75,7 +75,7 @@ Item {
     }
 
     onTextChanged: {
-      valueChanged( text, text == undefined )
+      valueChanged( text, text === undefined )
     }
   }
 

--- a/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
+++ b/qgsquick/from_qgis/plugin/editor/qgsquicktextedit.qml
@@ -103,7 +103,7 @@ Item {
     }
 
     onEditingFinished: {
-        valueChanged( text, text == '' )
+        valueChanged( text, text === undefined )
       }
     }
 

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -381,7 +381,7 @@ Item {
                   height: section === "" ? 0 : form.style.group.height
                   color: form.style.group.marginColor
                   anchors.top: parent.top
-                  
+
                   Rectangle {
                     anchors.fill: parent
                     anchors {
@@ -391,7 +391,7 @@ Item {
                       bottomMargin: form.style.group.bottomMargin
                     }
                     color: form.style.group.backgroundColor
-                    
+
                     Text {
                       anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
                       font.bold: true
@@ -547,7 +547,12 @@ Item {
         Connections {
           target: attributeEditorLoader.item
           onValueChanged: {
+            var valueChanged = value != AttributeValue
             AttributeValue = isNull ? undefined : value
+            // updates other attributes if a user males a change
+            if (valueChanged) {
+              form.model.attributeModel.updateDefaultValuesAttributes()
+            }
           }
         }
 

--- a/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
+++ b/qgsquick/from_qgis/plugin/qgsquickfeatureform.qml
@@ -551,7 +551,7 @@ Item {
             AttributeValue = isNull ? undefined : value
             // updates other attributes if a user males a change
             if (valueChanged) {
-              form.model.attributeModel.updateDefaultValuesAttributes()
+              form.model.attributeModel.updateDefaultValuesAttributes(Field)
             }
           }
         }


### PR DESCRIPTION
This fixes updating attributes for fields with default values and when`Apply default value on update` checked.
A new function `QgsQuickAttributeModel::updateDefaultValuesAttributes` is introduced which is called after an attribute has changed.

It is similar to `QgsQuickAttributeModel::resetAttributes` which seems to not be (explicitly) called. I think the idea was to use it in similar manner, however as description says, it should reset all attributes which is not the case now. Since it not used, I suggest to delete it. If not, it would be good to refactor it with `QgsQuickAttributeModel::updateDefaultValuesAttributes` a bit since it also evaluates expression for fields. So far, I kept it untouched before we asses it in the review.

NOTES:
* If a field has such default value definition, it is always updated - even last known value setting is ignored.
* default values are applied when a user changes attribute from a form - so when `valueChanged` signal for each widget in QML is sent. In case of a textWidget, valueChanged is called after typing a single symbol. 

UPDATE:
* Fixed binding warnings (hope all of them)
* Fixed behaviour - now its allowed to edit a field which has default value definition. 
    - Similarly to QGIS, when a new feature is created and field (A) with default value is updated, its allowed to edit it. When a feature is saved, the field (A) has the same value as user type in the field (A).
    - Similarly to QGIS, when an existing feature is edited, field (A) with default value is updated. User can edit also value for field (A), but eventually when a feature is saved and form closes, field (A) value is overwritten with its default value definition.
* Changed behaviour for TextField widget - to have the same behaviour as it is in QGIS for a case, when a user deletes text for a field (B), but field (A) uses value of field (B) for its default value definition. When a user does so in QGIS, value for the field (A) is calculated with an empty string instead of NULL how it was before in Input. Note that most likely NULL values for other widgets may not be handled properly.
    
It seems that there could be multiple use-cases for default values. Would be good to create a complex table/document with expected behaviour for forms and default values - we can copy it from QGIS docs if it does exist. According to the document, we should create tests to cover the cases and avoid possible regression. Also we will see what is still not unsupported. 

Feel free to discuss on behaviours mentioned in NOTES.

IOS build failed due to version.
Purchasing test failed with on test.dev instance (as well as master does).
Added also manual tests: https://github.com/lutraconsulting/input-manual-tests/issues/6
Currently only added a new test for `Forms` tests - we could possibly have an extra test-case for all types of use-cases for default values and last known value. 
 
https://user-images.githubusercontent.com/6735606/113023590-19d58180-9186-11eb-81bf-93c54d6fe9f9.mp4

