### PR TITLE
Fixed behaviour of TextField in ProjectWizard

### DIFF
--- a/app/qml/components/FieldRow.qml
+++ b/app/qml/components/FieldRow.qml
@@ -31,7 +31,7 @@ Item {
       Layout.preferredWidth: row.itemSize
 
       Component.onCompleted: text = AttributeName
-      onDisplayTextChanged: AttributeName = displayText
+      onTextChanged: AttributeName = text
     }
 
     ComboBox {

--- a/app/qml/components/FieldRow.qml
+++ b/app/qml/components/FieldRow.qml
@@ -26,10 +26,12 @@ Item {
     InputTextField {
       id: textField
       color: fieldDelegate.color
-      text: AttributeName
       Layout.fillHeight: true
       Layout.fillWidth: true
       Layout.preferredWidth: row.itemSize
+
+      Component.onCompleted: text = AttributeName
+      onDisplayTextChanged: AttributeName = displayText
     }
 
     ComboBox {

--- a/app/qml/components/FieldRow.qml
+++ b/app/qml/components/FieldRow.qml
@@ -30,8 +30,6 @@ Item {
       Layout.fillHeight: true
       Layout.fillWidth: true
       Layout.preferredWidth: row.itemSize
-
-      onDisplayTextChanged: AttributeName = displayText
     }
 
     ComboBox {


### PR DESCRIPTION
I couldn't replicate the issue, but I could replicate similar problem with auto uppercase - when a user types into an Attribute field with fixed uppercase option (usually double click on shift to "lock" shift), it always switches back to lower case. It doesn't happen for a project name field.

This PR fixes the issue described above. However, the reported issue could be very related and fixed as well. Best to test.
Now the field value is bound to `text` without an extra handling for displayText.

closes #1334 