### PR TITLE
Applied focus fix for search bar

### DIFF
--- a/app/qml/BrowseDataFeaturesPanel.qml
+++ b/app/qml/BrowseDataFeaturesPanel.qml
@@ -61,12 +61,6 @@ Item {
       __inputUtils.showNotification( qsTr( "Showing only the first %1 features" ).arg( featuresLimit ) )
   }
 
-  onVisibleChanged: {
-    // On Android, due to a Qt bug, we need to call deactivate again on page close to clear text search
-    if ( !visible && __androidUtils.isAndroid )
-      searchBar.deactivate()
-  }
-
   Page {
     id: featuresPage
     anchors.fill: parent

--- a/app/qml/SearchBar.qml
+++ b/app/qml/SearchBar.qml
@@ -43,6 +43,12 @@ Rectangle {
     searchTextChanged("")
   }
 
+  onVisibleChanged: {
+    // On Android, due to a Qt bug, we need to call deactivate again on page close to clear text search and focus
+    if ( !visible && __androidUtils.isAndroid )
+      root.deactivate()
+  }
+
   Timer {
     id: searchTimer
     interval: emitInterval


### PR DESCRIPTION
Also ProjectPanel needs the same fix as it was applied for BrowsingData panel.
Most likely, it would be needed always for the search bar.

Verified that this is Android issue and cannot be replicated on iOS

closes #1420 