### PR TITLE
Fields outside groups

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -277,18 +277,11 @@ void AttributeController::updateOnLayerChange()
       {
         if ( element->type() == QgsAttributeEditorElement::AeTypeContainer )
         {
-          mHasTabs = true;
-          break;
-        }
-      }
-
-      if ( mHasTabs )
-      {
-        for ( QgsAttributeEditorElement *element : root->children() )
-        {
-          if ( element->type() == QgsAttributeEditorElement::AeTypeContainer )
+          QgsAttributeEditorContainer *container = static_cast<QgsAttributeEditorContainer *>( element );
+          if ( !container->isGroupBox() )
           {
-            QgsAttributeEditorContainer *container = static_cast<QgsAttributeEditorContainer *>( element );
+            mHasTabs = true;
+
             if ( container->columnCount() > 1 )
             {
               qDebug() << "tab " << container->name() << " in manual config has multiple columns. not supported on mobile devices!";
@@ -296,13 +289,10 @@ void AttributeController::updateOnLayerChange()
             }
             createTab( container );
           }
-          else
-          {
-            qDebug() << "element in tab layout that is not part of any tab. Ignoring!";
-          }
         }
       }
-      else
+
+      if ( !mHasTabs )
       {
         createTab( root );
       }


### PR DESCRIPTION
Shows fields that are outside of groups (not tabs) as it was before refactoring.

Added check if group is a tab or not and behave based on that 

Example project from the issue now renders correctly:
![image](https://user-images.githubusercontent.com/22449698/119318204-4df68b80-bc79-11eb-8757-e9fb5d98d4cd.png)


resolves #1412 
credits to PP