### PR TITLE
Replaced name property with instance itself for map layer

### DIFF
--- a/app/loader.cpp
+++ b/app/loader.cpp
@@ -107,7 +107,7 @@ bool Loader::forceLoad( const QString &filePath, bool force )
     res = mProject->read( filePath );
     mActiveLayer.resetActiveLayer();
     mMapThemeModel.reloadMapThemes( mProject );
-    setActiveLayer( mAppSettings.defaultLayer() );
+    setActiveLayerByName( mAppSettings.defaultLayer() );
     setMapSettingsLayers();
 
     emit projectReloaded( mProject );
@@ -265,7 +265,7 @@ void Loader::appAboutToQuit()
 
 
 
-void Loader::setActiveLayer( QString layerName ) const
+void Loader::setActiveLayerByName( QString layerName ) const
 {
   if ( !layerName.isEmpty() )
   {

--- a/app/loader.h
+++ b/app/loader.h
@@ -65,7 +65,7 @@ class Loader: public QObject
     /**
      * setActiveLayer sets active layer from layer name
      */
-    Q_INVOKABLE void setActiveLayer( QString layerName ) const;
+    void setActiveLayer( QString layerName ) const;
 
     /**
      * setActiveLayer sets active layer from layer

--- a/app/loader.h
+++ b/app/loader.h
@@ -65,7 +65,7 @@ class Loader: public QObject
     /**
      * setActiveLayer sets active layer from layer name
      */
-    void setActiveLayer( QString layerName ) const;
+    void setActiveLayerByName( QString layerName ) const;
 
     /**
      * setActiveLayer sets active layer from layer

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -69,7 +69,7 @@ ApplicationWindow {
                 recordToolbar.visible = true
                 recordToolbar.extraPanelVisible = false
 
-                __loader.setActiveLayer( featurePanel.feature.layer.name )
+                __loader.setActiveLayer( featurePanel.feature.layer )
                 updateRecordToolbar()
 
                 var screenPos = digitizing.pointFeatureMapCoordinates( featurePanel.feature )


### PR DESCRIPTION
See #1452 

> I wanted to remove the `setActiveLayer` function with string parameter, however we use it here: https://github.com/lutraconsulting/input/blob/master/app/loader.cpp#L110

EDIT:

JS/QML handling of overriden function is different, so the most probable scenario was that qml tried to call the pointer version of this function with string argument (resulting in nullptr). https://stackoverflow.com/questions/28529776/qt-qml-and-method-overloads thus I have removed the `Q_INVOKABLE` keyword 