### PR TITLE
Guess widget type for an empty field config

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -27,6 +27,7 @@
 #include "qgsattributeeditorcontainer.h"
 #include "qgsvectorlayerutils.h"
 #include "qgsmessagelog.h"
+#include "inpututils.h"
 
 AttributeController::AttributeController( QObject *parent )
   : QObject( parent )
@@ -97,6 +98,17 @@ QgsAttributeEditorContainer *AttributeController::autoLayoutTabContainer() const
     root->addChildElement( field );
   }
   return root.release();
+}
+
+QgsEditorWidgetSetup AttributeController::getEditorWidgetSetup( QgsVectorLayer *layer, int fieldIndex ) const
+{
+  QgsEditorWidgetSetup setup = layer->editorWidgetSetup( fieldIndex );
+  if ( setup.type().isEmpty() )
+  {
+    QgsField field = layer->fields().at( fieldIndex );
+    return InputUtils::getEditorWidgetSetup( field );
+  }
+  return setup;
 }
 
 bool AttributeController::allowTabs( QgsAttributeEditorContainer *container )
@@ -222,7 +234,7 @@ void AttributeController::flatten(
               FormItem::Field,
               layer->attributeDisplayName( fieldIndex ),
               !isReadOnly,
-              layer->editorWidgetSetup( fieldIndex ),
+              getEditorWidgetSetup( layer, fieldIndex ),
               fieldIndex,
               field.constraints(),
               parentVisibilityExpressions // field doesn't have visibility expression itself

--- a/app/attributes/attributecontroller.h
+++ b/app/attributes/attributecontroller.h
@@ -176,6 +176,8 @@ class  AttributeController : public QObject
 
     // Generates fake root tab for auto-layout
     QgsAttributeEditorContainer *autoLayoutTabContainer() const;
+    //! Returns editor widget setup according params. If is empty, returns a default setup according field's type.
+    QgsEditorWidgetSetup getEditorWidgetSetup( QgsVectorLayer *layer, int fieldIndex ) const;
 
     /**
      * Checks if tab layout is allowed for given container. Function is not recursive and checks only first level elements.

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -709,6 +709,61 @@ const QUrl InputUtils::getEditorComponentSource( const QString &widgetName )
   }
 }
 
+const QgsEditorWidgetSetup InputUtils::getEditorWidgetSetup( const QgsField &field )
+{
+  if ( field.isNumeric() )
+    return getEditorWidgetSetup( field, QStringLiteral( "Range" ) );
+  else if ( field.isDateOrTime() )
+    return getEditorWidgetSetup( field, QStringLiteral( "DateTime" ) );
+  else if ( field.type() == QVariant::Bool )
+    return getEditorWidgetSetup( field, QStringLiteral( "CheckBox" ) );
+  else
+    return getEditorWidgetSetup( field, QStringLiteral( "TextEdit" ) );
+}
+
+const QgsEditorWidgetSetup InputUtils::getEditorWidgetSetup( const QgsField &field, const QString &widgetType )
+{
+  if ( field.name() == QStringLiteral( "fid" ) )
+    return QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() );
+
+  if ( widgetType.isEmpty() )
+  {
+    return QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), QVariantMap() );
+  }
+  else
+  {
+    QVariantMap config;
+    if ( widgetType == QStringLiteral( "TextEdit" ) )
+    {
+      config.insert( QStringLiteral( "isMultiline" ), false );
+      config.insert( QStringLiteral( "UseHtml" ), false );
+    }
+    else if ( widgetType == QStringLiteral( "DateTime" ) )
+    {
+      config.insert( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::DATETIME_FORMAT );
+      config.insert( QStringLiteral( "display_format" ), QgsDateTimeFieldFormatter::DATETIME_FORMAT );
+    }
+    else if ( widgetType == QStringLiteral( "Range" ) )
+    {
+      config.insert( QStringLiteral( "Style" ), QStringLiteral( "SpinBox" ) );
+      config.insert( QStringLiteral( "Precision" ), QStringLiteral( "0" ) );
+      config.insert( QStringLiteral( "Min" ), QString::number( INT_MIN ) );
+      config.insert( QStringLiteral( "Max" ), QString::number( INT_MAX ) );
+      config.insert( QStringLiteral( "Step" ), 1 );
+    }
+    else if ( widgetType == QStringLiteral( "ExternalResource" ) )
+    {
+      config.insert( QStringLiteral( "RelativeStorage" ), QStringLiteral( "1" ) );
+      config.insert( QStringLiteral( "StorageMode" ), QStringLiteral( "0" ) );
+      config.insert( QStringLiteral( "PropertyCollection" ), QVariantMap() );
+      QgsPropertyCollection collection;
+      config.insert( QStringLiteral( "PropertyCollection" ), collection.toVariant( QgsPropertiesDefinition() ) );
+    }
+
+    return QgsEditorWidgetSetup( widgetType, config );
+  }
+}
+
 QString InputUtils::formatPoint(
   const QgsPoint &point,
   QgsCoordinateFormatter::Format format,

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -334,6 +334,15 @@ class InputUtils: public QObject
      */
     Q_INVOKABLE static QModelIndex invalidIndex();
 
+    /**
+     * Returns widget setup according the field type - supports only basic types.
+     * Note that external widget cannot be guessed from type since its the very same as text.
+     * @param field QgsField
+     * @return QgsEditorWidgetSetup for given field.
+     */
+    static const QgsEditorWidgetSetup getEditorWidgetSetup( const QgsField &field );
+    static const QgsEditorWidgetSetup getEditorWidgetSetup( const QgsField &field, const QString &widgetType );
+
   signals:
     Q_INVOKABLE void showNotificationRequested( const QString &message );
 

--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -8,6 +8,7 @@
 #include "qgsvectorfilewriter.h"
 #include "qgsdatetimefieldformatter.h"
 #include <qgsmarkersymbollayer.h>
+#include "inpututils.h"
 
 ProjectWizard::ProjectWizard( const QString &dataDir, QObject *parent )
   : QObject( parent )
@@ -62,7 +63,7 @@ QgsVectorLayer *ProjectWizard::createGpkgLayer( QString const &projectDir, QList
   for ( int i = 0; i < l->fields().count(); ++i )
   {
     QgsField f = l->fields().at( i );
-    QgsEditorWidgetSetup setup = getEditorWidget( f, findWidgetTypeByFieldName( f.name(), fieldsConfig ) );
+    QgsEditorWidgetSetup setup = InputUtils::getEditorWidgetSetup( f, findWidgetTypeByFieldName( f.name(), fieldsConfig ) );
     l->setEditorWidgetSetup( i, setup );
   }
   l->setRenderer( surveyLayerRenderer() );
@@ -120,49 +121,6 @@ void ProjectWizard::writeMapCanvasSetting( QDomDocument &doc )
   mapcanvasNode.setAttribute( QStringLiteral( "annotationsVisible" ), false );
   qgisNode.appendChild( mapcanvasNode );
   mSettings->writeXml( mapcanvasNode, doc );
-}
-
-QgsEditorWidgetSetup ProjectWizard::getEditorWidget( const QgsField &field, const QString &widgetType )
-{
-  if ( field.name() == QStringLiteral( "fid" ) )
-    return QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() );
-
-  if ( widgetType.isEmpty() )
-  {
-    return QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), QVariantMap() );
-  }
-  else
-  {
-    QVariantMap config;
-    if ( widgetType == QStringLiteral( "TextEdit" ) )
-    {
-      config.insert( QStringLiteral( "isMultiline" ), false );
-      config.insert( QStringLiteral( "UseHtml" ), false );
-    }
-    else if ( widgetType == QStringLiteral( "DateTime" ) )
-    {
-      config.insert( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::DATETIME_FORMAT );
-      config.insert( QStringLiteral( "display_format" ), QgsDateTimeFieldFormatter::DATETIME_FORMAT );
-    }
-    else if ( widgetType == QStringLiteral( "Range" ) )
-    {
-      config.insert( QStringLiteral( "Style" ), QStringLiteral( "SpinBox" ) );
-      config.insert( QStringLiteral( "Precision" ), QStringLiteral( "0" ) );
-      config.insert( QStringLiteral( "Min" ), QString::number( INT_MIN ) );
-      config.insert( QStringLiteral( "Max" ), QString::number( INT_MAX ) );
-      config.insert( QStringLiteral( "Step" ), 1 );
-    }
-    else if ( widgetType == QStringLiteral( "ExternalResource" ) )
-    {
-      config.insert( QStringLiteral( "RelativeStorage" ), QStringLiteral( "1" ) );
-      config.insert( QStringLiteral( "StorageMode" ), QStringLiteral( "0" ) );
-      config.insert( QStringLiteral( "PropertyCollection" ), QVariantMap() );
-      QgsPropertyCollection collection;
-      config.insert( QStringLiteral( "PropertyCollection" ), collection.toVariant( QgsPropertiesDefinition() ) );
-    }
-
-    return QgsEditorWidgetSetup( widgetType, config );
-  }
 }
 
 QgsFields ProjectWizard::createFields( const QList<FieldConfiguration> fieldsConfig ) const

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -37,7 +37,6 @@ class ProjectWizard : public QObject
     void notify( const QString &message );
   private:
     QgsVectorLayer *createGpkgLayer( QString const &projectDir, QList<FieldConfiguration> const &fieldsConfig );
-    QgsEditorWidgetSetup getEditorWidget( QgsField const &field, const QString &widgetType );
     QgsFields createFields( const QList<FieldConfiguration> fieldsConfig ) const;
     QgsSingleSymbolRenderer *surveyLayerRenderer();
     QVariant::Type parseType( const QString &type ) const;

--- a/app/qml/ProjectWizardPage.qml
+++ b/app/qml/ProjectWizardPage.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.3
 import QtGraphicalEffects 1.0
 import QtQuick.Dialogs 1.2
 
+import QgsQuick 0.1 as QgsQuick
 import lc 1.0
 import "." // import InputStyle singleton
 import "./components"


### PR DESCRIPTION
If widget setup is empty, Input tries to guess widget automatically - note that only numbers, date/time, bool fields are straightforward - for instance, external (photo) widget cannot be guessed only according field type (any ideas how handle such case?)

Added also QgsQuick import in WizardPage (its using QgsQuick.Utils.dp)

tested with project provided within the issue.

closes #1464 