### PR TITLE
Fix of opening account panel after sign out

### DIFF
--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -966,8 +966,9 @@ void MerginApi::pingMerginReplyFinished()
 
 void MerginApi::onPlanProductIdChanged()
 {
-  if (mUserAuth->hasAuthData()) {
-      getUserInfo();
+  if ( mUserAuth->hasAuthData() )
+  {
+    getUserInfo();
   }
 }
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -966,7 +966,9 @@ void MerginApi::pingMerginReplyFinished()
 
 void MerginApi::onPlanProductIdChanged()
 {
-  getUserInfo();
+  if (mUserAuth->hasAuthData()) {
+      getUserInfo();
+  }
 }
 
 QNetworkReply *MerginApi::getProjectInfo( const QString &projectFullName, bool withoutAuth )

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -452,7 +452,7 @@ class MerginApi: public QObject
     void pingMerginReplyFinished();
     /**
      * @brief When plan has been changed, an extra userInfo request is needed to update also storage.
-     * Calls user info only when has authData, otherwise slots catches the signal from clering user data after signing out.
+     * Calls user info only when has authData, otherwise slots catches the signal from clearing user data after signing out.
      */
     void onPlanProductIdChanged();
 

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -450,7 +450,10 @@ class MerginApi: public QObject
     void authorizeFinished();
     void registrationFinished( const QString &username = QStringLiteral(), const QString &password = QStringLiteral() );
     void pingMerginReplyFinished();
-    //! When plan has been changed, an extra userInfo request is needed to update also storage.
+    /**
+     * @brief When plan has been changed, an extra userInfo request is needed to update also storage.
+     * Calls user info only when has authData, otherwise slots catches the signal from clering user data after signing out.
+     */
     void onPlanProductIdChanged();
 
   private:


### PR DESCRIPTION
Fix of really annoying bug that has been introduces after CE support PR.

**Story behind:**
When a user signs out, userInfo, subscriptionInfo and authData are cleared. After CE support PR a new signal has been introduced to update user info, when subscription has changed (storage has to be updated - this extra call was needed mostly for tests). 

**The cause:**
This extra call for userInfo triggers authorization, which opens an extra Login page in the stackview. This extra page is unexpected and stackview pops out Login page instead of Account page (where user clicks on Sign out button). Therefore AccountPage was still present (and empty)

**Solution:**
Since after the sign out, all user data are cleared, there is not need to request userInfo at all. Simple condition was added to prevent it.

Another possible solution would be to use different signals for clearing user data and where data are updated. 

closes #1367