### PR TITLE
Added StorageLimitDialog

### DIFF
--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -23,6 +23,9 @@ Item {
   property string activeProjectId: ""
   property string activeProjectPath: ""
 
+  property alias stackView: stackView
+  property alias subscribePanelComp: subscribePanelComp
+
   signal openProjectRequested( string projectId, string projectPath )
   signal resetView() // resets view to state as when panel is opened
 

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -23,9 +23,6 @@ Item {
   property string activeProjectId: ""
   property string activeProjectPath: ""
 
-  property alias stackView: stackView
-  property alias subscribePanelComp: subscribePanelComp
-
   signal openProjectRequested( string projectId, string projectPath )
   signal resetView() // resets view to state as when panel is opened
 
@@ -37,6 +34,14 @@ Item {
   function hidePanel() {
     root.visible = false
     stackView.clearStackAndClose()
+  }
+
+  function manageSubscriptionPlans() {
+    if (__purchasing.hasInAppPurchases && (__purchasing.hasManageSubscriptionCapability || !__merginApi.subscriptionInfo.ownsActiveSubscription )) {
+      stackView.push( subscribePanelComp)
+    } else {
+      Qt.openUrlExternally(__purchasing.subscriptionManageUrl);
+    }
   }
 
   visible: false
@@ -506,13 +511,7 @@ Item {
       onBack: {
         stackView.popOnePageOrClose()
       }
-      onManagePlansClicked: {
-        if (__purchasing.hasInAppPurchases && (__purchasing.hasManageSubscriptionCapability || !__merginApi.subscriptionInfo.ownsActiveSubscription )) {
-          stackView.push( subscribePanelComp)
-        } else {
-          Qt.openUrlExternally(__purchasing.subscriptionManageUrl);
-        }
-      }
+      onManagePlansClicked: manageSubscriptionPlans()
       onSignOutClicked: {
         if ( __merginApi.userAuth.hasAuthData() ) {
           __merginApi.clearAuth()

--- a/app/qml/StorageLimitDialog.qml
+++ b/app/qml/StorageLimitDialog.qml
@@ -1,3 +1,12 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Dialogs 1.1
@@ -7,7 +16,7 @@ import "./components"
 
 Dialog {
   property var uploadSize
-  property string titleText
+  property string titleText: qsTr("You have reached a data limit")
   property int diskUsage: __merginApi.userInfo.diskUsage
   property int storageLimit: __merginApi.userInfo.storageLimit
   property string planAlias: __merginApi.subscriptionInfo.planAlias
@@ -96,7 +105,7 @@ Dialog {
       font.pixelSize: InputStyle.fontPixelSizeNormal
       font.underline: true
       color: InputStyle.fontColor
-      text: qsTr("Find a plan that fits you better!")
+      text: qsTr("Manage subscriptions")
       visible: __merginApi.apiSupportsSubscriptions
 
       MouseArea {
@@ -112,7 +121,7 @@ Dialog {
     }
 
     DelegateButton {
-      text: "OK"
+      text: qsTr("Cancel")
       onClicked: root.close()
       height: root.fieldHeight
       width: parent.width

--- a/app/qml/StorageLimitDialog.qml
+++ b/app/qml/StorageLimitDialog.qml
@@ -1,0 +1,122 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Dialogs 1.1
+import QtQuick.Layouts 1.12
+
+import "./components"
+
+Dialog {
+  property var uploadSize
+  property string titleText
+  property int diskUsage: __merginApi.userInfo.diskUsage
+  property int storageLimit: __merginApi.userInfo.storageLimit
+  property string planAlias: __merginApi.subscriptionInfo.planAlias
+  property real fieldHeight: InputStyle.rowHeight
+
+  signal openSubscriptionPlans
+
+  id: root
+  visible: false
+  modal: true
+  closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+  onAccepted: root.close()
+  anchors.centerIn: parent
+  margins: InputStyle.outerFieldMargin
+
+  background: Rectangle {
+    anchors.fill: parent
+    color: "white"
+  }
+
+  contentItem: ColumnLayout {
+    anchors.margins: InputStyle.outerFieldMargin
+
+    Text {
+      id: title
+      anchors.topMargin: InputStyle.panelMargin
+      height: root.fieldHeight
+      text: root.titleText
+      color: InputStyle.fontColor
+      font.pixelSize: InputStyle.fontPixelSizeTitle
+      font.bold: true
+      verticalAlignment: Text.AlignVCenter
+      horizontalAlignment: Text.AlignHCenter
+    }
+
+    TextWithIcon {
+      width: parent.width
+      height: root.fieldHeight
+      source: 'sync.svg'
+      text: qsTr("Data to sync: %1").arg(__inputUtils.bytesToHumanSize(
+                                           uploadSize))
+    }
+
+    Row {
+      width: parent.width
+      height: root.fieldHeight
+      Item {
+        width: root.fieldHeight
+        height: root.fieldHeight
+
+        CircularProgressBar {
+          id: storageIcon
+          width: parent.width * 0.6
+          anchors.centerIn: parent
+          height: width
+          value: root.diskUsage / root.storageLimit
+        }
+      }
+
+      Text {
+        id: textItem
+        height: root.fieldHeight
+        verticalAlignment: Text.AlignVCenter
+        font.pixelSize: InputStyle.fontPixelSizeNormal
+        color: InputStyle.fontColor
+        text: qsTr("Using %1 / %2").arg(__inputUtils.bytesToHumanSize(
+                                          diskUsage)).arg(
+                __inputUtils.bytesToHumanSize(storageLimit))
+      }
+    }
+
+    TextWithIcon {
+      width: parent.width
+      height: root.fieldHeight
+      source: 'edit.svg'
+      text: qsTr("Plan: %1").arg(planAlias)
+      visible: __merginApi.apiSupportsSubscriptions
+    }
+
+    Text {
+      id: planLink
+      height: root.fieldHeight
+      Layout.fillWidth: true
+      horizontalAlignment: Qt.AlignHCenter
+      verticalAlignment: Qt.AlignVCenter
+      font.pixelSize: InputStyle.fontPixelSizeNormal
+      font.underline: true
+      color: InputStyle.fontColor
+      text: qsTr("Find a plan that fits you better!")
+      visible: __merginApi.apiSupportsSubscriptions
+
+      MouseArea {
+        anchors.fill: parent
+        onClicked: root.openSubscriptionPlans()
+      }
+    }
+
+    Item {
+      id: spacer
+      height: InputStyle.fontPixelSizeTitle
+      width: parent.width
+    }
+
+    DelegateButton {
+      text: "OK"
+      onClicked: root.close()
+      height: root.fieldHeight
+      width: parent.width
+      Layout.fillWidth: true
+    }
+  }
+}

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -671,7 +671,7 @@ ApplicationWindow {
         onOpenSubscriptionPlans: {
           if (__merginApi.apiSupportsSubscriptions) {
             storageLimitDialog.close()
-            projectPanel.stackView.push( projectPanel.subscribePanelComp )
+            projectPanel.manageSubscriptionPlans()
           }
         }
     }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -669,8 +669,8 @@ ApplicationWindow {
     StorageLimitDialog {
         id: storageLimitDialog
         onOpenSubscriptionPlans: {
+          storageLimitDialog.close()
           if (__merginApi.apiSupportsSubscriptions) {
-            storageLimitDialog.close()
             projectPanel.manageSubscriptionPlans()
           }
         }
@@ -702,7 +702,6 @@ ApplicationWindow {
           if (__merginApi.apiSupportsSubscriptions) {
             __merginApi.getSubscriptionInfo()
           }
-          storageLimitDialog.titleText = message
           storageLimitDialog.uploadSize = uploadSize
           storageLimitDialog.open()
         }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -666,6 +666,16 @@ ApplicationWindow {
         z: zPanel + 1000 // the most top
     }
 
+    StorageLimitDialog {
+        id: storageLimitDialog
+        onOpenSubscriptionPlans: {
+          if (__merginApi.apiSupportsSubscriptions) {
+            storageLimitDialog.close()
+            projectPanel.stackView.push( projectPanel.subscribePanelComp )
+          }
+        }
+    }
+
     MessageDialog {
         id: alertDialog
         onAccepted: alertDialog.close()
@@ -686,7 +696,18 @@ ApplicationWindow {
             var msg = message ? message : qsTr("Failed to communicate with Mergin.%1Try improving your network connection.".arg("<br/>"))
             showAsDialog ? showDialog(msg) : showMessage(msg)
         }
-        onNotify: showMessage(message)
+
+        onStorageLimitReached: {
+          __merginApi.getUserInfo()
+          if (__merginApi.apiSupportsSubscriptions) {
+            __merginApi.getSubscriptionInfo()
+          }
+          storageLimitDialog.titleText = message
+          storageLimitDialog.uploadSize = uploadSize
+          storageLimitDialog.open()
+        }
+
+        onNotify: showDialog(msg)
 
         onProjectDataChanged: {
           //! if current project has been updated, refresh canvas

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -66,5 +66,6 @@
         <file>components/ProjectDelegateItem.qml</file>
         <file>components/ProjectList.qml</file>
         <file>components/RichTextBlock.qml</file>
+        <file>StorageLimitDialog.qml</file>
     </qresource>
 </RCC>

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1598,14 +1598,28 @@ void MerginApi::uploadStartReplyFinished()
     int status = statusCode.toInt();
     QString serverMsg = extractServerErrorMsg( r->readAll() );
     QString errorMsg = r->errorString();
-    bool showAsDialog = status == 400 && serverMsg == QStringLiteral( "You have reached a data limit" );
+    bool showLimitReachedDialog = status == 400 && serverMsg == QStringLiteral( "You have reached a data limit" );
 
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1. %2" ).arg( r->errorString(), serverMsg ) );
 
     transaction.replyUploadStart->deleteLater();
     transaction.replyUploadStart = nullptr;
 
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: uploadStartReply" ), showAsDialog );
+    if ( showLimitReachedDialog )
+    {
+      QList<MerginFile> files = transaction.uploadQueue;
+      qreal uploadSize = 0;
+      for ( MerginFile f : files )
+      {
+        uploadSize = uploadSize + f.size;
+      }
+      emit storageLimitReached( serverMsg, QStringLiteral( "Mergin API error: uploadStartReply" ), uploadSize );
+    }
+    else
+    {
+      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: uploadStartReply" ) );
+    }
+
     finishProjectSync( projectFullName, false );
   }
 }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1613,7 +1613,7 @@ void MerginApi::uploadStartReplyFinished()
       {
         uploadSize = uploadSize + f.size;
       }
-      emit storageLimitReached( serverMsg, QStringLiteral( "Mergin API error: uploadStartReply" ), uploadSize );
+      emit storageLimitReached( uploadSize );
     }
     else
     {

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1598,7 +1598,7 @@ void MerginApi::uploadStartReplyFinished()
     int status = statusCode.toInt();
     QString serverMsg = extractServerErrorMsg( r->readAll() );
     QString errorMsg = r->errorString();
-    bool showLimitReachedDialog = status == 400 && serverMsg == QStringLiteral( "You have reached a data limit" );
+    bool showLimitReachedDialog = status == 400 && serverMsg.contains( QStringLiteral( "You have reached a data limit" ) );
 
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1. %2" ).arg( r->errorString(), serverMsg ) );
 
@@ -1607,11 +1607,11 @@ void MerginApi::uploadStartReplyFinished()
 
     if ( showLimitReachedDialog )
     {
-      QList<MerginFile> files = transaction.uploadQueue;
+      const QList<MerginFile> files = transaction.uploadQueue;
       qreal uploadSize = 0;
-      for ( MerginFile f : files )
+      for ( const MerginFile &f : files )
       {
-        uploadSize = uploadSize + f.size;
+        uploadSize += f.size;
       }
       emit storageLimitReached( uploadSize );
     }

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -405,7 +405,7 @@ class MerginApi: public QObject
     void syncProjectStatusChanged( const QString &projectFullName, qreal progress );
     void reloadProject( const QString &projectDir );
     void networkErrorOccurred( const QString &message, const QString &additionalInfo, bool showAsDialog = false );
-    void storageLimitReached( const QString &message, const QString &additionalInfo, qreal uploadSize );
+    void storageLimitReached( qreal uploadSize );
     void notify( const QString &message );
     void authRequested();
     void authChanged();

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -405,6 +405,7 @@ class MerginApi: public QObject
     void syncProjectStatusChanged( const QString &projectFullName, qreal progress );
     void reloadProject( const QString &projectDir );
     void networkErrorOccurred( const QString &message, const QString &additionalInfo, bool showAsDialog = false );
+    void storageLimitReached( const QString &message, const QString &additionalInfo, qreal uploadSize );
     void notify( const QString &message );
     void authRequested();
     void authChanged();


### PR DESCRIPTION
Introduced a new dialog when a storage limit has been reached during the sync. Includes some information according the related ticket. Data are fetched between when MerginApi sends a signal of reached limit and when dialog is opened. Since the userInfo/subscription info request may take some time, information labels in the dialog could be empty/out-dated till the request is finished.

Things to consider:
* design/content of the dialog (e.g. labels, text sizes,...)
* what should be done when a user clicks on text - currently opens subscription page.
* request user/subscription info in advance - currently there is no need to have those info before user opens AccountPage, therefore requests are sent also when the page is about to be opened.

https://user-images.githubusercontent.com/6735606/116530461-5e1b8500-a8de-11eb-8ab6-b4f162ca65db.MP4

Version for core Mergin (without subscriptions):
![IMG_0117](https://user-images.githubusercontent.com/6735606/116530529-6ecbfb00-a8de-11eb-9779-e2e1b2c14826.PNG)

closes #1362 
related to https://github.com/lutraconsulting/input/issues/1089