### PR TITLE
CE support

### DIFF
--- a/app/inputhelp.cpp
+++ b/app/inputhelp.cpp
@@ -10,6 +10,7 @@
 #include "inputhelp.h"
 #include "merginuserauth.h"
 #include "merginuserinfo.h"
+#include "merginsubscriptioninfo.h"
 #include "merginsubscriptionstatus.h"
 #include "merginapi.h"
 #include "inpututils.h"
@@ -139,8 +140,8 @@ QVector<QString> InputHelp::logHeader( bool isHtml )
     retLines.push_back( QStringLiteral( "Mergin Data: %1/%2 Bytes" )
                         .arg( InputUtils::bytesToHumanSize( mMerginApi->userInfo()->diskUsage() ) )
                         .arg( InputUtils::bytesToHumanSize( mMerginApi->userInfo()->storageLimit() ) ) );
-    retLines.push_back( QStringLiteral( "Subscription plan: %1" ).arg( mMerginApi->userInfo()->planAlias() ) );
-    retLines.push_back( QStringLiteral( "Subscription Status: %1" ).arg( MerginSubscriptionStatus::toString( static_cast<MerginSubscriptionStatus::SubscriptionStatus>( mMerginApi->userInfo()->subscriptionStatus() ) ) ) );
+    retLines.push_back( QStringLiteral( "Subscription plan: %1" ).arg( mMerginApi->subscriptionInfo()->planAlias() ) );
+    retLines.push_back( QStringLiteral( "Subscription Status: %1" ).arg( MerginSubscriptionStatus::toString( static_cast<MerginSubscriptionStatus::SubscriptionStatus>( mMerginApi->subscriptionInfo()->subscriptionStatus() ) ) ) );
   }
   else
   {

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -324,7 +324,7 @@ QString InputUtils::bytesToHumanSize( double bytes )
   }
   else if ( bytes < 1024.0 * 1024.0 )
   {
-    return QString::number( bytes, 'f', precision ) + " KB";
+    return QString::number( bytes / 1024.0, 'f', precision ) + " KB";
   }
   else if ( bytes < 1024.0 * 1024.0 * 1024.0 )
   {

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -37,6 +37,7 @@
 #include "digitizingcontroller.h"
 #include "merginapi.h"
 #include "merginapistatus.h"
+#include "merginsubscriptioninfo.h"
 #include "merginsubscriptionstatus.h"
 #include "merginsubscriptiontype.h"
 #include "merginprojectstatusmodel.h"
@@ -219,6 +220,7 @@ void initDeclarative()
 {
   qmlRegisterUncreatableType<MerginUserAuth>( "lc", 1, 0, "MerginUserAuth", "" );
   qmlRegisterUncreatableType<MerginUserInfo>( "lc", 1, 0, "MerginUserInfo", "" );
+  qmlRegisterUncreatableType<MerginSubscriptionInfo>( "lc", 1, 0, "MerginSubscriptionInfo", "" );
   qmlRegisterUncreatableType<PurchasingPlan>( "lc", 1, 0, "MerginPlan", "" );
   qmlRegisterUncreatableType<MapThemesModel>( "lc", 1, 0, "MapThemesModel", "" );
   qmlRegisterUncreatableType<Loader>( "lc", 1, 0, "Loader", "" );

--- a/app/purchasing.cpp
+++ b/app/purchasing.cpp
@@ -529,6 +529,7 @@ void Purchasing::onTransactionVerificationSucceeded( PurchasingTransaction *tran
 
   removePendingTransaction( transaction );
   mMerginApi->getUserInfo();
+  mMerginApi->getSubscriptionInfo();
 }
 
 void Purchasing::onTransactionVerificationFailed( PurchasingTransaction *transaction )

--- a/app/purchasing.cpp
+++ b/app/purchasing.cpp
@@ -14,6 +14,7 @@
 #include "merginapi.h"
 #include "inpututils.h"
 #include "merginuserinfo.h"
+#include "merginsubscriptioninfo.h"
 #include "coreutils.h"
 
 #if defined (APPLE_PURCHASING)
@@ -199,8 +200,8 @@ Purchasing::Purchasing( MerginApi *merginApi, QObject *parent )
   connect( mMerginApi, &MerginApi::apiRootChanged, this, &Purchasing::onMerginServerChanged );
   connect( mMerginApi, &MerginApi::apiSupportsSubscriptionsChanged, this, &Purchasing::onMerginServerStatusChanged );
   connect( mMerginApi, &MerginApi::apiVersionStatusChanged, this, &Purchasing::onMerginServerStatusChanged );
-  connect( mMerginApi->userInfo(), &MerginUserInfo::planProviderChanged, this, &Purchasing::evaluateHasInAppPurchases );
-  connect( mMerginApi->userInfo(), &MerginUserInfo::planProductIdChanged, this, &Purchasing::onMerginPlanProductIdChanged );
+  connect( mMerginApi->subscriptionInfo(), &MerginSubscriptionInfo::planProviderChanged, this, &Purchasing::evaluateHasInAppPurchases );
+  connect( mMerginApi->subscriptionInfo(), &MerginSubscriptionInfo::planProductIdChanged, this, &Purchasing::onMerginPlanProductIdChanged );
 
   connect( this, &Purchasing::hasInAppPurchasesChanged, this, &Purchasing::onHasInAppPurchasesChanged );
 }
@@ -238,11 +239,11 @@ void Purchasing::evaluateHasInAppPurchases()
     mBackend->userCanMakePayments();
 
   bool hasCompatiblePlanType = true;
-  if ( mMerginApi->userInfo()->ownsActiveSubscription() )
+  if ( mMerginApi->subscriptionInfo()->ownsActiveSubscription() )
   {
     hasCompatiblePlanType =
       bool( mBackend ) &&
-      mBackend->provider() == mMerginApi->userInfo()->planProvider();
+      mBackend->provider() == mMerginApi->subscriptionInfo()->planProvider();
   }
   setHasInAppPurchases( hasInApp && hasCompatiblePlanType );
 }
@@ -344,15 +345,15 @@ void Purchasing::onMerginPlanProductIdChanged()
   if ( !mBackend )
     return;
 
-  QString planId = mMerginApi->userInfo()->planProductId();
+  QString planId = mMerginApi->subscriptionInfo()->planProductId();
   if ( planId.isEmpty() )
     return;
 
-  if ( mBackend->provider() != mMerginApi->userInfo()->planProvider() )
+  if ( mBackend->provider() != mMerginApi->subscriptionInfo()->planProvider() )
     return;
 
-  QString price = mBackend->getLocalizedPrice( mMerginApi->userInfo()->planProductId() );
-  mMerginApi->userInfo()->setLocalizedPrice( price );
+  QString price = mBackend->getLocalizedPrice( mMerginApi->subscriptionInfo()->planProductId() );
+  mMerginApi->subscriptionInfo()->setLocalizedPrice( price );
 }
 
 void Purchasing::onMerginServerStatusChanged()

--- a/app/purchasing.cpp
+++ b/app/purchasing.cpp
@@ -528,7 +528,6 @@ void Purchasing::onTransactionVerificationSucceeded( PurchasingTransaction *tran
     notify( tr( "Successfully purchased subscription" ) );
 
   removePendingTransaction( transaction );
-  mMerginApi->getUserInfo();
   mMerginApi->getSubscriptionInfo();
 }
 

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -31,6 +31,7 @@ Page {
   property string subscriptionsTimestamp: __merginApi.userInfo.subscriptionTimestamp
   property string nextBillPrice: __merginApi.userInfo.nextBillPrice
   property bool ownsActiveSubscription: __merginApi.userInfo.ownsActiveSubscription
+  property bool apiSupportsSubscriptions: __merginApi.apiSupportsSubscriptions
 
   id: root
   visible: true
@@ -110,6 +111,7 @@ Page {
     }
 
     TextWithIcon {
+      visible: root.apiSupportsSubscriptions
       width: parent.width
       source: 'edit.svg'
       text: root.planAlias

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -24,13 +24,13 @@ Page {
 
   property string username: __merginApi.userAuth.username
   property string email: __merginApi.userInfo.email
-  property string planAlias: __merginApi.userInfo.planAlias
-  property int storageLimit: __merginApi.userInfo.storageLimit
   property int diskUsage: __merginApi.userInfo.diskUsage
-  property int subscriptionStatus: __merginApi.userInfo.subscriptionStatus
-  property string subscriptionsTimestamp: __merginApi.userInfo.subscriptionTimestamp
-  property string nextBillPrice: __merginApi.userInfo.nextBillPrice
-  property bool ownsActiveSubscription: __merginApi.userInfo.ownsActiveSubscription
+  property int storageLimit: __merginApi.userInfo.storageLimit
+  property string planAlias: __merginApi.subscriptionInfo.planAlias
+  property int subscriptionStatus: __merginApi.subscriptionInfo.subscriptionStatus
+  property string subscriptionsTimestamp: __merginApi.subscriptionInfo.subscriptionTimestamp
+  property string nextBillPrice: __merginApi.subscriptionInfo.nextBillPrice
+  property bool ownsActiveSubscription: __merginApi.subscriptionInfo.ownsActiveSubscription
   property bool apiSupportsSubscriptions: __merginApi.apiSupportsSubscriptions
 
   id: root

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -176,6 +176,8 @@ Item {
               onClicked: {
                 if (__merginApi.userAuth.hasAuthData() && __merginApi.apiVersionStatus === MerginApiStatus.OK) {
                   __merginApi.getUserInfo()
+                  if (__merginApi.apiSupportsSubscriptions)
+                    __merginApi.getSubscriptionInfo()
                   stackView.push( accountPanelComp )
                 }
                 else
@@ -434,11 +436,9 @@ Item {
           if (__merginApi.apiVersionStatus === MerginApiStatus.OK && stackView.currentItem.objectName === "authPanel") {
             if (__merginApi.userAuth.hasAuthData()) {
               refreshProjectList()
-            } else if (toolbar.highlighted !== homeBtn.text) {
-              if (stackView.currentItem.objectName !== "authPanel") {
+            } else if (stackView.currentItem.objectName !== "authPanel") {
                 stackView.push(authPanelComp, {state: "login"})
               }
-            }
           }
         }
         onAuthRequested: {

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -436,9 +436,11 @@ Item {
           if (__merginApi.apiVersionStatus === MerginApiStatus.OK && stackView.currentItem.objectName === "authPanel") {
             if (__merginApi.userAuth.hasAuthData()) {
               refreshProjectList()
-            } else if (stackView.currentItem.objectName !== "authPanel") {
+            } else if (toolbar.highlighted !== homeBtn.text) {
+              if (stackView.currentItem.objectName !== "authPanel") {
                 stackView.push(authPanelComp, {state: "login"})
               }
+            }
           }
         }
         onAuthRequested: {
@@ -502,7 +504,7 @@ Item {
         stackView.popOnePageOrClose()
       }
       onManagePlansClicked: {
-        if (__purchasing.hasInAppPurchases && (__purchasing.hasManageSubscriptionCapability || !__merginApi.userInfo.ownsActiveSubscription )) {
+        if (__purchasing.hasInAppPurchases && (__purchasing.hasManageSubscriptionCapability || !__merginApi.subscriptionInfo.ownsActiveSubscription )) {
           stackView.push( subscribePanelComp)
         } else {
           Qt.openUrlExternally(__purchasing.subscriptionManageUrl);

--- a/app/qml/SubscribePlanItem.qml
+++ b/app/qml/SubscribePlanItem.qml
@@ -22,7 +22,7 @@ Item {
   property var plan
   property string name
 
-  property bool hasPlan: __merginApi.userInfo.ownsActiveSubscription || !root.plan
+  property bool hasPlan: __merginApi.subscriptionInfo.ownsActiveSubscription || !root.plan
 
   Column {
     width: parent.width

--- a/app/test/testingpurchasingbackend.cpp
+++ b/app/test/testingpurchasingbackend.cpp
@@ -11,6 +11,7 @@
 
 #include "merginapi.h"
 #include "merginuserinfo.h"
+#include "merginsubscriptioninfo.h"
 #include "inpututils.h"
 
 #if defined (HAVE_WIDGETS)
@@ -58,7 +59,7 @@ void TestingPurchasingBackend::createTransaction( QSharedPointer<PurchasingPlan>
       items << "Buy professional plan | tier12";
     }
 
-    if ( mMerginApi->userInfo()->ownsActiveSubscription() )
+    if ( mMerginApi->subscriptionInfo()->ownsActiveSubscription() )
     {
       items << "Immediately refund the subscription (got refund) | cancel"
             << "Set grace period | grace"
@@ -116,7 +117,7 @@ void TestingPurchasingBackend::createTransaction( QSharedPointer<PurchasingPlan>
 
 void TestingPurchasingBackend::restore()
 {
-  if ( mMerginApi->userInfo()->ownsActiveSubscription() )
+  if ( mMerginApi->subscriptionInfo()->ownsActiveSubscription() )
   {
     // we can try to "restore" only recommended plan in test backend
     return;
@@ -146,11 +147,11 @@ QString TestingPurchasingBackend::subscriptionBillingUrl()
 QSharedPointer<TestingPurchasingTransaction> TestingPurchasingBackend::createTestingTransaction( QSharedPointer<PurchasingPlan> plan, const QString &data, bool restore )
 {
   QString planMerginId;
-  const int id = mMerginApi->userInfo()->subscriptionId();
+  const int id = mMerginApi->subscriptionInfo()->subscriptionId();
   if ( id > 0 )
   {
     // this is an existing subscription
-    planMerginId = QString::number( mMerginApi->userInfo()->subscriptionId() );
+    planMerginId = QString::number( mMerginApi->subscriptionInfo()->subscriptionId() );
   }
 
   QString recept = planMerginId + "|" + data;

--- a/app/test/testpurchasing.cpp
+++ b/app/test/testpurchasing.cpp
@@ -35,7 +35,7 @@ void TestPurchasing::runPurchasingCommand( TestingPurchasingBackend::NextPurchas
 {
   mPurchasingBackend->setNextPurchaseResult( result );
 
-  QSignalSpy spy0( mApi->userInfo(), &MerginUserInfo::subscriptionChanged );
+  QSignalSpy spy0( mApi, &MerginApi::subscriptionChanged );
   mPurchasing->purchase( planId );
   QVERIFY( spy0.wait( TestUtils::LONG_REPLY ) );
   QCOMPARE( spy0.count(), 1 );
@@ -51,6 +51,11 @@ void TestPurchasing::initTestCase()
   mApi->authorize( username, password );
   QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
   QCOMPARE( spy.count(), 1 );
+
+  QSignalSpy spy2( mApi, &MerginApi::subscriptionChanged );
+  mApi->getSubscriptionInfo();
+  QVERIFY( spy2.wait( TestUtils::LONG_REPLY ) );
+  QCOMPARE( spy2.count(), 1 );
 
   // verify we have test or none subscription
   MerginSubscriptionType::SubscriptionType subscriptionType = mApi->userInfo()->planProvider();

--- a/app/test/testpurchasing.cpp
+++ b/app/test/testpurchasing.cpp
@@ -35,7 +35,7 @@ void TestPurchasing::runPurchasingCommand( TestingPurchasingBackend::NextPurchas
 {
   mPurchasingBackend->setNextPurchaseResult( result );
 
-  QSignalSpy spy0( mApi, &MerginApi::userInfoChanged );
+  QSignalSpy spy0( mApi->userInfo(), &MerginUserInfo::planProductIdChanged );
   mPurchasing->purchase( planId );
   QVERIFY( spy0.wait( TestUtils::LONG_REPLY ) );
   QCOMPARE( spy0.count(), 1 );

--- a/app/test/testpurchasing.cpp
+++ b/app/test/testpurchasing.cpp
@@ -35,7 +35,7 @@ void TestPurchasing::runPurchasingCommand( TestingPurchasingBackend::NextPurchas
 {
   mPurchasingBackend->setNextPurchaseResult( result );
 
-  QSignalSpy spy0( mApi->userInfo(), &MerginUserInfo::planProductIdChanged );
+  QSignalSpy spy0( mApi->userInfo(), &MerginUserInfo::subscriptionChanged );
   mPurchasing->purchase( planId );
   QVERIFY( spy0.wait( TestUtils::LONG_REPLY ) );
   QCOMPARE( spy0.count(), 1 );
@@ -155,7 +155,7 @@ void TestPurchasing::testUserSendsBadReceipt()
 
 void TestPurchasing::testUserRestore()
 {
-  QSignalSpy spy0( mApi, &MerginApi::userInfoChanged );
+  QSignalSpy spy0( mApi->userInfo(), &MerginUserInfo::subscriptionChanged );
   mPurchasing->restore();
   QVERIFY( spy0.wait( TestUtils::LONG_REPLY ) );
   QCOMPARE( spy0.count(), 1 );

--- a/app/test/testpurchasing.h
+++ b/app/test/testpurchasing.h
@@ -38,7 +38,14 @@ class TestPurchasing: public QObject
     void testUserRestore();
 
   private:
-    void runPurchasingCommand( TestingPurchasingBackend::NextPurchaseResult result, const QString &planId );
+    /**
+     * @brief runPurchasingCommand Test util function to invoke purchasing function and wait for the replies.
+     * @param result
+     * @param planId ID of the plan that is going to be purchased.
+     * @param waitForUserInfo True, if current user planID will be changed after executing the command.
+     *        The change will trigger an extra userInfo request to update storage.
+     */
+    void runPurchasingCommand( TestingPurchasingBackend::NextPurchaseResult result, const QString &planId, bool waitForUserInfo = false );
 
     MerginApi *mApi = nullptr;
     Purchasing *mPurchasing = nullptr;

--- a/core/core.pri
+++ b/core/core.pri
@@ -3,6 +3,7 @@ SOURCES += \
   $$PWD/coreutils.cpp \
   $$PWD/merginapi.cpp \
   $$PWD/merginapistatus.cpp \
+  $$PWD/merginsubscriptioninfo.cpp \
   $$PWD/merginsubscriptionstatus.cpp \
   $$PWD/merginsubscriptiontype.cpp \
   $$PWD/merginprojectstatusmodel.cpp \
@@ -17,6 +18,7 @@ HEADERS += \
   $$PWD/coreutils.h \
   $$PWD/merginapi.h \
   $$PWD/merginapistatus.h \
+  $$PWD/merginsubscriptioninfo.h \
   $$PWD/merginsubscriptionstatus.h \
   $$PWD/merginsubscriptiontype.h \
   $$PWD/merginprojectstatusmodel.h \

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -48,6 +48,7 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
   QObject::connect( this, &MerginApi::apiRootChanged, this, &MerginApi::pingMergin );
   QObject::connect( this, &MerginApi::pingMerginFinished, this, &MerginApi::checkMerginVersion );
   QObject::connect( mUserInfo, &MerginUserInfo::userInfoChanged, this, &MerginApi::userInfoChanged );
+  QObject::connect( mUserInfo, &MerginUserInfo::subscriptionChanged, this, &MerginApi::userInfoChanged );
   QObject::connect( mUserAuth, &MerginUserAuth::authChanged, this, &MerginApi::authChanged );
 
   loadAuthData();

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -48,7 +48,7 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
   QObject::connect( this, &MerginApi::apiRootChanged, this, &MerginApi::pingMergin );
   QObject::connect( this, &MerginApi::pingMerginFinished, this, &MerginApi::checkMerginVersion );
   QObject::connect( mUserInfo, &MerginUserInfo::userInfoChanged, this, &MerginApi::userInfoChanged );
-  QObject::connect( mUserInfo, &MerginUserInfo::subscriptionChanged, this, &MerginApi::userInfoChanged );
+  QObject::connect( mUserInfo, &MerginUserInfo::subscriptionChanged, this, &MerginApi::subscriptionChanged );
   QObject::connect( mUserAuth, &MerginUserAuth::authChanged, this, &MerginApi::authChanged );
 
   loadAuthData();
@@ -848,7 +848,6 @@ void MerginApi::authorizeFinished()
       mUserAuth->setFromJson( docObj );
 
       getUserInfo();
-      getSubscriptionInfo();
     }
     else
     {

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -265,6 +265,8 @@ class MerginApi: public QObject
     */
     Q_INVOKABLE void authorize( const QString &login, const QString &password );
     Q_INVOKABLE void getUserInfo();
+    //! Sends subscribtion info request using old userInfo endpoint.
+    Q_INVOKABLE void getSubscriptionInfo();
     Q_INVOKABLE void clearAuth();
     Q_INVOKABLE void resetApiRoot();
     Q_INVOKABLE QString resetPasswordUrl();
@@ -437,6 +439,7 @@ class MerginApi: public QObject
     void uploadCancelReplyFinished();
 
     void getUserInfoFinished();
+    void getBillingInfoFinished();
     void saveAuthData();
     void createProjectFinished();
     void deleteProjectFinished();

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -265,7 +265,7 @@ class MerginApi: public QObject
     */
     Q_INVOKABLE void authorize( const QString &login, const QString &password );
     Q_INVOKABLE void getUserInfo();
-    //! Sends subscribtion info request using old userInfo endpoint.
+    //! Sends subscription info request using userInfo endpoint.
     Q_INVOKABLE void getSubscriptionInfo();
     Q_INVOKABLE void clearAuth();
     Q_INVOKABLE void resetApiRoot();
@@ -439,7 +439,7 @@ class MerginApi: public QObject
     void uploadCancelReplyFinished();
 
     void getUserInfoFinished();
-    void getBillingInfoFinished();
+    void getSubscriptionInfoFinished();
     void saveAuthData();
     void createProjectFinished();
     void deleteProjectFinished();

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -413,6 +413,7 @@ class MerginApi: public QObject
     void projectCreated( const QString &projectName, bool result );
     void serverProjectDeleted( const QString &projecFullName, bool result );
     void userInfoChanged();
+    void subscriptionChanged();
     void pingMerginFinished( const QString &apiVersion, bool serverSupportsSubscriptions, const QString &msg );
     void pullFilesStarted();
     //! Emitted when started to upload chunks (useful for unit testing)

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -31,6 +31,7 @@
 
 class MerginUserAuth;
 class MerginUserInfo;
+class MerginSubscriptionInfo;
 class Purchasing;
 
 struct ProjectDiff
@@ -175,6 +176,7 @@ class MerginApi: public QObject
     Q_OBJECT
     Q_PROPERTY( MerginUserAuth *userAuth READ userAuth NOTIFY authChanged )
     Q_PROPERTY( MerginUserInfo *userInfo READ userInfo NOTIFY userInfoChanged )
+    Q_PROPERTY( MerginSubscriptionInfo *subscriptionInfo READ subscriptionInfo NOTIFY subscriptionInfoChanged )
     Q_PROPERTY( QString apiRoot READ apiRoot WRITE setApiRoot NOTIFY apiRootChanged )
     Q_PROPERTY( bool apiSupportsSubscriptions READ apiSupportsSubscriptions NOTIFY apiSupportsSubscriptionsChanged )
     Q_PROPERTY( /*MerginApiStatus::ApiStatus*/ int apiVersionStatus READ apiVersionStatus NOTIFY apiVersionStatusChanged )
@@ -185,6 +187,7 @@ class MerginApi: public QObject
 
     MerginUserAuth *userAuth() const;
     MerginUserInfo *userInfo() const;
+    MerginSubscriptionInfo *subscriptionInfo() const;
 
     /**
      * Returns path of the local directory in which all projects are stored.
@@ -413,7 +416,7 @@ class MerginApi: public QObject
     void projectCreated( const QString &projectName, bool result );
     void serverProjectDeleted( const QString &projecFullName, bool result );
     void userInfoChanged();
-    void subscriptionChanged();
+    void subscriptionInfoChanged();
     void pingMerginFinished( const QString &apiVersion, bool serverSupportsSubscriptions, const QString &msg );
     void pullFilesStarted();
     //! Emitted when started to upload chunks (useful for unit testing)
@@ -447,6 +450,8 @@ class MerginApi: public QObject
     void authorizeFinished();
     void registrationFinished( const QString &username = QStringLiteral(), const QString &password = QStringLiteral() );
     void pingMerginReplyFinished();
+    //! When plan has been changed, an extra userInfo request is needed to update also storage.
+    void onPlanProductIdChanged();
 
   private:
     MerginProject parseProjectMetadata( const QJsonObject &project );
@@ -542,8 +547,8 @@ class MerginApi: public QObject
     QString mDataDir; // dir with all projects
 
     MerginUserInfo *mUserInfo; //owned by this (qml grouped-properties)
+    MerginSubscriptionInfo *mSubscriptionInfo; //owned by this (qml grouped-properties)
     MerginUserAuth *mUserAuth; //owned by this (qml grouped-properties)
-
 
     enum CustomAttribute
     {

--- a/core/merginsubscriptioninfo.cpp
+++ b/core/merginsubscriptioninfo.cpp
@@ -1,0 +1,187 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "merginsubscriptioninfo.h"
+#include "coreutils.h"
+
+MerginSubscriptionInfo::MerginSubscriptionInfo( QObject *parent )
+  : QObject( parent )
+{
+  clear();
+}
+
+void MerginSubscriptionInfo::clearSubscriptionData()
+{
+  mSubscriptionStatus = MerginSubscriptionStatus::FreeSubscription;
+  mSubscriptionTimestamp = "";
+  mNextBillPrice = "";
+  mSubscriptionId = -1;
+  mOwnsActiveSubscription = false;
+}
+
+void MerginSubscriptionInfo::clearPlanInfo()
+{
+  mPlanAlias = "";
+  mPlanProvider = MerginSubscriptionType::NoneSubscriptionType;
+  mPlanProductId = "";
+  emit planProviderChanged();
+  emit planProductIdChanged();
+}
+
+void MerginSubscriptionInfo::clear()
+{
+  clearSubscriptionData();
+//  mDiskUsage = 0;
+//  mStorageLimit = 0;
+  clearPlanInfo();
+
+  emit subscriptionInfoChanged();
+}
+
+void MerginSubscriptionInfo::setFromJson( QJsonObject docObj )
+{
+//  QJsonObject profileObj = docObj.value( QStringLiteral( "profile" ) ).toObject();
+//  mStorageLimit = profileObj.value( QStringLiteral( "storage" ) ).toDouble();
+
+  // parse service data
+  QJsonObject serviceObj = docObj.value( QStringLiteral( "service" ) ).toObject();
+
+  // parse service.subscription data
+  QJsonObject subscriptionObj = serviceObj.value( QStringLiteral( "subscription" ) ).toObject();
+  if ( subscriptionObj.isEmpty() )
+  {
+    // only free plan is assigned, subscription data is not present in JSON
+    clearSubscriptionData();
+  }
+  else
+  {
+    // user has subscription
+
+    mNextBillPrice = subscriptionObj.value( QStringLiteral( "next_bill_price" ) ).toString();
+    QString nextPaymentDate = subscriptionObj.value( QStringLiteral( "next_payment" ) ).toString();
+    QString validUntil = subscriptionObj.value( QStringLiteral( "valid_until" ) ).toString();
+    if ( nextPaymentDate.isEmpty() )
+    {
+      mSubscriptionTimestamp = CoreUtils::localizedDateFromUTFString( validUntil );
+    }
+    else
+    {
+      mSubscriptionTimestamp = CoreUtils::localizedDateFromUTFString( nextPaymentDate );
+    }
+
+    mSubscriptionId = subscriptionObj.value( QStringLiteral( "id" ) ).toInt();
+    QString status = subscriptionObj.value( QStringLiteral( "status" ) ).toString();
+
+    if ( status == "active" )
+    {
+      if ( nextPaymentDate.isEmpty() )
+      {
+        mSubscriptionStatus = MerginSubscriptionStatus::SubscriptionUnsubscribed;
+      }
+      else
+      {
+        mSubscriptionStatus = MerginSubscriptionStatus::ValidSubscription;
+      }
+    }
+
+    else if ( status == "past_due" )
+    {
+      mSubscriptionStatus = MerginSubscriptionStatus::SubscriptionInGracePeriod;
+    }
+    else // cancelled
+    {
+      mSubscriptionStatus = MerginSubscriptionStatus::CanceledSubscription;
+    }
+  }
+
+  // parse service.plan data
+  QJsonObject planObj = serviceObj.value( QStringLiteral( "plan" ) ).toObject();
+  mOwnsActiveSubscription = planObj.value( QStringLiteral( "is_paid_plan" ) ).toBool();
+  mPlanAlias = planObj.value( QStringLiteral( "alias" ) ).toString();
+
+
+  MerginSubscriptionType::SubscriptionType planProvider = MerginSubscriptionType::fromString( planObj.value( QStringLiteral( "type" ) ).toString() );
+  if ( planProvider != mPlanProvider )
+  {
+    mPlanProvider = planProvider;
+    emit planProviderChanged();
+  }
+  QString planProductId = planObj.value( QStringLiteral( "product_id" ) ).toString();
+  if ( planProductId !=  mPlanProductId )
+  {
+    mPlanProductId = planProductId;
+    emit planProductIdChanged();
+  }
+
+  emit subscriptionInfoChanged();
+}
+
+bool MerginSubscriptionInfo::ownsActiveSubscription() const
+{
+  return mOwnsActiveSubscription;
+}
+
+void MerginSubscriptionInfo::setLocalizedPrice( const QString &price )
+{
+  if ( price.isEmpty() )
+    return;
+
+  if ( price != mNextBillPrice )
+  {
+    mNextBillPrice = price;
+    emit subscriptionInfoChanged();
+  }
+}
+
+
+int MerginSubscriptionInfo::subscriptionId() const
+{
+  return mSubscriptionId;
+}
+
+
+MerginSubscriptionType::SubscriptionType MerginSubscriptionInfo::planProvider() const
+{
+  return mPlanProvider;
+}
+
+QString MerginSubscriptionInfo::planProductId() const
+{
+  return mPlanProductId;
+}
+
+QString MerginSubscriptionInfo::planAlias() const
+{
+  return mPlanAlias;
+}
+
+QString MerginSubscriptionInfo::nextBillPrice() const
+{
+  return mNextBillPrice;
+}
+
+int MerginSubscriptionInfo::subscriptionStatus() const
+{
+  return mSubscriptionStatus;
+}
+
+//double MerginSubscriptionInfo::diskUsage() const
+//{
+//  return mDiskUsage;
+//}
+
+//double MerginSubscriptionInfo::storageLimit() const
+//{
+//  return mStorageLimit;
+//}
+
+QString MerginSubscriptionInfo::subscriptionTimestamp() const
+{
+  return mSubscriptionTimestamp;
+}

--- a/core/merginsubscriptioninfo.cpp
+++ b/core/merginsubscriptioninfo.cpp
@@ -37,8 +37,6 @@ void MerginSubscriptionInfo::clearPlanInfo()
 void MerginSubscriptionInfo::clear()
 {
   clearSubscriptionData();
-//  mDiskUsage = 0;
-//  mStorageLimit = 0;
   clearPlanInfo();
 
   emit subscriptionInfoChanged();
@@ -170,16 +168,6 @@ int MerginSubscriptionInfo::subscriptionStatus() const
 {
   return mSubscriptionStatus;
 }
-
-//double MerginSubscriptionInfo::diskUsage() const
-//{
-//  return mDiskUsage;
-//}
-
-//double MerginSubscriptionInfo::storageLimit() const
-//{
-//  return mStorageLimit;
-//}
 
 QString MerginSubscriptionInfo::subscriptionTimestamp() const
 {

--- a/core/merginsubscriptioninfo.cpp
+++ b/core/merginsubscriptioninfo.cpp
@@ -44,9 +44,6 @@ void MerginSubscriptionInfo::clear()
 
 void MerginSubscriptionInfo::setFromJson( QJsonObject docObj )
 {
-//  QJsonObject profileObj = docObj.value( QStringLiteral( "profile" ) ).toObject();
-//  mStorageLimit = profileObj.value( QStringLiteral( "storage" ) ).toDouble();
-
   // parse service data
   QJsonObject serviceObj = docObj.value( QStringLiteral( "service" ) ).toObject();
 

--- a/core/merginsubscriptioninfo.h
+++ b/core/merginsubscriptioninfo.h
@@ -10,7 +10,6 @@
 #ifndef MERGINSUBSCRIPTIONINFO_H
 #define MERGINSUBSCRIPTIONINFO_H
 
-
 #include <QObject>
 #include <QString>
 #include <QJsonObject>

--- a/core/merginsubscriptioninfo.h
+++ b/core/merginsubscriptioninfo.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef MERGINSUBSCRIPTIONINFO_H
+#define MERGINSUBSCRIPTIONINFO_H
+
+
+#include <QObject>
+#include <QString>
+#include <QJsonObject>
+
+#include "merginsubscriptionstatus.h"
+#include "merginsubscriptiontype.h"
+
+class MerginSubscriptionInfo: public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QString planAlias READ planAlias NOTIFY subscriptionInfoChanged ) // see PurchasingPlan::alias()
+    Q_PROPERTY( /*MerginSubscriptionType::SubscriptionType*/ int planProvider READ planProvider NOTIFY subscriptionInfoChanged ) // see PurchasingTransaction::provider()
+    Q_PROPERTY( QString planProductId READ planProductId NOTIFY subscriptionInfoChanged ) // see PurchasingPlan::id()
+    Q_PROPERTY( /*MerginSubscriptionStatus::SubscriptionStatus*/ int subscriptionStatus READ subscriptionStatus NOTIFY subscriptionInfoChanged )
+    Q_PROPERTY( QString subscriptionTimestamp READ subscriptionTimestamp NOTIFY subscriptionInfoChanged )
+    Q_PROPERTY( QString nextBillPrice READ nextBillPrice NOTIFY subscriptionInfoChanged ) // in Bytes
+    Q_PROPERTY( bool ownsActiveSubscription READ ownsActiveSubscription NOTIFY subscriptionInfoChanged )
+
+  public:
+    explicit MerginSubscriptionInfo( QObject *parent = nullptr );
+    ~MerginSubscriptionInfo() = default;
+
+  public:
+    void clearSubscriptionData();
+    void clearPlanInfo();
+    void clear();
+
+    QString planAlias() const;
+    int subscriptionId() const;
+    MerginSubscriptionType::SubscriptionType planProvider() const;
+    QString planProductId() const;
+    QString nextBillPrice() const;
+    /*MerginSubscriptionStatus::SubscriptionStatus*/ int subscriptionStatus() const;
+    QString subscriptionTimestamp() const;
+    bool ownsActiveSubscription() const;
+
+    void setLocalizedPrice( const QString &price );
+    void setFromJson( QJsonObject docObj );
+    void setSubscriptionInfoFromJson( QJsonObject docObj );
+
+  signals:
+    void subscriptionInfoChanged();
+    void planProductIdChanged();
+    void planProviderChanged();
+    void storageChanged( double storage );
+
+  private:
+    QString mPlanAlias;
+    int mSubscriptionId = -1;
+    MerginSubscriptionType::SubscriptionType mPlanProvider = MerginSubscriptionType::NoneSubscriptionType;
+    QString mPlanProductId;
+    bool mOwnsActiveSubscription = false;
+    QString mNextBillPrice;
+    MerginSubscriptionStatus::SubscriptionStatus mSubscriptionStatus = MerginSubscriptionStatus::FreeSubscription;
+    QString mSubscriptionTimestamp;
+};
+
+#endif // MERGINSUBSCRIPTIONINFO_H

--- a/core/merginuserauth.cpp
+++ b/core/merginuserauth.cpp
@@ -40,9 +40,8 @@ bool MerginUserAuth::hasAuthData()
 void MerginUserAuth::setFromJson( QJsonObject docObj )
 {
   // parse profile data
-  QJsonObject profileObj = docObj.value( QStringLiteral( "profile" ) ).toObject();
-  mUserId = profileObj.value( QStringLiteral( "user" ) ).toInt();
-  mUsername = profileObj.value( QStringLiteral( "username" ) ).toString();
+  mUserId = docObj.value( QStringLiteral( "user" ) ).toInt();
+  mUsername = docObj.value( QStringLiteral( "username" ) ).toString();
 
   // parse session data
   QJsonObject session = docObj.value( QStringLiteral( "session" ) ).toObject();

--- a/core/merginuserinfo.cpp
+++ b/core/merginuserinfo.cpp
@@ -43,11 +43,15 @@ void MerginUserInfo::clear()
 void MerginUserInfo::setFromJson( QJsonObject docObj )
 {
   // parse profile data
-  QJsonObject profileObj = docObj.value( QStringLiteral( "profile" ) ).toObject();
-  mEmail = profileObj.value( QStringLiteral( "email" ) ).toString();
-  mDiskUsage = profileObj.value( QStringLiteral( "disk_usage" ) ).toDouble();
-  mStorageLimit = profileObj.value( QStringLiteral( "storage" ) ).toDouble();
+  mEmail = docObj.value( QStringLiteral( "email" ) ).toString();
+  mDiskUsage = docObj.value( QStringLiteral( "disk_usage" ) ).toDouble();
+  mStorageLimit = docObj.value( QStringLiteral( "storage" ) ).toDouble();
 
+  emit userInfoChanged();
+}
+
+void MerginUserInfo::setSubscriptionInfoFromJson( QJsonObject docObj )
+{
   // parse service data
   QJsonObject serviceObj = docObj.value( QStringLiteral( "service" ) ).toObject();
 

--- a/core/merginuserinfo.cpp
+++ b/core/merginuserinfo.cpp
@@ -58,6 +58,10 @@ void MerginUserInfo::setFromJson( QJsonObject docObj )
 
 void MerginUserInfo::setSubscriptionInfoFromJson( QJsonObject docObj )
 {
+
+  QJsonObject profileObj = docObj.value( QStringLiteral( "profile" ) ).toObject();
+  mStorageLimit = profileObj.value( QStringLiteral( "storage" ) ).toDouble();
+
   // parse service data
   QJsonObject serviceObj = docObj.value( QStringLiteral( "service" ) ).toObject();
 

--- a/core/merginuserinfo.cpp
+++ b/core/merginuserinfo.cpp
@@ -38,11 +38,11 @@ void MerginUserInfo::clear()
 {
   clearSubscriptionData();
   mEmail = "";
-  clearPlanInfo();
   mDiskUsage = 0;
   mStorageLimit = 0;
   clearPlanInfo();
 
+  emit subscriptionChanged();
   emit userInfoChanged();
 }
 
@@ -130,7 +130,7 @@ void MerginUserInfo::setSubscriptionInfoFromJson( QJsonObject docObj )
     emit planProductIdChanged();
   }
 
-  emit userInfoChanged();
+  emit subscriptionChanged();
 }
 
 bool MerginUserInfo::ownsActiveSubscription() const
@@ -146,7 +146,7 @@ void MerginUserInfo::setLocalizedPrice( const QString &price )
   if ( price != mNextBillPrice )
   {
     mNextBillPrice = price;
-    emit userInfoChanged();
+    emit subscriptionChanged();
   }
 }
 

--- a/core/merginuserinfo.cpp
+++ b/core/merginuserinfo.cpp
@@ -25,18 +25,24 @@ void MerginUserInfo::clearSubscriptionData()
   mOwnsActiveSubscription = false;
 }
 
+void MerginUserInfo::clearPlanInfo()
+{
+  mPlanAlias = "";
+  mPlanProvider = MerginSubscriptionType::NoneSubscriptionType;
+  mPlanProductId = "";
+  emit planProviderChanged();
+  emit planProductIdChanged();
+}
+
 void MerginUserInfo::clear()
 {
   clearSubscriptionData();
   mEmail = "";
-  mPlanAlias = "";
-  mPlanProvider = MerginSubscriptionType::NoneSubscriptionType;
-  mPlanProductId = "";
+  clearPlanInfo();
   mDiskUsage = 0;
   mStorageLimit = 0;
+  clearPlanInfo();
 
-  emit planProviderChanged();
-  emit planProductIdChanged();
   emit userInfoChanged();
 }
 

--- a/core/merginuserinfo.cpp
+++ b/core/merginuserinfo.cpp
@@ -16,33 +16,12 @@ MerginUserInfo::MerginUserInfo( QObject *parent )
   clear();
 }
 
-void MerginUserInfo::clearSubscriptionData()
-{
-  mSubscriptionStatus = MerginSubscriptionStatus::FreeSubscription;
-  mSubscriptionTimestamp = "";
-  mNextBillPrice = "";
-  mSubscriptionId = -1;
-  mOwnsActiveSubscription = false;
-}
-
-void MerginUserInfo::clearPlanInfo()
-{
-  mPlanAlias = "";
-  mPlanProvider = MerginSubscriptionType::NoneSubscriptionType;
-  mPlanProductId = "";
-  emit planProviderChanged();
-  emit planProductIdChanged();
-}
-
 void MerginUserInfo::clear()
 {
-  clearSubscriptionData();
   mEmail = "";
   mDiskUsage = 0;
   mStorageLimit = 0;
-  clearPlanInfo();
 
-  emit subscriptionChanged();
   emit userInfoChanged();
 }
 
@@ -56,136 +35,10 @@ void MerginUserInfo::setFromJson( QJsonObject docObj )
   emit userInfoChanged();
 }
 
-void MerginUserInfo::setSubscriptionInfoFromJson( QJsonObject docObj )
-{
-
-  QJsonObject profileObj = docObj.value( QStringLiteral( "profile" ) ).toObject();
-  mStorageLimit = profileObj.value( QStringLiteral( "storage" ) ).toDouble();
-
-  // parse service data
-  QJsonObject serviceObj = docObj.value( QStringLiteral( "service" ) ).toObject();
-
-  // parse service.subscription data
-  QJsonObject subscriptionObj = serviceObj.value( QStringLiteral( "subscription" ) ).toObject();
-  if ( subscriptionObj.isEmpty() )
-  {
-    // only free plan is assigned, subscription data is not present in JSON
-    clearSubscriptionData();
-  }
-  else
-  {
-    // user has subscription
-
-    mNextBillPrice = subscriptionObj.value( QStringLiteral( "next_bill_price" ) ).toString();
-    QString nextPaymentDate = subscriptionObj.value( QStringLiteral( "next_payment" ) ).toString();
-    QString validUntil = subscriptionObj.value( QStringLiteral( "valid_until" ) ).toString();
-    if ( nextPaymentDate.isEmpty() )
-    {
-      mSubscriptionTimestamp = CoreUtils::localizedDateFromUTFString( validUntil );
-    }
-    else
-    {
-      mSubscriptionTimestamp = CoreUtils::localizedDateFromUTFString( nextPaymentDate );
-    }
-
-    mSubscriptionId = subscriptionObj.value( QStringLiteral( "id" ) ).toInt();
-    QString status = subscriptionObj.value( QStringLiteral( "status" ) ).toString();
-
-    if ( status == "active" )
-    {
-      if ( nextPaymentDate.isEmpty() )
-      {
-        mSubscriptionStatus = MerginSubscriptionStatus::SubscriptionUnsubscribed;
-      }
-      else
-      {
-        mSubscriptionStatus = MerginSubscriptionStatus::ValidSubscription;
-      }
-    }
-
-    else if ( status == "past_due" )
-    {
-      mSubscriptionStatus = MerginSubscriptionStatus::SubscriptionInGracePeriod;
-    }
-    else // cancelled
-    {
-      mSubscriptionStatus = MerginSubscriptionStatus::CanceledSubscription;
-    }
-  }
-
-  // parse service.plan data
-  QJsonObject planObj = serviceObj.value( QStringLiteral( "plan" ) ).toObject();
-  mOwnsActiveSubscription = planObj.value( QStringLiteral( "is_paid_plan" ) ).toBool();
-  mPlanAlias = planObj.value( QStringLiteral( "alias" ) ).toString();
-  MerginSubscriptionType::SubscriptionType planProvider = MerginSubscriptionType::fromString( planObj.value( QStringLiteral( "type" ) ).toString() );
-  if ( planProvider != mPlanProvider )
-  {
-    mPlanProvider = planProvider;
-    emit planProviderChanged();
-  }
-  QString planProductId = planObj.value( QStringLiteral( "product_id" ) ).toString();
-  if ( planProductId !=  mPlanProductId )
-  {
-    mPlanProductId = planProductId;
-    emit planProductIdChanged();
-  }
-
-  emit subscriptionChanged();
-}
-
-bool MerginUserInfo::ownsActiveSubscription() const
-{
-  return mOwnsActiveSubscription;
-}
-
-void MerginUserInfo::setLocalizedPrice( const QString &price )
-{
-  if ( price.isEmpty() )
-    return;
-
-  if ( price != mNextBillPrice )
-  {
-    mNextBillPrice = price;
-    emit subscriptionChanged();
-  }
-}
-
-
-int MerginUserInfo::subscriptionId() const
-{
-  return mSubscriptionId;
-}
-
-
-MerginSubscriptionType::SubscriptionType MerginUserInfo::planProvider() const
-{
-  return mPlanProvider;
-}
-
-QString MerginUserInfo::planProductId() const
-{
-  return mPlanProductId;
-}
-
 
 QString MerginUserInfo::email() const
 {
   return mEmail;
-}
-
-QString MerginUserInfo::planAlias() const
-{
-  return mPlanAlias;
-}
-
-QString MerginUserInfo::nextBillPrice() const
-{
-  return mNextBillPrice;
-}
-
-int MerginUserInfo::subscriptionStatus() const
-{
-  return mSubscriptionStatus;
 }
 
 double MerginUserInfo::diskUsage() const
@@ -198,7 +51,8 @@ double MerginUserInfo::storageLimit() const
   return mStorageLimit;
 }
 
-QString MerginUserInfo::subscriptionTimestamp() const
+void MerginUserInfo::onStorageChanged( double storage )
 {
-  return mSubscriptionTimestamp;
+  mStorageLimit = storage;
+  emit userInfoChanged();
 }

--- a/core/merginuserinfo.h
+++ b/core/merginuserinfo.h
@@ -22,17 +22,16 @@ class MerginUserInfo: public QObject
 {
     Q_OBJECT
     Q_PROPERTY( QString email READ email NOTIFY userInfoChanged )
-
-    Q_PROPERTY( QString planAlias READ planAlias NOTIFY userInfoChanged ) // see PurchasingPlan::alias()
-    Q_PROPERTY( /*MerginSubscriptionType::SubscriptionType*/ int planProvider READ planProvider NOTIFY userInfoChanged ) // see PurchasingTransaction::provider()
-    Q_PROPERTY( QString planProductId READ planProductId NOTIFY userInfoChanged ) // see PurchasingPlan::id()
-
-    Q_PROPERTY( /*MerginSubscriptionStatus::SubscriptionStatus*/ int subscriptionStatus READ subscriptionStatus NOTIFY userInfoChanged )
     Q_PROPERTY( double storageLimit READ storageLimit NOTIFY userInfoChanged )
-    Q_PROPERTY( QString subscriptionTimestamp READ subscriptionTimestamp NOTIFY userInfoChanged )
-    Q_PROPERTY( QString nextBillPrice READ nextBillPrice NOTIFY userInfoChanged ) // in Bytes
     Q_PROPERTY( double diskUsage READ diskUsage NOTIFY userInfoChanged ) // in Bytes
-    Q_PROPERTY( bool ownsActiveSubscription READ ownsActiveSubscription NOTIFY userInfoChanged )
+
+    Q_PROPERTY( QString planAlias READ planAlias NOTIFY subscriptionChanged ) // see PurchasingPlan::alias()
+    Q_PROPERTY( /*MerginSubscriptionType::SubscriptionType*/ int planProvider READ planProvider NOTIFY subscriptionChanged ) // see PurchasingTransaction::provider()
+    Q_PROPERTY( QString planProductId READ planProductId NOTIFY subscriptionChanged ) // see PurchasingPlan::id()
+    Q_PROPERTY( /*MerginSubscriptionStatus::SubscriptionStatus*/ int subscriptionStatus READ subscriptionStatus NOTIFY subscriptionChanged )
+    Q_PROPERTY( QString subscriptionTimestamp READ subscriptionTimestamp NOTIFY subscriptionChanged )
+    Q_PROPERTY( QString nextBillPrice READ nextBillPrice NOTIFY subscriptionChanged ) // in Bytes
+    Q_PROPERTY( bool ownsActiveSubscription READ ownsActiveSubscription NOTIFY subscriptionChanged )
 
   public:
     explicit MerginUserInfo( QObject *parent = nullptr );
@@ -61,6 +60,7 @@ class MerginUserInfo: public QObject
 
   signals:
     void userInfoChanged();
+    void subscriptionChanged();
     void planProductIdChanged();
     void planProviderChanged();
 

--- a/core/merginuserinfo.h
+++ b/core/merginuserinfo.h
@@ -25,57 +25,27 @@ class MerginUserInfo: public QObject
     Q_PROPERTY( double storageLimit READ storageLimit NOTIFY userInfoChanged )
     Q_PROPERTY( double diskUsage READ diskUsage NOTIFY userInfoChanged ) // in Bytes
 
-    Q_PROPERTY( QString planAlias READ planAlias NOTIFY subscriptionChanged ) // see PurchasingPlan::alias()
-    Q_PROPERTY( /*MerginSubscriptionType::SubscriptionType*/ int planProvider READ planProvider NOTIFY subscriptionChanged ) // see PurchasingTransaction::provider()
-    Q_PROPERTY( QString planProductId READ planProductId NOTIFY subscriptionChanged ) // see PurchasingPlan::id()
-    Q_PROPERTY( /*MerginSubscriptionStatus::SubscriptionStatus*/ int subscriptionStatus READ subscriptionStatus NOTIFY subscriptionChanged )
-    Q_PROPERTY( QString subscriptionTimestamp READ subscriptionTimestamp NOTIFY subscriptionChanged )
-    Q_PROPERTY( QString nextBillPrice READ nextBillPrice NOTIFY subscriptionChanged ) // in Bytes
-    Q_PROPERTY( bool ownsActiveSubscription READ ownsActiveSubscription NOTIFY subscriptionChanged )
-
   public:
     explicit MerginUserInfo( QObject *parent = nullptr );
     ~MerginUserInfo() = default;
 
   public:
-    void clearSubscriptionData();
-    void clearPlanInfo();
     void clear();
+    void setFromJson( QJsonObject docObj );
 
     QString email() const;
-    QString planAlias() const;
-    int subscriptionId() const;
-    MerginSubscriptionType::SubscriptionType planProvider() const;
-    QString planProductId() const;
-    QString nextBillPrice() const;
-    /*MerginSubscriptionStatus::SubscriptionStatus*/ int subscriptionStatus() const;
     double diskUsage() const;
     double storageLimit() const;
-    QString subscriptionTimestamp() const;
-    bool ownsActiveSubscription() const;
-
-    void setLocalizedPrice( const QString &price );
-    void setFromJson( QJsonObject docObj );
-    void setSubscriptionInfoFromJson( QJsonObject docObj );
 
   signals:
     void userInfoChanged();
-    void subscriptionChanged();
-    void planProductIdChanged();
-    void planProviderChanged();
+  public slots:
+    void onStorageChanged( double storage );
 
   private:
     QString mEmail;
-    QString mPlanAlias;
-    int mSubscriptionId = -1;
-    MerginSubscriptionType::SubscriptionType mPlanProvider = MerginSubscriptionType::NoneSubscriptionType;
-    QString mPlanProductId;
-    bool mOwnsActiveSubscription = false;
-    QString mNextBillPrice;
-    MerginSubscriptionStatus::SubscriptionStatus mSubscriptionStatus = MerginSubscriptionStatus::FreeSubscription;
     double mDiskUsage = 0.0; // in Bytes
     double mStorageLimit = 0.0; // in Bytes
-    QString mSubscriptionTimestamp;
 };
 
 #endif // MERGINUSERINFO_H

--- a/core/merginuserinfo.h
+++ b/core/merginuserinfo.h
@@ -40,6 +40,7 @@ class MerginUserInfo: public QObject
 
   public:
     void clearSubscriptionData();
+    void clearPlanInfo();
     void clear();
 
     QString email() const;

--- a/core/merginuserinfo.h
+++ b/core/merginuserinfo.h
@@ -56,6 +56,7 @@ class MerginUserInfo: public QObject
 
     void setLocalizedPrice( const QString &price );
     void setFromJson( QJsonObject docObj );
+    void setSubscriptionInfoFromJson( QJsonObject docObj );
 
   signals:
     void userInfoChanged();


### PR DESCRIPTION
Changes due to support for CE Mergin server. The idea is to use primary mergin core endpoints. Request related to subscription are sent extra. Therefore login and userInfo request were changed.

Note that there is a possibility to corrupt data by mixing projects from different servers ATM: https://github.com/lutraconsulting/input/issues/1347

**Squash and Merge** option can be ideally used.

Account page with server supporting subscription:
<img width="752" alt="Screenshot 2021-04-22 at 10 06 06" src="https://user-images.githubusercontent.com/6735606/115724347-28781880-a381-11eb-8675-09d715874364.png">

Account page with server NOT supporting subscription (looks quite empty):
<img width="752" alt="Screenshot 2021-04-22 at 10 08 58" src="https://user-images.githubusercontent.com/6735606/115724365-2b730900-a381-11eb-8b74-ab600a0afe3a.png">

related to #1289 