### PR TITLE
Refactoring, solving multiple issues

### DIFF
--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -153,7 +153,10 @@ void ProjectsModel::listProjects( const QString &searchExpression, int page )
   mLastRequestId = mBackend->listProjects( searchExpression, modelTypeToFlag(), "", page );
 
   if ( !mLastRequestId.isEmpty() )
-    emit setModelIsLoading( true );
+  {
+    setModelIsLoading( true );
+    clearProjects();
+  }
 }
 
 void ProjectsModel::listProjectsByName()
@@ -166,7 +169,10 @@ void ProjectsModel::listProjectsByName()
   mLastRequestId = mBackend->listProjectsByName( projectNames() );
 
   if ( !mLastRequestId.isEmpty() )
-    emit setModelIsLoading( true );
+  {
+    setModelIsLoading( true );
+    clearProjects();
+  }
 }
 
 bool ProjectsModel::hasMoreProjects() const
@@ -205,7 +211,7 @@ void ProjectsModel::onListProjectsFinished( const MerginProjectsList &merginProj
   mPaginatedPage = page;
   emit hasMoreProjectsChanged();
 
-  emit setModelIsLoading( false );
+  setModelIsLoading( false );
 }
 
 void ProjectsModel::onListProjectsByNameFinished( const MerginProjectsList &merginProjects, Transactions pendingProjects, QString requestId )
@@ -219,7 +225,7 @@ void ProjectsModel::onListProjectsByNameFinished( const MerginProjectsList &merg
   mergeProjects( merginProjects, pendingProjects );
   endResetModel();
 
-  emit setModelIsLoading( false );
+  setModelIsLoading( false );
 }
 
 void ProjectsModel::mergeProjects( const MerginProjectsList &merginProjects, Transactions pendingProjects, bool keepPrevious )
@@ -512,9 +518,7 @@ void ProjectsModel::onAuthChanged()
   {
     if ( mModelType == CreatedProjectsModel || mModelType == SharedProjectsModel )
     {
-      beginResetModel();
-      mProjects.clear();
-      endResetModel();
+      clearProjects();
     }
   }
 }
@@ -571,6 +575,16 @@ QStringList ProjectsModel::projectNames() const
   }
 
   return projectNames;
+}
+
+void ProjectsModel::clearProjects()
+{
+  beginResetModel();
+  mProjects.clear();
+  mServerProjectsCount = -1;
+  endResetModel();
+
+  emit hasMoreProjectsChanged();
 }
 
 void ProjectsModel::loadLocalProjects()

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -276,7 +276,8 @@ void ProjectsModel::mergeProjects( const MerginProjectsList &merginProjects, Tra
     // lets check also for projects that are currently being downloaded and add them to local projects list
     Transactions::const_iterator i = pendingProjects.constBegin();
 
-    while (i != pendingProjects.constEnd()) {
+    while ( i != pendingProjects.constEnd() )
+    {
       // all projects that are left in transactions are those being downloaded, so we add all of them
       std::shared_ptr<Project> project = std::make_shared<Project>();
       project->mergin = std::unique_ptr<MerginProject>( new MerginProject() );

--- a/app/projectsmodel.h
+++ b/app/projectsmodel.h
@@ -169,6 +169,7 @@ class ProjectsModel : public QAbstractListModel
   private:
     QString modelTypeToFlag() const;
     QStringList projectNames() const;
+    void clearProjects();
     void loadLocalProjects();
     void initializeProjectsModel();
 

--- a/app/projectsproxymodel.cpp
+++ b/app/projectsproxymodel.cpp
@@ -18,14 +18,17 @@ void ProjectsProxyModel::initialize()
   setSourceModel( mModel );
   mModelType = mModel->modelType();
 
-  if ( mModelType == ProjectsModel::CreatedProjectsModel )
-    setFilterRole( ProjectsModel::ProjectName );
-  else
-    setFilterRole( ProjectsModel::ProjectFullName );
+  if ( mModelType != ProjectsModel::PublicProjectsModel ) // do not sort at all in public projects, they come sorted from Mergin
+  {
+    if ( mModelType == ProjectsModel::CreatedProjectsModel )
+      setFilterRole( ProjectsModel::ProjectName );
+    else
+      setFilterRole( ProjectsModel::ProjectFullName );
 
-  setFilterCaseSensitivity( Qt::CaseInsensitive );
+    setFilterCaseSensitivity( Qt::CaseInsensitive );
 
-  sort( 0, Qt::AscendingOrder );
+    sort( 0, Qt::AscendingOrder );
+  }
 }
 
 QString ProjectsProxyModel::searchExpression() const

--- a/app/qml/components/ProjectList.qml
+++ b/app/qml/components/ProjectList.qml
@@ -92,7 +92,7 @@ Item {
       onOpenRequested: {
         if ( model.ProjectIsLocal )
           root.openProjectRequested( projectId, model.ProjectFilePath )
-        else if ( !model.ProjectIsLocal && model.ProjectIsMergin ) {
+        else if ( !model.ProjectIsLocal && model.ProjectIsMergin && !model.ProjectPending) {
           downloadProjectDialog.relatedProjectId = model.ProjectId
           downloadProjectDialog.open()
         }

--- a/app/qml/components/ProjectList.qml
+++ b/app/qml/components/ProjectList.qml
@@ -169,7 +169,11 @@ Item {
   Item {
     id: noLocalProjectsMessageContainer
 
-    visible: listview.count === 0 && !storagePermissionText.visible && projectModelType === ProjectsModel.LocalProjectsModel && root.searchText === ""
+    visible: listview.count === 0 && // this check is getting longer and longer, would be good to replace with states
+             !storagePermissionText.visible &&
+             projectModelType === ProjectsModel.LocalProjectsModel &&
+             root.searchText === "" &&
+             !controllerModel.isLoading
 
     anchors.fill: parent
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -88,7 +88,7 @@ QString MerginApi::listProjects( const QString &searchExpression, const QString 
   {
     query.addQueryItem( "flag", flag );
   }
-  query.addQueryItem( "order_by", QStringLiteral( "name" ) );
+  query.addQueryItem( "order_by", QStringLiteral( "namespace" ) );
   // Required query parameters
   query.addQueryItem( "page", QString::number( page ) );
   query.addQueryItem( "per_page", QString::number( PROJECT_PER_PAGE ) );


### PR DESCRIPTION
There are four fixes included (one fix pre commit):
 - 0ff8ff1 click on project that is being first time downloaded brought _Download window_ again, now does not
 - 78b8a98 project that is being downloaded **for the first time** is now visible also in home page in local projects list
 - 5ad9d42 removed custom sorting in public projects list and use Mergin sorting instead (changed it to use namespace for time being, there will be an option in Mergin to sort by namespace and name in future)
 - 97c3f6d clears list of projects in model when request is sent, not after response is received - this led to UI issues (listview still holding projects though request already sent to refresh it)
 - 6939b15 hides no projects text when model is loading projects