### PR TITLE
Fixed geom edit of a new feature

### DIFF
--- a/app/attributes/attributecontroller.h
+++ b/app/attributes/attributecontroller.h
@@ -103,6 +103,7 @@ class  AttributeController : public QObject
     Q_INVOKABLE bool deleteFeature();
     Q_INVOKABLE bool create();
     Q_INVOKABLE bool save();
+    Q_INVOKABLE bool isNewFeature() const;
 
     int tabCount() const;
 
@@ -154,7 +155,6 @@ class  AttributeController : public QObject
 
     void updateOnLayerChange();
     void updateOnFeatureChange();
-    bool isNewFeature() const;
 
     /**
      * Recalculates visibility & constrains & default values

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -33,6 +33,10 @@ Drawer {
         featureForm.save()
     }
 
+    function isNewFeature() {
+      return attributeController.isNewFeature()
+    }
+
     function reload() {
       attributeController.reset()
       featureForm.reset()

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -131,10 +131,20 @@ ApplicationWindow {
         }
         else if (digitizing.hasPointGeometry(layer)) {
             var recordedPoint = getRecordedPoint()
+            var newFormState = "Edit"
             featurePanel.feature = digitizing.changePointGeometry(featurePanel.feature, recordedPoint, digitizing.useGpsPoint)
-            featurePanel.saveFeatureGeom()
+
+            if (featurePanel.isNewFeature()) {
+              digitizingHighlight.featureLayerPair = featurePanel.feature
+              digitizingHighlight.visible = true
+              newFormState = "Add"
+            } else {
+              // save only existing feature
+              featurePanel.saveFeatureGeom()
+            }
+
             stateManager.state = "view"
-            featurePanel.show_panel(featurePanel.feature, "Edit", "form")
+            featurePanel.show_panel(featurePanel.feature, newFormState, "form")
         }
     }
 


### PR DESCRIPTION
Edit geometry of a (point) feature was originally implemented for existing features, so the case for new features was not working properly. This PR fixes this case.

https://user-images.githubusercontent.com/6735606/120173991-e4402980-c204-11eb-8592-f16a84853fce.mp4

closes #1380 