### PR TITLE
Use onTextChanged for multiline-text edit widget.

### DIFF
--- a/app/qml/editor/inputtextedit.qml
+++ b/app/qml/editor/inputtextedit.qml
@@ -77,6 +77,15 @@ Item {
     onEditingFinished: {
       valueChanged( text, text === undefined )
     }
+
+    //! Commit value if has changed when widget gets out of the FeatureForm (ListView) viewport
+    Component.onDestruction: {
+      if ( textField.activeFocus ) {
+        if ( value !== textField.text ) {
+          valueChanged( textField.text, textField.text === undefined )
+        }
+      }
+    }
   }
 
   TextArea {
@@ -102,8 +111,17 @@ Item {
         radius: customStyle.fields.cornerRadius
     }
 
-    onTextChanged: {
+    onEditingFinished: {
         valueChanged( text, text === undefined )
+      }
+    }
+
+    //! Commit value if has changed when widget gets out of the FeatureForm (ListView) viewport
+    Component.onDestruction: {
+      if ( textArea.activeFocus ) {
+        if ( value !== textArea.text ) {
+          valueChanged( textArea.text, textArea.text === undefined )
+        }
       }
     }
 

--- a/app/qml/editor/inputtextedit.qml
+++ b/app/qml/editor/inputtextedit.qml
@@ -102,7 +102,7 @@ Item {
         radius: customStyle.fields.cornerRadius
     }
 
-    onEditingFinished: {
+    onTextChanged: {
         valueChanged( text, text === undefined )
       }
     }


### PR DESCRIPTION
Issue affects not only multiline, but also simple textEdit widget (after range widget PR).
As it was reported, value has not been applied when user scrolls away - so a widget gets out of the feature form's viewport and is destroyed afterwards. There was no other signal emitted (e.g of losing focus or editingFinished), so value has not been committed. 

Such extra handling has been added on destroy event.
The condition of saving a new value is that it has to be different from original value. So its questionable if after changing a value and then reverting it back without committing it in between should or should not trigger `valueChanged` (and updating the form afterwards). Current implementation ignores such case.

test project `tin1/form_widgets`

Note that PurchasingTest failed.

closes #1502 