### PR TITLE
Changed endpoint for subscription info

### DIFF
--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -685,7 +685,7 @@ void MerginApi::getSubscriptionInfo()
   }
 
   QNetworkRequest request = getDefaultRequest();
-  QString urlString = mApiRoot + QStringLiteral( "v1/user/" );
+  QString urlString = mApiRoot + QStringLiteral( "v1/user/service" );
   QUrl url( urlString );
   request.setUrl( url );
 

--- a/core/merginsubscriptioninfo.cpp
+++ b/core/merginsubscriptioninfo.cpp
@@ -44,11 +44,8 @@ void MerginSubscriptionInfo::clear()
 
 void MerginSubscriptionInfo::setFromJson( QJsonObject docObj )
 {
-  // parse service data
-  QJsonObject serviceObj = docObj.value( QStringLiteral( "service" ) ).toObject();
-
   // parse service.subscription data
-  QJsonObject subscriptionObj = serviceObj.value( QStringLiteral( "subscription" ) ).toObject();
+  QJsonObject subscriptionObj = docObj.value( QStringLiteral( "subscription" ) ).toObject();
   if ( subscriptionObj.isEmpty() )
   {
     // only free plan is assigned, subscription data is not present in JSON
@@ -96,7 +93,7 @@ void MerginSubscriptionInfo::setFromJson( QJsonObject docObj )
   }
 
   // parse service.plan data
-  QJsonObject planObj = serviceObj.value( QStringLiteral( "plan" ) ).toObject();
+  QJsonObject planObj = docObj.value( QStringLiteral( "plan" ) ).toObject();
   mOwnsActiveSubscription = planObj.value( QStringLiteral( "is_paid_plan" ) ).toBool();
   mPlanAlias = planObj.value( QStringLiteral( "alias" ) ).toString();
 


### PR DESCRIPTION
Changed endpoint and handling of the reply accordingly.

There is also a second part of the ticket that is rather user-related: to unify loading of userInfo + userSubscription data, so the page content will be shown after both request are finished. 
Do we want to add there a loading indicator and have a blank page till data will be fetched?

closes #1375 