### PR TITLE
Fix of crash when value relation is missing referenced table/fields

### DIFF
--- a/app/featureslistmodel.cpp
+++ b/app/featureslistmodel.cpp
@@ -216,18 +216,24 @@ void FeaturesListModel::setupValueRelation( const QVariantMap &config )
 
   QgsVectorLayer *layer = QgsValueRelationFieldFormatter::resolveLayer( config, QgsProject::instance() );
 
-  if ( layer )
+  if ( layer && layer->fields().size() != 0 )
   {
     // save key and value field
     QgsFields fields = layer->fields();
 
-    setKeyField( fields.field( config.value( QStringLiteral( "Key" ) ).toString() ).name() );
-    setFeatureTitleField( fields.field( config.value( QStringLiteral( "Value" ) ).toString() ).name() );
+    QString keyFieldName = config.value( QStringLiteral( "Key" ) ).toString();
+    QString valueFieldName = config.value( QStringLiteral( "Value" ) ).toString();
 
-    // store value relation filter expression
-    setFilterExpression( config.value( QStringLiteral( "FilterExpression" ) ).toString() );
+    if ( fields.indexOf( keyFieldName ) >= 0 && fields.indexOf( valueFieldName ) >= 0 )
+    {
+      setKeyField( keyFieldName );
+      setFeatureTitleField( valueFieldName );
 
-    loadFeaturesFromLayer( layer );
+      // store value relation filter expression
+      setFilterExpression( config.value( QStringLiteral( "FilterExpression" ) ).toString() );
+
+      loadFeaturesFromLayer( layer );
+    }
   }
 
   endResetModel();

--- a/app/featureslistmodel.cpp
+++ b/app/featureslistmodel.cpp
@@ -16,6 +16,7 @@
 #include "featureslistmodel.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgslogger.h"
+#include "coreutils.h"
 
 FeaturesListModel::FeaturesListModel( QObject *parent )
   : QAbstractListModel( parent ),
@@ -234,7 +235,11 @@ void FeaturesListModel::setupValueRelation( const QVariantMap &config )
 
       loadFeaturesFromLayer( layer );
     }
+    else
+      CoreUtils::log( QStringLiteral( "FeaturesListModel" ), QStringLiteral( "Missing referenced fields for value relations." ) );
   }
+  else
+    CoreUtils::log( QStringLiteral( "FeaturesListModel" ), QStringLiteral( "Missing referenced table for value relations." ) );
 
   endResetModel();
 }


### PR DESCRIPTION
Added test if related layer has any field and if the layer has fields needed for creating relation.
Note that both key and value fields have to be present (might be the same field though).

Also simplified code since we already got field names from the config, so we dont need to fetch field itself and get name out of it. Only if it handles also aliases or any other case? From quick look on QgsFields implementation it looks safe though. What do you think?

Tested with project provided in https://github.com/lutraconsulting/input/issues/1226

closes #1257 