### PR TITLE
Group visibility

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -480,7 +480,9 @@ void AttributeController::recalculateDerivedItems( )
       exp.prepare( &expressionContext );
       bool visible = true;
       if ( exp.isValid() )
-        exp.evaluate( &expressionContext ).toInt();
+      {
+        visible = exp.evaluate( &expressionContext ).toBool();
+      }
 
       if ( item->isVisible() != visible )
       {

--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -459,7 +459,7 @@ void AttributeController::recalculateDerivedItems( )
   const int LIMIT = 3;
   int tryNumber = 0;
   bool anyValueChanged = true;
-  while ( anyValueChanged || tryNumber < LIMIT )
+  while ( anyValueChanged && tryNumber < LIMIT )
   {
     anyValueChanged = recalculateDefaultValues( changedFormItems, expressionContext );
     ++tryNumber;

--- a/app/attributes/attributetabmodel.cpp
+++ b/app/attributes/attributetabmodel.cpp
@@ -32,6 +32,7 @@ QHash<int, QByteArray> AttributeTabModel::roleNames() const
   QHash<int, QByteArray> roles = QAbstractItemModel::roleNames();
   roles[AttributeTabModel::Name]  = QByteArray( "Name" );
   roles[AttributeTabModel::Visible] = QByteArray( "Visible" );
+  roles[AttributeTabModel::TabIndex] = QByteArray( "TabIndex" );
   return roles;
 }
 
@@ -60,6 +61,8 @@ QVariant AttributeTabModel::data( const QModelIndex &index, int role ) const
       return item->name();
     case AttributeTabModel::Visible:
       return item->isVisible();
+    case AttributeTabModel::TabIndex:
+      return item->tabIndex();
     default:
       return QVariant();
   }

--- a/app/attributes/attributetabmodel.h
+++ b/app/attributes/attributetabmodel.h
@@ -41,7 +41,8 @@ class  AttributeTabModel : public QAbstractListModel
     enum AttributeTabRoles
     {
       Name = Qt::UserRole + 1, //!< Tab name
-      Visible //!< Tab visible
+      Visible, //!< Tab visible
+      TabIndex //!< Tab id ~ index
     };
 
     Q_ENUM( AttributeTabRoles )

--- a/app/qml/FeatureForm.qml
+++ b/app/qml/FeatureForm.qml
@@ -309,7 +309,7 @@ Item {
 
         Item {
           id: formPage
-          property int currentIndex: index
+          property int tabIndex: model.TabIndex
 
           // The main form content area
           Rectangle {
@@ -367,8 +367,7 @@ Item {
               onReset: content.contentY = 0
             }
 
-
-            model: swipeViewRepeater.model.attributeFormProxyModel(formPage.currentIndex)
+            model: swipeViewRepeater.model.attributeFormProxyModel(formPage.tabIndex)
 
            delegate: fieldItem
 


### PR DESCRIPTION
Fixes tab visibility. Needs to be further tested with more complex projects, `1_form_test` is working

Problem was, that expression result for visibility was not being saved and used. Also added `TabIndex` to TabModel to be able to reference specific tab from QML.

Resolves #1399 