### PR TITLE
Scrollable account page

### DIFF
--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -50,227 +50,242 @@ Page {
     withBackButton: true
   }
 
-  // /////////////////
-  // Body
-  Column {
-    id: accountBodyContainer
+
+  ScrollView {
+    id: scrollView
     anchors.top: header.bottom
-    width: subscribeButton.width
-    anchors.horizontalCenter: parent.horizontalCenter
+    width: root.width
+    height: root.height - header.height
+    contentHeight: accountBodyContainer.height + footer.height
+    clip: true
 
-    // avatar
-    Row {
-        id: avatarContainer
-        height: InputStyle.rowHeightHeader * 2
-        anchors.horizontalCenter: parent.horizontalCenter
+    // /////////////////
+    // Body
+    Column {
+      id: accountBodyContainer
+      width: root.width
+      height: Math.max(accountBodyContainer.childrenRect.height, scrollView.height - footer.height)
 
-        Item {
-          id: avatar
-          width: avatarContainer.height
-          height: width
+      // avatar
+      Row {
+          id: avatarContainer
+          height: InputStyle.rowHeightHeader * 2
+          anchors.horizontalCenter: parent.horizontalCenter
 
-          Rectangle {
-            id: avatarImage
-            anchors.centerIn: parent
-            width: avatar.width * 0.8
+          Item {
+            id: avatar
+            width: avatarContainer.height
             height: width
-            color: InputStyle.fontColor
-            radius: width*0.5
-            antialiasing: true
 
-            Image {
-              id: userIcon
+            Rectangle {
+              id: avatarImage
               anchors.centerIn: parent
-              source: 'account.svg'
-              height: parent.height * 0.8
-              width: height
-              sourceSize.width: width
-              sourceSize.height: height
-              fillMode: Image.PreserveAspectFit
-            }
+              width: avatar.width * 0.8
+              height: width
+              color: InputStyle.fontColor
+              radius: width*0.5
+              antialiasing: true
 
-            ColorOverlay {
-              anchors.fill: userIcon
-              source: userIcon
-              color: "#FFFFFF"
+              Image {
+                id: userIcon
+                anchors.centerIn: parent
+                source: 'account.svg'
+                height: parent.height * 0.8
+                width: height
+                sourceSize.width: width
+                sourceSize.height: height
+                fillMode: Image.PreserveAspectFit
+              }
+
+              ColorOverlay {
+                anchors.fill: userIcon
+                source: userIcon
+                color: "#FFFFFF"
+              }
             }
           }
+      }
+
+      TextWithIcon {
+        width: parent.width
+        source: 'account.svg'
+        text: root.username
+      }
+
+      TextWithIcon {
+        width: parent.width
+        source: 'envelope-solid.svg'
+        text: root.email
+      }
+
+      TextWithIcon {
+        visible: root.apiSupportsSubscriptions
+        width: parent.width
+        source: 'edit.svg'
+        text: root.planAlias
+      }
+
+      TextWithIcon {
+        visible: root.subscriptionStatus === MerginSubscriptionStatus.SubscriptionUnsubscribed
+        width: parent.width
+        source: 'info.svg'
+        text: qsTr("Your subscription will not auto-renew after %1")
+              .arg(root.subscriptionsTimestamp)
+      }
+
+      TextWithIcon {
+        visible: root.subscriptionStatus === MerginSubscriptionStatus.SubscriptionInGracePeriod
+        width: parent.width
+        source: 'exclamation-triangle-solid.svg'
+        onLinkActivated: Qt.openUrlExternally(link)
+        text: qsTr("Please update your %1billing details%2 as soon as possible")
+                .arg("<a href='" + __purchasing.subscriptionBillingUrl + "'>")
+                .arg("</a>")
+        iconColor: InputStyle.highlightColor
+      }
+
+      TextWithIcon {
+        visible: root.subscriptionStatus === MerginSubscriptionStatus.ValidSubscription
+        width: parent.width
+        source: 'ic_today.svg'
+        text: qsTr("Your next bill will be for %1 on %2")
+        .arg(root.nextBillPrice)
+        .arg(root.subscriptionsTimestamp)
+      }
+
+      TextWithIcon {
+        visible: root.subscriptionStatus === MerginSubscriptionStatus.CanceledSubscription
+        width: parent.width
+        source: 'ic_today.svg'
+        text: qsTr("Your subscription was cancelled on %1")
+              .arg(root.subscriptionsTimestamp)
+      }
+
+      Row {
+        width: parent.width
+        Item {
+          width: root.fieldHeight
+          height: root.fieldHeight
+
+          CircularProgressBar {
+            id: storageIcon
+            width: parent.width*0.6
+            anchors.centerIn: parent
+            height: width
+            value: root.diskUsage/root.storageLimit
+          }
         }
-    }
 
-    TextWithIcon {
-      width: parent.width
-      source: 'account.svg'
-      text: root.username
-    }
+        Text {
+          id: textItem
+          height: root.fieldHeight
+          verticalAlignment: Text.AlignVCenter
+          font.pixelSize: InputStyle.fontPixelSizeNormal
+          color: InputStyle.fontColor
+          text: qsTr("Using %1 / %2").arg(__inputUtils.bytesToHumanSize(root.diskUsage)).arg(__inputUtils.bytesToHumanSize(root.storageLimit))
+        }
+      }
 
-    TextWithIcon {
-      width: parent.width
-      source: 'envelope-solid.svg'
-      text: root.email
-    }
-
-    TextWithIcon {
-      visible: root.apiSupportsSubscriptions
-      width: parent.width
-      source: 'edit.svg'
-      text: root.planAlias
-    }
-
-    TextWithIcon {
-      visible: root.subscriptionStatus === MerginSubscriptionStatus.SubscriptionUnsubscribed
-      width: parent.width
-      source: 'info.svg'
-      text: qsTr("Your subscription will not auto-renew after %1")
-            .arg(root.subscriptionsTimestamp)
-    }
-
-    TextWithIcon {
-      visible: root.subscriptionStatus === MerginSubscriptionStatus.SubscriptionInGracePeriod
-      width: parent.width
-      source: 'exclamation-triangle-solid.svg'
-      onLinkActivated: Qt.openUrlExternally(link)
-      text: qsTr("Please update your %1billing details%2 as soon as possible")
-              .arg("<a href='" + __purchasing.subscriptionBillingUrl + "'>")
-              .arg("</a>")
-      iconColor: InputStyle.highlightColor
-    }
-
-    TextWithIcon {
-      visible: root.subscriptionStatus === MerginSubscriptionStatus.ValidSubscription
-      width: parent.width
-      source: 'ic_today.svg'
-      text: qsTr("Your next bill will be for %1 on %2")
-      .arg(root.nextBillPrice)
-      .arg(root.subscriptionsTimestamp)
-    }
-
-    TextWithIcon {
-      visible: root.subscriptionStatus === MerginSubscriptionStatus.CanceledSubscription
-      width: parent.width
-      source: 'ic_today.svg'
-      text: qsTr("Your subscription was cancelled on %1")
-            .arg(root.subscriptionsTimestamp)
-    }
-
-    Row {
-      width: parent.width
       Item {
-        width: root.fieldHeight
-        height: root.fieldHeight
+        //spacer
+        height: 10 * InputStyle.dp
+        width: parent.width
+      }
 
-        CircularProgressBar {
-          id: storageIcon
-          width: parent.width*0.6
-          anchors.centerIn: parent
-          height: width
-          value: root.diskUsage/root.storageLimit
+      Button {
+        id: subscribeButton
+        enabled: !__purchasing.transactionPending
+        width: root.width - 2 * InputStyle.rowHeightHeader
+        anchors.horizontalCenter: parent.horizontalCenter
+        visible: __merginApi.apiSupportsSubscriptions
+
+        height: InputStyle.rowHeightHeader
+        text: __purchasing.transactionPending ? qsTr("Working...") : root.ownsActiveSubscription ? qsTr("Manage Subscription") : qsTr("Subscription plans")
+        font.pixelSize: InputStyle.fontPixelSizeTitle
+
+        background: Rectangle {
+          color: InputStyle.highlightColor
         }
+
+        onClicked: managePlansClicked()
+
+        contentItem: Text {
+          text: subscribeButton.text
+          font: subscribeButton.font
+          opacity: enabled ? 1.0 : 0.3
+          color: "white"
+          horizontalAlignment: Text.AlignHCenter
+          verticalAlignment: Text.AlignVCenter
+          elide: Text.ElideRight
+        }
+      }
+
+      Item {
+        id: spacer
+        visible: textRestore.visible
+        height: InputStyle.fontPixelSizeTitle
+        width:parent.width
       }
 
       Text {
-        id: textItem
-        height: root.fieldHeight
+        id: textRestore
+        visible: __iosUtils.isIos && __merginApi.apiSupportsSubscriptions && __purchasing.hasInAppPurchases && !__purchasing.transactionPending
+        textFormat: Text.RichText
+        onLinkActivated: restorePurchasesClicked()
+        elide: Text.ElideRight
+        horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
+        text: "<style>a:link { color: " + InputStyle.highlightColor
+              + "; text-decoration: underline; }</style>" + qsTr(
+                "You can also %1restore%2 your purchases")
+              .arg("<a href='http://restore-purchases'>")
+              .arg("</a>")
         font.pixelSize: InputStyle.fontPixelSizeNormal
         color: InputStyle.fontColor
-        text: qsTr("Using %1 / %2").arg(__inputUtils.bytesToHumanSize(root.diskUsage)).arg(__inputUtils.bytesToHumanSize(root.storageLimit))
+        width: root.width
+        leftPadding: InputStyle.rowHeightHeader
+        rightPadding: InputStyle.rowHeightHeader
       }
     }
 
-    Item {
-      //spacer
-      height: 10 * InputStyle.dp
+    // /////////////////
+    // Footer
+    Column {
+      id: footer
+      height: InputStyle.rowHeight
       width: parent.width
-    }
-
-    Button {
-      id: subscribeButton
-      enabled: !__purchasing.transactionPending
-      width: root.width - 2 * InputStyle.rowHeightHeader
+      anchors.bottom: parent.bottom
       anchors.horizontalCenter: parent.horizontalCenter
-      visible: __merginApi.apiSupportsSubscriptions
 
-      height: InputStyle.rowHeightHeader
-      text: __purchasing.transactionPending ? qsTr("Working...") : root.ownsActiveSubscription ? qsTr("Manage Subscription") : qsTr("Subscription plans")
-      font.pixelSize: InputStyle.fontPixelSizeTitle
+      Button {
+        id: signOutButton
+        height: InputStyle.fontPixelSizeTitle
+        text: qsTr("Sign out")
+        font.pixelSize: signOutButton.height
+        font.bold: true
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        background: Rectangle {
+          color: root.bgColor
+        }
 
-      background: Rectangle {
-        color: InputStyle.highlightColor
+        onClicked: signOutClicked()
+
+        contentItem: Text {
+          text: signOutButton.text
+          font: signOutButton.font
+          color: InputStyle.highlightColor
+          horizontalAlignment: Text.AlignHCenter
+          verticalAlignment: Text.AlignVCenter
+          elide: Text.ElideRight
+        }
       }
 
-      onClicked: managePlansClicked()
-
-      contentItem: Text {
-        text: subscribeButton.text
-        font: subscribeButton.font
-        opacity: enabled ? 1.0 : 0.3
-        color: "white"
-        horizontalAlignment: Text.AlignHCenter
-        verticalAlignment: Text.AlignVCenter
-        elide: Text.ElideRight
+      Item {
+        id: spacer2
+        height: InputStyle.fontPixelSizeTitle
+        width:parent.width
       }
-    }
-
-    Item {
-      id: spacer
-      visible: textRestore.visible
-      height: InputStyle.fontPixelSizeTitle
-      width:parent.width
-    }
-
-    Text {
-      id: textRestore
-      visible: __iosUtils.isIos && __merginApi.apiSupportsSubscriptions && __purchasing.hasInAppPurchases && !__purchasing.transactionPending
-      textFormat: Text.RichText
-      onLinkActivated: restorePurchasesClicked()
-      elide: Text.ElideRight
-      horizontalAlignment: Text.AlignHCenter
-      verticalAlignment: Text.AlignVCenter
-      text: "<style>a:link { color: " + InputStyle.highlightColor
-            + "; text-decoration: underline; }</style>" + qsTr(
-              "You can also %1restore%2 your purchases")
-            .arg("<a href='http://restore-purchases'>")
-            .arg("</a>")
-      font.pixelSize: InputStyle.fontPixelSizeNormal
-      color: InputStyle.fontColor
-      width: root.width - 2 * InputStyle.rowHeightHeader
-    }
-  }
-
-  // /////////////////
-  // Footer
-  Column {
-    anchors.bottom: parent.bottom
-    anchors.horizontalCenter: parent.horizontalCenter
-
-    Button {
-      id: signOutButton
-      height: InputStyle.fontPixelSizeTitle
-      text: qsTr("Sign out")
-      font.pixelSize: signOutButton.height
-      font.bold: true
-      anchors.horizontalCenter: parent.horizontalCenter
-      background: Rectangle {
-        color: root.bgColor
-      }
-
-      onClicked: signOutClicked()
-
-      contentItem: Text {
-        text: signOutButton.text
-        font: signOutButton.font
-        color: InputStyle.highlightColor
-        horizontalAlignment: Text.AlignHCenter
-        verticalAlignment: Text.AlignVCenter
-        elide: Text.ElideRight
-      }
-    }
-
-    Item {
-      id: spacer2
-      height: InputStyle.fontPixelSizeTitle
-      width:parent.width
     }
   }
 }

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -250,7 +250,7 @@ Page {
 
     // /////////////////
     // Footer
-    Column {
+    Item {
       id: footer
       height: InputStyle.rowHeight
       width: parent.width
@@ -279,12 +279,6 @@ Page {
           verticalAlignment: Text.AlignVCenter
           elide: Text.ElideRight
         }
-      }
-
-      Item {
-        id: spacer2
-        height: InputStyle.fontPixelSizeTitle
-        width:parent.width
       }
     }
   }


### PR DESCRIPTION
Added ScrollView wrapper for its content and the footer.The footer has been simplified as well - dummy spacer replaced by property config for the footer. 
Header stays always on the top - back button and title is located which is always handy.

Also thinking about having generic scrollable wrapper component so it can be used for all pages. Currently, at least Subscribe page is still not optimised for landscape mode.

https://user-images.githubusercontent.com/6735606/120474607-b267c800-c3a8-11eb-8c58-3db6377f58e6.MP4

closes #933 