### PR TITLE
Fetch more bug

### DIFF
--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -156,7 +156,9 @@ void ProjectsModel::listProjects( const QString &searchExpression, int page )
   if ( !mLastRequestId.isEmpty() )
   {
     setModelIsLoading( true );
-    clearProjects();
+    // clear only after requesting the very first page, otherwise we want to append results to the model
+    if ( page == 1 )
+      clearProjects();
   }
 }
 


### PR DESCRIPTION
Fix of incorrect cleaning of the project model after fetch more project action.
After each request of listing project, the model was cleared. Therefore Input loses projects fetched in previous request. Additionally, fetch more option was always there even if there were no more projects to fetch on Mergin, because projects model never reached the same amount of project as were on the server due to cleaning. That caused the issue reported in 1360.   

closes #1360 