### PR TITLE
Restrict "non searchable" attributes in a feature request query

### DIFF
--- a/qgsquick/from_qgis/qgsquickfeatureslistmodel.cpp
+++ b/qgsquick/from_qgis/qgsquickfeatureslistmodel.cpp
@@ -97,6 +97,9 @@ QString QgsQuickFeaturesListModel::foundPair( const QgsQuickFeatureLayerPair &pa
   {
     for ( const QgsField &field : fields )
     {
+      if ( field.configurationFlags().testFlag( QgsField::ConfigurationFlag::NotSearchable ) )
+        continue;
+
       QString attrValue = pair.feature().attribute( field.name() ).toString();
 
       if ( attrValue.toLower().indexOf( word.toLower() ) != -1 )
@@ -132,6 +135,9 @@ QString QgsQuickFeaturesListModel::buildSearchExpression()
 
     for ( const QgsField &field : fields )
     {
+      if ( field.configurationFlags().testFlag( QgsField::ConfigurationFlag::NotSearchable ) )
+        continue;
+
       if ( field.isNumeric() && searchExpressionIsNumeric )
         expressionParts << QStringLiteral( "%1 ~ '%2.*'" ).arg( QgsExpression::quotedColumnRef( field.name() ), word );
       else if ( field.type() == QVariant::String )


### PR DESCRIPTION
Attributes marked as `not searchable` are filtered out from QgsFeature request (scope) as well as from informative text for features shown on the BrowseDataPage.

Note that values for such attributes are still present in features fetched from the request (request.subsetOfAttributes() is kept unset and therefore a user see all attributes while browsing).

PR for QgsQuick will be made after this PR would be approved.

closes #1354 