### PR TITLE
Multipolygon highlight crash

### DIFF
--- a/app/qml/Highlight.qml
+++ b/app/qml/Highlight.qml
@@ -150,7 +150,7 @@ Item {
 
     let startIndex = 2
     let endIndex = polyData.length
-    elements.push( componentMoveTo.createObject( objOwner, { "x": data[ startIndex ], "y": data[ startIndex + 1 ] } ) )
+    elements.push( componentMoveTo.createObject( objOwner, { "x": polyData[ startIndex ], "y": polyData[ startIndex + 1 ] } ) )
     for ( let j = startIndex; j < endIndex; j += 2 ) {
       elements.push( componentLineTo.createObject( objOwner, { "x": polyData[ j ], "y": polyData[ j + 1 ] } ) )
     }
@@ -197,7 +197,7 @@ Item {
 
         // True if drawing as Shape with multiple ShapePaths
         // False if using single ShapePath and simple filtering data <-- resolves crash
-        let showAsMultipolygonShape = false
+        let showAsMultipolygonShape = true
 
         if (showAsMultipolygonShape) {
           let testData = prepareData(data)

--- a/app/qml/Highlight.qml
+++ b/app/qml/Highlight.qml
@@ -152,7 +152,12 @@ Item {
         elements.push( componentMoveTo.createObject( objOwner, { "x": data[ dataStartIndex ], "y": data[ dataStartIndex + 1 ] } ) )
         for ( let i = dataStartIndex + 2; i < data.length; i += 2 )
         {
-          elements.push( componentLineTo.createObject( objOwner, { "x": data[ i ], "y": data[ i + 1 ] } ) )
+          if (data[ i ] === geometryType) {
+            console.log("Skipping ", data[ i ], data[ i + 1 ])
+            continue
+          } else {
+            elements.push( componentLineTo.createObject( objOwner, { "x": data[ i ], "y": data[ i + 1 ] } ) )
+          }
         }
 
         if ( recordingInProgress && guideLineAllowed ) { // construct a guide line / polygon

--- a/app/qml/Highlight.qml
+++ b/app/qml/Highlight.qml
@@ -148,17 +148,19 @@ Item {
         let objOwner = ( geometryType === 1 ? lineShapePath : polygonShapePath )
         let elements = ( geometryType === 1 ? newLineElements : newPolygonElements )
 
-        // move brush to the first point and start drawing from next point
-        elements.push( componentMoveTo.createObject( objOwner, { "x": data[ dataStartIndex ], "y": data[ dataStartIndex + 1 ] } ) )
-        for ( let i = dataStartIndex + 2; i < data.length; i += 2 )
+        // Create (multi) geometry for the highlight
+        let i = 0
+        let k = 0
+        while ( i < data.length )
         {
-          if (data[ i ] === geometryType) {
-            //! a new interior rings starts here
-            elements.push( componentMoveTo.createObject( objOwner, { "x": data[ i + 2 ], "y": data[ i + 3 ] } ) )
-            continue
-          } else {
-            elements.push( componentLineTo.createObject( objOwner, { "x": data[ i ], "y": data[ i + 1 ] } ) )
+          let geomType = data[ i++ ];
+          let pointsCount = data[ i++ ];
+          elements.push( componentMoveTo.createObject( objOwner, { "x": data[ i ], "y": data[ i + 1 ] } ) )
+          for ( k = i; k < i + pointsCount * 2; k += 2 )
+          {
+            elements.push( componentLineTo.createObject( objOwner, { "x": data[ k ], "y": data[ k + 1 ] } ) )
           }
+          i = k
         }
 
         if ( recordingInProgress && guideLineAllowed ) { // construct a guide line / polygon

--- a/app/qml/Highlight.qml
+++ b/app/qml/Highlight.qml
@@ -155,8 +155,10 @@ Item {
         {
           let geomType = data[ i++ ];
           let pointsCount = data[ i++ ];
+          // Move to the first point
           elements.push( componentMoveTo.createObject( objOwner, { "x": data[ i ], "y": data[ i + 1 ] } ) )
-          for ( k = i; k < i + pointsCount * 2; k += 2 )
+          // Draw lines for rest of points in the segment
+          for ( k = i + 2; k < i + pointsCount * 2; k += 2 )
           {
             elements.push( componentLineTo.createObject( objOwner, { "x": data[ k ], "y": data[ k + 1 ] } ) )
           }

--- a/app/qml/Highlight.qml
+++ b/app/qml/Highlight.qml
@@ -113,65 +113,6 @@ Item {
     guideLine.pathElements = elements
   }
 
-  //! Util function to create array of array of coordinates
-  //! [X] -> [[X]]
-  //! index 0 is geometry type
-  //! index 1 is no of vertices
-  function prepareData(data)
-  {
-    let result = []
-    let d = []
-    let polygonType = 2
-    d.push(data[0])
-    d.push(data[1])
-    let startIndex = 2
-
-    for ( let i = startIndex; i < data.length; i += 2 ) {
-      // Rather simplified condition used for testing
-      if (data[i] !== polygonType) {
-        d.push(data[i])
-        d.push(data[i+1])
-      } else {
-        result.push(Array.from(d))
-        d = []
-        d.push(data[i])
-        d.push(data[i+1])
-      }
-    }
-    result.push(Array.from(d))
-    return result
-  }
-
-  function createPolyHighlight(polyData, no) {
-    let color = ["red", "brown", "blue", "green", "yellow", "red", "brown", "blue", "green", "yellow", "red", "brown", "blue", "green", "yellow", "red", "brown", "blue", "green", "yellow"]
-    let currPolygon = shapePart.createObject(shapePart, {fillColor: color[no]})
-    let objOwner = currPolygon;
-    let elements = []
-
-    let startIndex = 2
-    let endIndex = polyData.length
-    elements.push( componentMoveTo.createObject( objOwner, { "x": polyData[ startIndex ], "y": polyData[ startIndex + 1 ] } ) )
-    for ( let j = startIndex; j < endIndex; j += 2 ) {
-      elements.push( componentLineTo.createObject( objOwner, { "x": polyData[ j ], "y": polyData[ j + 1 ] } ) )
-    }
-
-    currPolygon.pathElements = Array.from(elements)
-    return currPolygon
-  }
-
-  function createMultiPolyHighlight(data)
-  {
-    let multipolygonData = []
-    multipolygonShapePath.data = []
-
-    for ( let i = 0; i < data.length; i += 1 ) {
-      let polyData = data[i]
-      let currPolygon = createPolyHighlight(polyData, i)
-      multipolygonData.push(currPolygon)
-     }
-    multipolygonShapePath.data = multipolygonData
-  }
-
   function constructHighlights()
   {
     if ( !featureLayerPair || !mapSettings ) return
@@ -194,18 +135,6 @@ Item {
       }
       else // line or polygon
       {
-
-        // True if drawing as Shape with multiple ShapePaths
-        // False if using single ShapePath and simple filtering data <-- resolves crash
-        let showAsMultipolygonShape = true
-
-        if (showAsMultipolygonShape) {
-          let testData = prepareData(data)
-          console.log("Multipolygons: ", testData.length)
-          createMultiPolyHighlight(testData)
-          return
-        }
-
         // place temporary point marker if this is the first point in line / polygon
         if ( recordingInProgress && data.length < dataStartIndex + 3 )
         {
@@ -224,7 +153,8 @@ Item {
         for ( let i = dataStartIndex + 2; i < data.length; i += 2 )
         {
           if (data[ i ] === geometryType) {
-            console.log("Skipping ", data[ i ], data[ i + 1 ])
+            //! a new interior rings starts here
+            elements.push( componentMoveTo.createObject( objOwner, { "x": data[ i + 2 ], "y": data[ i + 3 ] } ) )
             continue
           } else {
             elements.push( componentLineTo.createObject( objOwner, { "x": data[ i ], "y": data[ i + 1 ] } ) )
@@ -352,24 +282,6 @@ Item {
       capStyle: ShapePath.FlatCap
       joinStyle: ShapePath.BevelJoin
     }
-
-    Shape{
-      id: multipolygonShapePath
-      data: []
-    }
-
-    Component {
-        id: shapePart;
-
-        ShapePath {
-          strokeColor: highlight.outlineColor
-          strokeWidth: highlight.outlinePenWidth / highlight.mapTransformScale  // negate scaling from the transform
-          fillColor: highlight.fillColor
-          capStyle: ShapePath.FlatCap
-          joinStyle: ShapePath.BevelJoin
-        }
-    }
-
 
     ShapePath {
       id: guideLine // also used for guide polygon


### PR DESCRIPTION
The crash was caused by:
`"qAbs(m_vertices.at(i).x) < (1 << 21)" in file painting/qtriangulator.cpp`

It seems that triangulation is sensitive to extreme values in path dataset (if a vertex is way away from average coordinates of other vertices).

Extreme values for our case were obtain by wrong parsing multipolygon coordinates into an array - it was handled as single polygon feature which resulted into invalid data. Instead, each polygon data should be rather split to be in valid format.

Fix changes how data are parsed - data are in one array, where each rings starts its part with two elements: index 0 - geometry type and index 1 - no. of vertices. Those values are used as indicators that interior ring data starts from there.
This fixes the crash but rather not data format itself. 

PR has eventually been simplified to use single Shape object for rendering.

<img width="492" alt="Screenshot 2021-04-16 at 18 01 40" src="https://user-images.githubusercontent.com/6735606/115052219-fc224f00-9edd-11eb-80e3-5ee71cc0e045.png">

How the feature is rendered in QGIS:
<img width="230" alt="Screenshot 2021-04-16 at 17 35 03" src="https://user-images.githubusercontent.com/6735606/115048753-32f66600-9eda-11eb-81c4-6f966ecf249e.png">


closes #1322 