### PR TITLE
Format time of sync

### DIFF
--- a/.github/workflows/autotests.yml
+++ b/.github/workflows/autotests.yml
@@ -118,6 +118,11 @@ jobs:
           cd build-Input/
           ./Input.app/Contents/MacOS/Input --testLinks
 
+      - name: run utils functions tests
+        run: |
+          cd build-Input/
+          ./Input.app/Contents/MacOS/Input --testUtils
+
       - name: run mergin api tests
         run: |
           cd build-Input/

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -112,18 +112,6 @@ QString InputUtils::formatNumber( const double number, int precision )
   return QString::number( number, 'f', precision );
 }
 
-QString InputUtils::formatDuration( int lengthOfCycle, const QString &cycleName )
-{
-  if ( lengthOfCycle == 1 )
-  {
-    return QStringLiteral( "%1 %2 ago" ).arg( lengthOfCycle ).arg( cycleName );
-  }
-  else
-  {
-    return QStringLiteral( "%1 %2s ago" ).arg( lengthOfCycle ).arg( cycleName );
-  }
-}
-
 QString InputUtils::formatDateTimeDiff( const QDateTime &tMin, const QDateTime &tMax )
 {
   qint64 daysDiff = tMin.daysTo( tMax );
@@ -145,36 +133,41 @@ QString InputUtils::formatDateTimeDiff( const QDateTime &tMin, const QDateTime &
     }
     else if ( secsDiff < 60 )
     {
-      return QStringLiteral( "a few seconds ago" );
+      return tr( "just now" );
     }
     else if ( secsDiff < 60 * 60 )
     {
-      return formatDuration( secsDiff / 60, QStringLiteral( "minute" ) );
+      int period = secsDiff / 60 ;
+      return ( period > 1 ) ? tr( "%1 minutes ago" ).arg( period ) : tr( "%1 minute ago" ).arg( period );
     }
     else if ( secsDiff < 60 * 60 * 24 )
     {
-      return formatDuration( qCeil( secsDiff / ( 60 * 60 ) ), QStringLiteral( "hour" ) );
+      int period = secsDiff / ( 60 * 60 );
+      return ( period > 1 ) ? tr( "%1 hours ago" ).arg( period ) : tr( "%1 hour ago" ).arg( period );
     }
     else
     {
-      return formatDuration( daysDiff, QStringLiteral( "day" ) );
+      return ( daysDiff > 1 ) ? tr( "%1 days ago" ).arg( daysDiff ) : tr( "%1 day ago" ).arg( daysDiff );
     }
   }
   else if ( daysDiff < 7 )
   {
-    return formatDuration( daysDiff, QStringLiteral( "day" ) );
+    return ( daysDiff > 1 ) ? tr( "%1 days ago" ).arg( daysDiff ) : tr( "%1 day ago" ).arg( daysDiff );
   }
   else if ( daysDiff < 31 )
   {
-    return formatDuration( qCeil( daysDiff / 7 ), QStringLiteral( "week" ) );
+    int period = daysDiff / 7;
+    return ( period > 1 ) ? tr( "%1 weeks ago" ).arg( period ) : tr( "%1 week ago" ).arg( period );
   }
   else if ( daysDiff < 365 )
   {
-    return formatDuration( qCeil( daysDiff / 31 ), QStringLiteral( "month" ) );
+    int period = daysDiff / 31;
+    return ( period > 1 ) ? tr( "%1 months ago" ).arg( period ) : tr( "%1 month ago" ).arg( period );
   }
   else
   {
-    return formatDuration( qCeil( daysDiff / 365 ), QStringLiteral( "year" ) );
+    int period = daysDiff / 365;
+    return ( period > 1 ) ? tr( "%1 years ago" ).arg( period ) : tr( "%1 year ago" ).arg( period );
   }
 
   return INVALID_DATETIME_STR;

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -114,7 +114,7 @@ QString InputUtils::formatNumber( const double number, int precision )
 
 QString InputUtils::formatDuration( int lengthOfCycle, const QString &cycleName )
 {
-  if ( lengthOfCycle == 0 || lengthOfCycle == 1 )
+  if ( lengthOfCycle == 1 )
   {
     return QStringLiteral( "%1 %2 ago" ).arg( lengthOfCycle ).arg( cycleName );
   }
@@ -139,11 +139,15 @@ QString InputUtils::formatDateTimeDiff( const QDateTime &tMin, const QDateTime &
   if ( daysDiff == 0 || daysDiff == 1 )
   {
     qint64 secsDiff = tMin.secsTo( tMax );
-    if ( secsDiff <= 0 )
+    if ( secsDiff < 0 )
     {
       return INVALID_DATETIME_STR;
     }
-    if ( secsDiff < 60 * 60 )
+    else if ( secsDiff < 60 )
+    {
+      return QStringLiteral( "a few seconds ago" );
+    }
+    else if ( secsDiff < 60 * 60 )
     {
       return formatDuration( secsDiff / 60, QStringLiteral( "minute" ) );
     }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -111,6 +111,76 @@ QString InputUtils::formatNumber( const double number, int precision )
   return QString::number( number, 'f', precision );
 }
 
+QString InputUtils::formatDuration( int lengthOfCycle, const QString &cycleName )
+{
+  if ( lengthOfCycle == 1 )
+  {
+    return QStringLiteral( "%1 %2 ago" ).arg( lengthOfCycle ).arg( cycleName );
+  }
+  else
+  {
+    return QStringLiteral( "%1 %2s ago" ).arg( lengthOfCycle ).arg( cycleName );
+  }
+}
+
+QString InputUtils::formatTimeDiff( const QDateTime &datetime )
+{
+  QDateTime currentTime = QDateTime::currentDateTime();
+  qint64 daysDiff = datetime.daysTo( currentTime );
+
+  // datetime is invalid
+  if ( daysDiff < 0 )
+  {
+    return QStringLiteral( "Invalid datetime" );
+  }
+
+  if ( daysDiff == 0 )
+  {
+    qint64 secsDiff = datetime.secsTo( currentTime );
+    if ( secsDiff <= 0 )
+    {
+      return QStringLiteral( "Invalid datetime" );
+    }
+    if ( secsDiff <= 60 * 60 )
+    {
+      return formatDuration( secsDiff / 60, QStringLiteral( "minute" ) );
+    }
+    else if ( secsDiff <= 60 * 60 * 24 )
+    {
+      return formatDuration( qCeil( daysDiff / 60 * 24 ), QStringLiteral( "hour" ) );
+    }
+    else
+    {
+      return formatDuration( qCeil( daysDiff / 60 * 24 ), QStringLiteral( "hour" ) );
+    }
+  }
+  else if ( daysDiff == 1 )
+  {
+    // Could be only few minutes over midnight
+
+
+    return QStringLiteral( "1 day ago" );
+  }
+  else if ( daysDiff < 7 )
+  {
+    return formatDuration( daysDiff, QStringLiteral( "day" ) );
+  }
+  else if ( daysDiff < 31 )
+  {
+    return formatDuration( qCeil( daysDiff / 7 ), QStringLiteral( "week" ) );
+  }
+  else if ( daysDiff < 365 )
+  {
+    return formatDuration( qCeil( daysDiff / 31 ), QStringLiteral( "month" ) );
+  }
+  else
+  {
+    return formatDuration( qCeil( daysDiff / 365 ), QStringLiteral( "month" ) );
+  }
+
+  return QStringLiteral( "Invalid datetime" );
+}
+
 void InputUtils::setExtentToFeature( const QgsQuickFeatureLayerPair &pair, QgsQuickMapSettings *mapSettings, double panelOffsetRatio )
 {
 

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -37,6 +37,7 @@ class InputUtils: public QObject
     Q_INVOKABLE QString getFileName( const QString &filePath );
     Q_INVOKABLE QString formatProjectName( const QString &fullProjectName );
     Q_INVOKABLE QString formatNumber( const double number, int precision = 1 );
+    static QString formatTimeDiff( const QDateTime &datetime );
 
     Q_INVOKABLE void setExtentToFeature( const QgsQuickFeatureLayerPair &pair, QgsQuickMapSettings *mapSettings, double panelOffsetRatio );
 
@@ -140,7 +141,8 @@ class InputUtils: public QObject
     // on iOS the names from gallery pickers are like
     // file:assets-library://asset/asset.PNG%3Fid=A53AB989-6354-433A-9CB9-958179B7C14D&ext=PNG
     // we need to change it to something more readable
-    QString sanitizeName( const QString &path );
+    static QString sanitizeName( const QString &path );
+    static QString formatDuration( int lengthOfCycle,  const QString &cycleName );
 
     static double ratherZeroThanNaN( double d );
     std::unique_ptr<AndroidUtils> mAndroidUtils;

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -37,8 +37,6 @@ class InputUtils: public QObject
     Q_INVOKABLE QString getFileName( const QString &filePath );
     Q_INVOKABLE QString formatProjectName( const QString &fullProjectName );
     Q_INVOKABLE QString formatNumber( const double number, int precision = 1 );
-    static QString formatTimeDiff( const QDateTime &datetime );
-
     Q_INVOKABLE void setExtentToFeature( const QgsQuickFeatureLayerPair &pair, QgsQuickMapSettings *mapSettings, double panelOffsetRatio );
 
     // utility functions to extract information from map settings
@@ -129,6 +127,15 @@ class InputUtils: public QObject
 
     //! Creates and registers custom expression functions to Input, so they can be used in default value definitions.
     static void registerInputExpressionFunctions();
+
+    /**
+     * @brief Creates formatted string of difference for given tMin and tMax datetimes (in minutes, hours, ... ago).
+     * Note, that tMin < tMax, otherwise arguments are invalid.
+     * @param tMin Datetime in the past
+     * @param tMax Datetime after tMin, currentDateTime by default.
+     * @return Formatted string
+     */
+    static QString formatDateTimeDiff( const QDateTime &tMin, const QDateTime &tMax = QDateTime::currentDateTimeUtc() );
 
   signals:
     Q_INVOKABLE void showNotificationRequested( const QString &message );

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -149,7 +149,6 @@ class InputUtils: public QObject
     // file:assets-library://asset/asset.PNG%3Fid=A53AB989-6354-433A-9CB9-958179B7C14D&ext=PNG
     // we need to change it to something more readable
     static QString sanitizeName( const QString &path );
-    static QString formatDuration( int lengthOfCycle,  const QString &cycleName );
 
     static double ratherZeroThanNaN( double d );
     std::unique_ptr<AndroidUtils> mAndroidUtils;

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -63,6 +63,7 @@
 #ifdef INPUT_TEST
 #include "test/testmerginapi.h"
 #include "test/testlinks.h"
+#include "test/testutilsfunctions.h"
 #if not defined APPLE_PURCHASING
 #include "test/testpurchasing.h"
 #endif
@@ -301,14 +302,16 @@ int main( int argc, char *argv[] )
   bool IS_MERGIN_API_TEST = false;
   bool IS_PURCHASING_TEST = false;
   bool IS_LINKS_TEST = false;
+  bool IS_UTILS_TEST = false;
   for ( int i = 0; i < argc; ++i )
   {
     if ( std::string( argv[i] ) == "--testMerginApi" ) IS_MERGIN_API_TEST = true;
     if ( std::string( argv[i] ) == "--testPurchasing" ) IS_PURCHASING_TEST = true;
     if ( std::string( argv[i] ) == "--testLinks" ) IS_LINKS_TEST = true;
+    if ( std::string( argv[i] ) == "--testUtils" ) IS_UTILS_TEST = true;
   }
-  Q_ASSERT( !( IS_MERGIN_API_TEST && IS_PURCHASING_TEST && IS_LINKS_TEST ) );
-  bool IS_TEST = IS_PURCHASING_TEST || IS_MERGIN_API_TEST || IS_LINKS_TEST;
+  Q_ASSERT( !( IS_MERGIN_API_TEST && IS_PURCHASING_TEST && IS_LINKS_TEST && IS_UTILS_TEST ) );
+  bool IS_TEST = IS_PURCHASING_TEST || IS_MERGIN_API_TEST || IS_LINKS_TEST || IS_UTILS_TEST;
 #endif
   qDebug() << "Built with QGIS version " << VERSION_INT;
 
@@ -433,6 +436,11 @@ int main( int argc, char *argv[] )
     {
       TestLinks linksTest( ma.get(), &iu );
       nFailed = QTest::qExec( &linksTest, args.count(), args.data() );
+    }
+    else if ( IS_UTILS_TEST )
+    {
+      TestUtilsFunctions utilsTest;
+      nFailed = QTest::qExec( &utilsTest, args.count(), args.data() );
     }
 #if not defined APPLE_PURCHASING
     else if ( IS_PURCHASING_TEST )

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -90,7 +90,7 @@ QVariant ProjectsModel::data( const QModelIndex &index, int role ) const
       }
       else if ( project->isMergin() )
       {
-        return QVariant( project->mergin->serverUpdated );
+        return QVariant( tr( "Updated %1" ).arg( InputUtils::formatTimeDiff( project->mergin->serverUpdated ) ) );
       }
 
       // This should not happen

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -86,11 +86,12 @@ QVariant ProjectsModel::data( const QModelIndex &index, int role ) const
           return QVariant( project->local->projectError );
         }
         QFileInfo fi( project->local->projectDir );
-        return QVariant( fi.lastModified().toLocalTime() ); // Maybe use better timestamp format https://doc.qt.io/qt-5/qdatetime.html#toString-3
+        // lastModified of projectDir is not reliable - gpkg file may have modified header after opening it. See more #1320
+        return QVariant( tr( "Updated %1" ).arg( InputUtils::formatDateTimeDiff( fi.lastModified().toUTC() ) ) );
       }
       else if ( project->isMergin() )
       {
-        return QVariant( tr( "Updated %1" ).arg( InputUtils::formatDateTimeDiff( project->mergin->serverUpdated ) ) );
+        return QVariant( tr( "Updated %1" ).arg( InputUtils::formatDateTimeDiff( project->mergin->serverUpdated.toUTC() ) ) );
       }
 
       // This should not happen

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -90,7 +90,7 @@ QVariant ProjectsModel::data( const QModelIndex &index, int role ) const
       }
       else if ( project->isMergin() )
       {
-        return QVariant( tr( "Updated %1" ).arg( InputUtils::formatTimeDiff( project->mergin->serverUpdated ) ) );
+        return QVariant( tr( "Updated %1" ).arg( InputUtils::formatDateTimeDiff( project->mergin->serverUpdated ) ) );
       }
 
       // This should not happen

--- a/app/sources.pri
+++ b/app/sources.pri
@@ -59,6 +59,7 @@ contains(DEFINES, INPUT_TEST) {
 
   SOURCES += \
       test/testutils.cpp \
+      test/testutilsfunctions.cpp \
       test/testmerginapi.cpp \
       test/testingpurchasingbackend.cpp \
       test/testpurchasing.cpp \
@@ -66,6 +67,7 @@ contains(DEFINES, INPUT_TEST) {
 
   HEADERS += \
       test/testutils.h \
+      test/testutilsfunctions.h \
       test/testmerginapi.h \
       test/testingpurchasingbackend.h \
       test/testpurchasing.h \

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -20,8 +20,8 @@ void TestUtilsFunctions::testFormatDuration()
   QDateTime t0 = QDateTime::currentDateTime();
 
   testFormatDuration( t0, -1, QStringLiteral( "Invalid datetime" ) );
-  testFormatDuration( t0, 0, QStringLiteral( "a few seconds ago" ) );
-  testFormatDuration( t0, 1, QStringLiteral( "a few seconds ago" ) );
+  testFormatDuration( t0, 0, QStringLiteral( "just now" ) );
+  testFormatDuration( t0, 1, QStringLiteral( "just now" ) );
   testFormatDuration( t0, 60, QStringLiteral( "1 minute ago" ) );
   testFormatDuration( t0, 2 * 60, QStringLiteral( "2 minutes ago" ) );
   testFormatDuration( t0, 1 * 60 * 60, QStringLiteral( "1 hour ago" ) );
@@ -38,7 +38,7 @@ void TestUtilsFunctions::testFormatDuration()
 
 void TestUtilsFunctions::testFormatDuration( const QDateTime &t0, qint64 diffSecs, const QString &expectedResult )
 {
-  QDateTime t1 = t0.addSecs( ( -1 ) * diffSecs );
-  QString str_t1 = InputUtils::formatDateTimeDiff( t1, t0 );
+  QDateTime t1 = t0.addSecs( diffSecs );
+  QString str_t1 = InputUtils::formatDateTimeDiff( t0, t1 );
   QCOMPARE( str_t1, expectedResult );
 }

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -19,8 +19,9 @@ void TestUtilsFunctions::testFormatDuration()
 {
   QDateTime t0 = QDateTime::currentDateTime();
 
-  testFormatDuration( t0, 0, QStringLiteral( "Invalid datetime" ) );
-  testFormatDuration( t0, 1, QStringLiteral( "0 minute ago" ) );
+  testFormatDuration( t0, -1, QStringLiteral( "Invalid datetime" ) );
+  testFormatDuration( t0, 0, QStringLiteral( "a few seconds ago" ) );
+  testFormatDuration( t0, 1, QStringLiteral( "a few seconds ago" ) );
   testFormatDuration( t0, 60, QStringLiteral( "1 minute ago" ) );
   testFormatDuration( t0, 2 * 60, QStringLiteral( "2 minutes ago" ) );
   testFormatDuration( t0, 1 * 60 * 60, QStringLiteral( "1 hour ago" ) );

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "testutilsfunctions.h"
+
+#include <QtTest/QtTest>
+#include <QtCore/QObject>
+
+const int DAY_IN_SECS = 60 * 60 * 24;
+const int MONTH_IN_SECS = 60 * 60 * 24 * 31;
+
+void TestUtilsFunctions::testFormatDuration()
+{
+  QDateTime t0 = QDateTime::currentDateTime();
+
+  testFormatDuration( t0, 0, QStringLiteral( "Invalid datetime" ) );
+  testFormatDuration( t0, 1, QStringLiteral( "0 minute ago" ) );
+  testFormatDuration( t0, 60, QStringLiteral( "1 minute ago" ) );
+  testFormatDuration( t0, 2 * 60, QStringLiteral( "2 minutes ago" ) );
+  testFormatDuration( t0, 1 * 60 * 60, QStringLiteral( "1 hour ago" ) );
+  testFormatDuration( t0, 2 * 60 * 60, QStringLiteral( "2 hours ago" ) );
+  testFormatDuration( t0, 1 * DAY_IN_SECS, QStringLiteral( "1 day ago" ) );
+  testFormatDuration( t0, 2 * DAY_IN_SECS, QStringLiteral( "2 days ago" ) );
+  testFormatDuration( t0, 7 * DAY_IN_SECS, QStringLiteral( "1 week ago" ) );
+  testFormatDuration( t0, 14 * DAY_IN_SECS, QStringLiteral( "2 weeks ago" ) );
+  testFormatDuration( t0, MONTH_IN_SECS, QStringLiteral( "1 month ago" ) );
+  testFormatDuration( t0, 2 * MONTH_IN_SECS, QStringLiteral( "2 months ago" ) );
+  testFormatDuration( t0, 12 * MONTH_IN_SECS, QStringLiteral( "1 year ago" ) );
+  testFormatDuration( t0, 24 * MONTH_IN_SECS, QStringLiteral( "2 years ago" ) );
+}
+
+void TestUtilsFunctions::testFormatDuration( const QDateTime &t0, qint64 diffSecs, const QString &expectedResult )
+{
+  QDateTime t1 = t0.addSecs( ( -1 ) * diffSecs );
+  QString str_t1 = InputUtils::formatDateTimeDiff( t1, t0 );
+  QCOMPARE( str_t1, expectedResult );
+}

--- a/app/test/testutilsfunctions.h
+++ b/app/test/testutilsfunctions.h
@@ -1,0 +1,29 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef TESTUTILSFUNCTIONS_H
+#define TESTUTILSFUNCTIONS_H
+
+#include <QObject>
+#include "inpututils.h"
+
+class TestUtilsFunctions: public QObject
+{
+    Q_OBJECT
+  public:
+    TestUtilsFunctions() = default;
+    ~TestUtilsFunctions() = default;
+  private slots:
+    void testFormatDuration();
+
+  private:
+    void testFormatDuration( const QDateTime &t0, qint64 diffSecs, const QString &expectedResult );
+};
+
+#endif // TESTUTILSFUNCTIONS_H


### PR DESCRIPTION
Nice format of last update of a project - `<duration><period_name> ago`, where 

- duration is length (number) of a period
- period name - one of: minute, hour,  week, month, year

Things to consider:
(**A**) The formatting is applied for both server and local projects (items), but the logic is untouched. Currently (or after models refactoring), it could be confusing what is actually "update" time. Current logic is that if a project is (also) local, it takes last modified timestamp of projectDir, otherwise takes serverUpdated timestamp. So if there is an update on server after your local changes, a user will see only time difference after local update. I guess this can be consider as bug or feature, so its up to discussion.
(**B**) A lastModified timestamp of a projectDir is used, which could be enough for description text, but it could be incorrect. Similarly to #1320 issue, where also timestamp was not enough to get correct projectStatus - problem was related to gpkg and modification of its header without modifying data. 

Added also test, where is best to see what is supported. Note that a new test class has been introduced + new test task added to auto-tests.

<img width="424" alt="Screenshot 2021-05-06 at 13 05 57" src="https://user-images.githubusercontent.com/6735606/117288541-e6b09d00-ae6b-11eb-868c-b8f6b7e4cb8d.png">


closes #1359 