### PR TITLE
Fix of crash due to hasChanges function

### DIFF
--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
@@ -406,7 +406,14 @@ void QgsQuickAttributeModel::create()
 
 bool QgsQuickAttributeModel::hasAnyChanges()
 {
-  return FID_IS_NULL( mFeatureLayerPair.feature().id() ) || mFeatureLayerPair.layer()->editBuffer()->isFeatureAttributesChanged( mFeatureLayerPair.feature().id() );
+  if ( FID_IS_NULL( mFeatureLayerPair.feature().id() ) ) return true;
+
+  if ( mFeatureLayerPair.layer() &&  mFeatureLayerPair.layer()->editBuffer() )
+  {
+    return mFeatureLayerPair.layer()->editBuffer()->isFeatureAttributesChanged( mFeatureLayerPair.feature().id() );
+  }
+
+  return false;
 }
 
 bool QgsQuickAttributeModel::commit()


### PR DESCRIPTION
Crash was caused by a null pointer of edit buffer. Therefore added some checks to avoid the situation.

Will be good to create PR to QgsQuick afterwards - note that this fix and previous changes were not added there yet at all. 

closes #1301 