### PR TITLE
Fixed attributePreview type enum in QML

### DIFF
--- a/app/qml/PreviewPanel.qml
+++ b/app/qml/PreviewPanel.qml
@@ -131,7 +131,7 @@ Item {
                 }
 
                 Image {
-                    visible: controller.type == AttributePreviewController.Image
+                    visible: controller.type == AttributePreviewController.Photo
                     source: controller.photo
                     sourceSize: Qt.size(width, height)
                     fillMode: Image.PreserveAspectFit


### PR DESCRIPTION
Wrong enum has been used in preview panel, therefore photo preview was not working at all.
Beside it, display name work as expected and its shown correctly as title in preview Panel - tested with lower, upper case and also when field name contains some special chars (e.g !@#$,..).

Demonstration of image preview + display name as the title using fields with upper case.
<img width="1436" alt="Screenshot 2021-06-01 at 14 00 54" src="https://user-images.githubusercontent.com/6735606/120321757-f775f680-c2e3-11eb-9e20-9d878ff1f46d.png">


closes #1276 