### PR TITLE
Range widget improvement

### DIFF
--- a/app/qml/editor/inputrange.qml
+++ b/app/qml/editor/inputrange.qml
@@ -64,9 +64,10 @@ Item {
       property int multiplier: {
         var m = 1;
         while (fieldItem.step * m < 1) {
-          m +=1
+          m *=10
         }
-        m
+        var precision = fieldItem.precision === 0 ? 1 : Math.pow(10, spinbox.precision)
+        Math.max(m, precision)
       }
       property int precision: fieldItem.precision
       property int intValue: fieldItem.parent.value * multiplier
@@ -149,7 +150,7 @@ Item {
                   font.pixelSize: spinbox.font.pixelSize * 2
                   font.bold: true
                   fontSizeMode: Text.Fit
-                  color: fieldItem.enabled ? customStyle.fields.fontColor : customStyle.toolbutton.backgroundColorInvalid
+                  color: fieldItem.enabled && spinbox.value > spinbox.from ? customStyle.fields.fontColor : customStyle.toolbutton.backgroundColorInvalid
                   leftPadding: customStyle.fields.sideMargin
                   horizontalAlignment: Text.AlignLeft
                   verticalAlignment: Text.AlignVCenter
@@ -170,7 +171,7 @@ Item {
                   font.pixelSize: spinbox.font.pixelSize * 2
                   font.bold: true
                   fontSizeMode: Text.Fit
-                  color: fieldItem.enabled ? customStyle.fields.fontColor : customStyle.toolbutton.backgroundColorInvalid
+                  color: fieldItem.enabled && spinbox.value < spinbox.to ? customStyle.fields.fontColor : customStyle.toolbutton.backgroundColorInvalid
                   anchors.right: parent.right
                   rightPadding: customStyle.fields.sideMargin
                   horizontalAlignment: Text.AlignRight


### PR DESCRIPTION
For following field config:
precision =  _p_, step precision = _sp_, that _p_ < _sp_ (e.g _p_=0, _sp_= 1 for step=0.1)
was range widget not working properly.

Another issue was that if `Minimum` or `Maximum` in config was out of range for QML Integer, the spinbox got broken.

Since QML spinbox works with QML integers for its properties (value, from, to, stepSize), all these properties have to be multiplied. This shrinks actual range that could cause overflow issue. Best to get spinbox working with doubles/reals.
However, not sure if it should be done in scope of this PR (?).

Tested on lutraconsulting/decimal_issue and  lutraconsulting/test_decimals projects.

docs: https://github.com/lutraconsulting/input-docs/pull/35
test (E): https://github.com/lutraconsulting/input-manual-tests/issues/6

closes #1395 
closes #996 