### PR TITLE
Incompatible type notification

### DIFF
--- a/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
+++ b/qgsquick/from_qgis/attributes/qgsquickattributemodel.cpp
@@ -185,7 +185,10 @@ bool QgsQuickAttributeModel::setData( const QModelIndex &index, const QVariant &
         QString msg( tr( "Value \"%1\" %4 could not be converted to a compatible value for field %2(%3)." ).arg( value.toString(), fld.name(), fld.typeName(), value.isNull() ? "NULL" : "NOT NULL" ) );
         QString userFriendlyMsg( tr( "Value %1 is not compatible with field type %2." ).arg( value.toString(), fld.typeName() ) );
         QgsMessageLog::logMessage( msg );
-        emit dataChangedFailed( userFriendlyMsg );
+        if ( !val.isNull() )
+        {
+          emit dataChangedFailed( userFriendlyMsg );
+        }
         return false;
       }
       bool success = mFeatureLayerPair.featureRef().setAttribute( index.row(), val );


### PR DESCRIPTION
Show compatibility issue notification only for not null values.

Null values have to be handled more properly for widgets though.

closes #1315 