### PR TITLE
Correct handling of focus of LoginForm fields

### DIFF
--- a/app/qml/LoginForm.qml
+++ b/app/qml/LoginForm.qml
@@ -31,6 +31,14 @@ Rectangle {
   property color fontColor
   property var fieldHeight
 
+  property bool isKeyboardOpen: Qt.inputMethod.keyboardRectangle.height
+  onIsKeyboardOpenChanged: if (!isKeyboardOpen) {
+      if (loginName.focus)
+        loginName.focus = false
+      if (passwordField.password.focus)
+        passwordField.password.focus = false
+    }
+
   function clean() {
     passwordField.password.text = ""
     loginName.text = ""
@@ -108,6 +116,7 @@ Rectangle {
           background: Rectangle {
             color: loginForm.bgColor
           }
+          onEditingFinished: focus = false
         }
       }
 

--- a/app/qml/components/PasswordField.qml
+++ b/app/qml/components/PasswordField.qml
@@ -54,6 +54,7 @@ Row {
       color: root.bgColor
     }
 
+    onEditingFinished: focus = false
     onVisibleChanged: if (!password.visible) password.echoMode = TextInput.Password
   }
 


### PR DESCRIPTION
Virtual Keyboard on Android steals Key event and therefore to unfocus a field, a user has to double click on return/back button to lost focus which updates the page to its default state.
Therefore focus handling was improved.  

Altogether with #1384 (scrollable Login form) should enhance user experience of Login form.

closes #1333 