### PR TITLE
Fix condition for undefined

### DIFF
--- a/app/qml/editor/inputrange.qml
+++ b/app/qml/editor/inputrange.qml
@@ -32,7 +32,7 @@ Item {
   property string suffix: config["Suffix"] ? config["Suffix"] : ""
 
    function getRange(rangeValue, defaultRange) {
-     if (rangeValue && rangeValue >= -max_range && rangeValue <= max_range)
+     if ( typeof rangeValue !== undefined && rangeValue >= -max_range && rangeValue <= max_range)
        return rangeValue
      else return defaultRange/spinbox.multiplier
    }


### PR DESCRIPTION
Changed the check for `undefined` max/min range, there was a problem with coercion, 0 was considered false and thus range widget ignored it and worked with `inf`

Fixes #1426 