### PR TITLE
Show relations in form

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -256,9 +256,9 @@ void AttributeController::flatten(
         QUuid widgetUuid = QUuid::createUuid();
 
         QgsAttributeEditorRelation *relationField = static_cast<QgsAttributeEditorRelation *>( element );
-        QgsRelation relation = relationField->relation();
+        QgsRelation associatedRelation = relationField->relation();
 
-        bool isNmRelation = layer->editFormConfig().widgetConfig( relation.id() )["nm-rel"].toBool();
+        bool isNmRelation = layer->editFormConfig().widgetConfig( associatedRelation.id() )["nm-rel"].toBool();
         if ( isNmRelation )
         {
           CoreUtils::log( "Relations", "Nm relations are not supported" );
@@ -276,7 +276,7 @@ void AttributeController::flatten(
               parentTabRow,
               FormItem::Relation,
               label,
-              relation
+              associatedRelation
             )
           );
 

--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -229,7 +229,7 @@ void AttributeController::flatten(
         const QString groupName = container->isGroupBox() ? container->name() : QString();
         std::shared_ptr<FormItem> formItemData =
           std::shared_ptr<FormItem>(
-            new FormItem(
+            FormItem::createFieldItem(
               fieldUuid,
               field,
               groupName,
@@ -258,7 +258,7 @@ void AttributeController::flatten(
         QgsAttributeEditorRelation *relationField = static_cast<QgsAttributeEditorRelation *>( element );
         QgsRelation associatedRelation = relationField->relation();
 
-        bool isNmRelation = layer->editFormConfig().widgetConfig( associatedRelation.id() )["nm-rel"].toBool();
+        bool isNmRelation = layer->editFormConfig().widgetConfig( associatedRelation.id() )[QStringLiteral( "nm-rel" )].toBool();
         if ( isNmRelation )
         {
           CoreUtils::log( "Relations", "Nm relations are not supported" );
@@ -270,7 +270,7 @@ void AttributeController::flatten(
 
         std::shared_ptr<FormItem> formItemData =
           std::shared_ptr<FormItem>(
-            new FormItem(
+            FormItem::createRelationItem(
               widgetUuid,
               groupName,
               parentTabRow,

--- a/app/attributes/attributedata.cpp
+++ b/app/attributes/attributedata.cpp
@@ -27,7 +27,8 @@ FormItem::FormItem(
   const QgsEditorWidgetSetup &editorWidgetSetup,
   int fieldIndex,
   const QgsFieldConstraints &contraints,
-  const QgsExpression &visibilityExpression
+  const QgsExpression &visibilityExpression,
+  const QgsRelation &relation
 )
   : mId( id )
   , mField( field )
@@ -40,37 +41,66 @@ FormItem::FormItem(
   , mFieldIndex( fieldIndex )
   , mConstraints( contraints )
   , mVisibilityExpression( visibilityExpression )
-  , mRelation( QgsRelation() ) // no relation for type field
+  , mRelation( relation ) // no relation for type field
 {
 }
 
-FormItem::FormItem(
+FormItem *FormItem::createFieldItem(
+  const QUuid &id,
+  const QgsField &field,
+  const QString &groupName,
+  int parentTabId,
+  FormItemType type,
+  const QString &name,
+  bool isEditable,
+  const QgsEditorWidgetSetup
+  &editorWidgetSetup,
+  int fieldIndex,
+  const QgsFieldConstraints &contraints,
+  const QgsExpression &visibilityExpression
+)
+{
+  return new FormItem(
+           id,
+           field,
+           groupName,
+           parentTabId,
+           type,
+           name,
+           isEditable,
+           editorWidgetSetup,
+           fieldIndex,
+           contraints,
+           visibilityExpression
+         );
+}
+
+FormItem *FormItem::createRelationItem(
   const QUuid &id,
   const QString &groupName,
   int parentTabId,
-  FormItem::FormItemType type,
+  FormItemType type,
   const QString &name,
   const QgsRelation &relation
 )
-  : mId( id )
-  , mField( QgsField() )
-  , mGroupName( groupName )
-  , mParentTabId( parentTabId )
-  , mType( type )
-  , mName( name )
-
-    // ---- not used for relation
-  , mIsEditable( true )
-  , mEditorWidgetSetup( QgsEditorWidgetSetup() )
-  , mFieldIndex( -1 )
-  , mConstraints( QgsFieldConstraints() )
-  , mVisibilityExpression( QgsExpression() )
-  , mConstraintSoftValid( true )
-  , mConstraintHardValid( true )
-    // ----
-
-  , mRelation( relation )
 {
+  FormItem *item = new FormItem(
+    id,
+    QgsField(),
+    groupName,
+    parentTabId,
+    type,
+    name,
+    true,
+    QgsEditorWidgetSetup(),
+    -1,
+    QgsFieldConstraints(),
+    QgsExpression(),
+    relation
+  );
+  item->setConstraintHardValid( true );
+  item->setConstraintSoftValid( true );
+  return item;
 }
 
 FormItem::FormItemType FormItem::type() const

--- a/app/attributes/attributedata.cpp
+++ b/app/attributes/attributedata.cpp
@@ -65,12 +65,12 @@ FormItem::FormItem(
   , mFieldIndex( -1 )
   , mConstraints( QgsFieldConstraints() )
   , mVisibilityExpression( QgsExpression() )
+  , mConstraintSoftValid( true )
+  , mConstraintHardValid( true )
     // ----
 
   , mRelation( relation )
 {
-  mConstraintHardValid = true;
-  mConstraintSoftValid = true;
 }
 
 FormItem::FormItemType FormItem::type() const
@@ -91,7 +91,7 @@ bool FormItem::isEditable() const
 QString FormItem::editorWidgetType() const
 {
   if ( mType == FormItem::Relation )
-    return "relation";
+    return QStringLiteral( "relation" );
 
   return mEditorWidgetSetup.type();
 }

--- a/app/attributes/attributedata.cpp
+++ b/app/attributes/attributedata.cpp
@@ -40,7 +40,37 @@ FormItem::FormItem(
   , mFieldIndex( fieldIndex )
   , mConstraints( contraints )
   , mVisibilityExpression( visibilityExpression )
+  , mRelation( QgsRelation() ) // no relation for type field
 {
+}
+
+FormItem::FormItem(
+  const QUuid &id,
+  const QString &groupName,
+  int parentTabId,
+  FormItem::FormItemType type,
+  const QString &name,
+  const QgsRelation &relation
+)
+  : mId( id )
+  , mField( QgsField() )
+  , mGroupName( groupName )
+  , mParentTabId( parentTabId )
+  , mType( type )
+  , mName( name )
+
+    // ---- not used for relation
+  , mIsEditable( true )
+  , mEditorWidgetSetup( QgsEditorWidgetSetup() )
+  , mFieldIndex( -1 )
+  , mConstraints( QgsFieldConstraints() )
+  , mVisibilityExpression( QgsExpression() )
+    // ----
+
+  , mRelation( relation )
+{
+  mConstraintHardValid = true;
+  mConstraintSoftValid = true;
 }
 
 FormItem::FormItemType FormItem::type() const
@@ -60,6 +90,9 @@ bool FormItem::isEditable() const
 
 QString FormItem::editorWidgetType() const
 {
+  if ( mType == FormItem::Relation )
+    return "relation";
+
   return mEditorWidgetSetup.type();
 }
 
@@ -146,6 +179,11 @@ QVariant FormItem::originalValue() const
 void FormItem::setOriginalValue( const QVariant &originalValue )
 {
   mOriginalValue = originalValue;
+}
+
+QgsRelation FormItem::relation() const
+{
+  return mRelation;
 }
 
 

--- a/app/attributes/attributedata.h
+++ b/app/attributes/attributedata.h
@@ -28,6 +28,7 @@
 #include "qgsfieldconstraints.h"
 #include "qgseditorwidgetsetup.h"
 #include "qgsexpression.h"
+#include "qgsrelation.h"
 #include "qgsfield.h"
 
 class  FormItem
@@ -44,6 +45,7 @@ class  FormItem
     };
     Q_ENUMS( FormItemType )
 
+    //! Constructor for field items
     FormItem(
       const QUuid &id,
       const QgsField &field,
@@ -58,6 +60,15 @@ class  FormItem
       const QgsExpression &visibilityExpression
     );
 
+    //! Contructor for relation items
+    FormItem(
+      const QUuid &id,
+      const QString &groupName,
+      int parentTabId,
+      FormItem::FormItemType type,
+      const QString &name,
+      const QgsRelation &relation
+    );
 
     FormItem::FormItemType type() const;
     QString name() const;
@@ -92,6 +103,8 @@ class  FormItem
     QVariant originalValue() const;
     void setOriginalValue( const QVariant &originalValue );
 
+    QgsRelation relation() const;
+
   private:
 
     const QUuid mId;
@@ -110,6 +123,8 @@ class  FormItem
     bool mConstraintHardValid = false;
     bool mVisible = false;
     QVariant mOriginalValue; // original unmodified value
+
+    const QgsRelation mRelation; // empty if type is field
 };
 
 class  TabItem

--- a/app/attributes/attributedata.h
+++ b/app/attributes/attributedata.h
@@ -57,11 +57,25 @@ class  FormItem
       const QgsEditorWidgetSetup &editorWidgetSetup,
       int fieldIndex,
       const QgsFieldConstraints &contraints,
+      const QgsExpression &visibilityExpression,
+      const QgsRelation &relation = QgsRelation()
+    );
+
+    static FormItem *createFieldItem(
+      const QUuid &id,
+      const QgsField &field,
+      const QString &groupName,
+      int parentTabId,
+      FormItem::FormItemType type,
+      const QString &name,
+      bool isEditable,
+      const QgsEditorWidgetSetup &editorWidgetSetup,
+      int fieldIndex,
+      const QgsFieldConstraints &contraints,
       const QgsExpression &visibilityExpression
     );
 
-    //! Contructor for relation items
-    FormItem(
+    static FormItem *createRelationItem(
       const QUuid &id,
       const QString &groupName,
       int parentTabId,

--- a/app/attributes/attributeformmodel.cpp
+++ b/app/attributes/attributeformmodel.cpp
@@ -80,6 +80,8 @@ QVariant AttributeFormModel::data( const QModelIndex &index, int role ) const
       return item->constraintHardValid();
     case ConstraintDescription:
       return item->constraintDescription();
+    case Relation:
+      return QVariant::fromValue( item->relation() );
     default:
       return QVariant();
   }
@@ -122,6 +124,7 @@ QHash<int, QByteArray> AttributeFormModel::roleNames() const
   roles[ConstraintHardValid] = QByteArray( "ConstraintHardValid" );
   roles[ConstraintSoftValid] = QByteArray( "ConstraintSoftValid" );
   roles[ConstraintDescription] = QByteArray( "ConstraintDescription" );
+  roles[Relation] = QByteArray( "Relation" );
 
   return roles;
 }

--- a/app/attributes/attributeformmodel.h
+++ b/app/attributes/attributeformmodel.h
@@ -58,7 +58,8 @@ class  AttributeFormModel : public QAbstractListModel
       Visible, //!< Field visible
       ConstraintSoftValid, //! Constraint soft valid
       ConstraintHardValid, //! Constraint hard valid
-      ConstraintDescription //!< Constraint description
+      ConstraintDescription, //!< Constraint description
+      Relation //!< QgsRelation instance for this item, empty if it is not a relation
     };
 
     Q_ENUM( AttributeFormRoles )

--- a/app/featureslistmodel.h
+++ b/app/featureslistmodel.h
@@ -178,7 +178,7 @@ class  FeaturesListModel : public QAbstractListModel
     //! Signal emitted when current feature has changed
     void currentFeatureChanged( QgsFeature feature );
 
-  private:
+  protected:
 
     //! Sets maximum limit and filter expression for request.
     void setupFeatureRequest( QgsFeatureRequest &request );
@@ -187,7 +187,7 @@ class  FeaturesListModel : public QAbstractListModel
     void loadFeaturesFromLayer( QgsVectorLayer *layer = nullptr );
 
     //! Empty data when resetting model
-    void emptyData();
+    virtual void emptyData();
 
     //! Builds feature title in list
     QVariant featureTitle( const FeatureLayerPair &featurePair ) const;
@@ -225,6 +225,7 @@ class  FeaturesListModel : public QAbstractListModel
 
     //! Field that represents field used as a feature title, if not set, display expression is used
     QString mFeatureTitleField;
+
 };
 
 #endif // FEATURESMODEL_H

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -697,7 +697,8 @@ const QUrl InputUtils::getEditorComponentSource( const QString &widgetName )
                                    QStringLiteral( "checkbox" ),
                                    QStringLiteral( "externalresource" ),
                                    QStringLiteral( "datetime" ),
-                                   QStringLiteral( "range" )
+                                   QStringLiteral( "range" ),
+                                   QStringLiteral( "relation" )
                                  };
   if ( supportedWidgets.contains( widgetName ) )
   {

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -85,6 +85,7 @@
 #include "scalebarkit.h"
 #include "qgsquickutils.h"
 #include "featureslistmodel.h"
+#include "relationfeaturesmodel.h"
 
 #include "projectsmodel.h"
 #include "projectsproxymodel.h"
@@ -294,6 +295,7 @@ void initDeclarative()
   qmlRegisterType< PositionKit >( "lc", 1, 0, "PositionKit" );
   qmlRegisterType< ScaleBarKit >( "lc", 1, 0, "ScaleBarKit" );
   qmlRegisterType< FeaturesListModel >( "lc", 1, 0, "FeaturesListModel" );
+  qmlRegisterType< RelationFeaturesModel >( "lc", 1, 0, "RelationFeaturesModel" );
 
   qmlRegisterUncreatableType< QgsUnitTypes >( "QgsQuick", 0, 1, "QgsUnitTypes", "Only enums from QgsUnitTypes can be used" );
   qmlRegisterType< QgsVectorLayer >( "QgsQuick", 0, 1, "VectorLayer" );

--- a/app/qml/FeatureForm.qml
+++ b/app/qml/FeatureForm.qml
@@ -407,9 +407,12 @@ Item {
 
     Item {
       id: fieldContainer
-      visible: Type === FormItemType.Field
+
+      property bool shouldBeVisible: Type === FormItemType.Field || Type === FormItemType.Relation
+
+      visible: shouldBeVisible
       // We also need to set height to zero if Type is not field otherwise children created blank space in form
-      height: Type === FormItemType.Field ? childrenRect.height : 0
+      height: shouldBeVisible ? childrenRect.height : 0
 
       anchors {
         left: parent.left
@@ -491,6 +494,8 @@ Item {
           property var customWidget: form.customWidgetCallback
           property bool supportsDataImport: importDataHandler.supportsDataImport(Name)
 
+          property var associatedRelation: Relation
+
           active: widget !== 'Hidden'
           Keys.forwardTo: backHandler
 
@@ -522,6 +527,12 @@ Item {
             if ( attributeEditorLoader.item && attributeEditorLoader.item.dataUpdated )
             {
               attributeEditorLoader.item.dataUpdated( form.controller.featureLayerPair.feature )
+            }
+          }
+          onFeatureLayerPairChanged: {
+            if ( attributeEditorLoader.item && attributeEditorLoader.item.featureLayerPairChanged )
+            {
+              attributeEditorLoader.item.featureLayerPairChanged()
             }
           }
         }

--- a/app/qml/FeatureFormStyling.qml
+++ b/app/qml/FeatureFormStyling.qml
@@ -67,6 +67,7 @@ QtObject {
     property QtObject fields: QtObject {
       property color fontColor: "black"
       property color backgroundColor: "lightGray"
+      property color backgroundColorDark: InputStyle.panelBackgroundDark
       property color backgroundColorInactive: "lightGray"
       property color activeColor: "#1B5E20"
       property color attentionColor: "red"
@@ -95,5 +96,9 @@ QtObject {
 
   property QtObject checkboxComponent: QtObject {
     property color baseColor: "black"
+  }
+
+  property QtObject relationComponent: QtObject {
+    property real textDelegateHeight: fields.height * 0.8
   }
 }

--- a/app/qml/FeaturePanel.qml
+++ b/app/qml/FeaturePanel.qml
@@ -251,6 +251,8 @@ Drawer {
 
                   property QtObject fields: QtObject {
                     property color backgroundColor: InputStyle.panelBackgroundLight
+                    property color backgroundColorDark: InputStyle.panelBackgroundDark
+                    property color backgroundColorDarker: InputStyle.panelBackgroundDarker
                     property color backgroundColorInactive: "grey"
                     property color fontColor: InputStyle.fontColor
                     property color activeColor: InputStyle.fontColor

--- a/app/qml/editor/inputrelation.qml
+++ b/app/qml/editor/inputrelation.qml
@@ -253,7 +253,7 @@ Item {
 
       MouseArea {
         anchors.fill: parent
-        onReleased: console.log("opening", model.FeatureId)
+        // ToDo: show feature form: onReleased
       }
     }
   }

--- a/app/qml/editor/inputrelation.qml
+++ b/app/qml/editor/inputrelation.qml
@@ -1,0 +1,271 @@
+﻿/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQml.Models 2.14
+
+import QgsQuick 0.1 as QgsQuick
+import lc 1.0
+
+Item {
+  id: root
+
+  property real iconSize: 15
+
+  /**
+   * Property mode sets how the relation widget will look like, there are two options:
+   * - text: features from child layer are placed on grid (cell displayed as rectangle) with display string
+   * - photo: list horizontal/verical of photos
+   */
+  property string mode: "text"
+  property int linkedFeaturesCount: rmodel.rowCount()
+  property bool canOpenFeaturesPage: false // if the advanced page for relations should be shown
+
+  signal valueChanged( var value, bool isNull )
+  signal featureLayerPairChanged()
+
+  onFeatureLayerPairChanged: {
+    // new feature layer pair, revert state and update delegate model
+    textModeContainer.state = "initial"
+    delegateModel.update()
+  }
+
+  RelationFeaturesModel {
+    id: rmodel
+
+    relation: associatedRelation
+    parentFeatureLayerPair: featurePair
+
+    onModelReset: root.linkedFeaturesCount = rowCount()
+  }
+
+  DelegateModel {
+    id: delegateModel
+    /*
+     * Inspired by https://martin.rpdev.net/2019/01/15/using-delegatemodel-in-qml-for-sorting-and-filtering.html
+     */
+
+    property var filterAcceptsItem: function( item ) {
+      if ( textModeContainer.state === "initial" ) {
+        return false
+      }
+      else if ( textModeContainer.state === "expanded" ) {
+        return true
+      }
+      return true
+    }
+
+    function update() {
+      // reset all items to default (invisible) group
+      if (items.count > 0) {
+        items.setGroups(0, items.count, "items");
+      }
+
+      for ( var i = 0; i < items.count; ++i ) {
+        var item = items.get( i );
+        if ( filterAcceptsItem( item.model ) ) {
+          item.inVisible = true;
+        }
+      }
+    }
+
+    model: rmodel
+    delegate: textDelegate
+
+    groups: DelegateModelGroup {
+      id: visibleItems
+
+      name: "visible"
+      includeByDefault: false
+    }
+
+    filterOnGroup: "visible"
+  }
+
+  anchors {
+    left: parent.left
+    right: parent.right
+  }
+
+  height: childrenRect.height
+
+  Item {
+    id: content
+
+    height: childrenRect.height
+    anchors {
+      left: parent.left
+      right: parent.right
+    }
+
+    // Text Mode Widget
+    Rectangle {
+      id: textModeContainer
+
+      Component.onCompleted: delegateModel.update()
+
+      states: [
+        State {
+          name: "initial"
+          PropertyChanges {
+            target: noOfFeaturesText
+            visible: true
+          }
+        },
+        State {
+          name: "expanded"
+          PropertyChanges {
+            target: textModeContainer
+            height: customStyle.fields.height * 3 // three rows
+          }
+          PropertyChanges {
+            target: noOfFeaturesText
+            visible: false
+          }
+        },
+        State {
+          name: "page"
+//          PropertyChanges {
+//            target: object
+
+//          }
+        }
+      ]
+
+      transitions: [
+        Transition {
+          from: "initial"
+          to: "expanded"
+          animations: NumberAnimation { property: "height"; duration: 100 }
+        }
+      ]
+
+      onStateChanged: delegateModel.update()
+
+      visible: mode === "text"
+      height: customStyle.fields.height
+      width: parent.width
+      state: "initial"
+
+      border.color: customStyle.fields.normalColor
+      border.width: 1 * QgsQuick.Utils.dp
+      color: customStyle.fields.backgroundColor
+      radius: customStyle.fields.cornerRadius
+
+      Text {
+        id: noOfFeaturesText
+
+        anchors.fill: parent
+        font.pointSize: customStyle.fields.fontPointSize
+        color: customStyle.fields.fontColor
+        horizontalAlignment: Qt.AlignHCenter
+        verticalAlignment: Qt.AlignVCenter
+
+        text: qsTr( "%n linked feature(s)", "Shows how many features are linked via relations", root.linkedFeaturesCount )
+      }
+
+      MouseArea {
+        anchors.fill: parent
+        onClicked: {
+          if ( textModeContainer.state === "initial" )
+            textModeContainer.state = "expanded"
+          else if ( textModeContainer.state === "expanded" && root.canOpenFeaturesPage )
+            textModeContrainer.state = "page"
+        }
+      }
+
+      Flow {
+        id: view
+
+        anchors.fill: parent
+        anchors.margins: customStyle.fields.sideMargin
+
+        spacing: customStyle.group.spacing
+
+        Repeater {
+          model: delegateModel
+        }
+      }
+    }
+
+    // Photo Mode Widget
+    Item {
+      id: photoModeContainer
+
+      visible: mode === "photo"
+      anchors.fill: parent
+
+      // todo: photo panel widget
+    }
+  }
+
+  Component {
+    id: textDelegate
+
+    Item {
+      id: textDelegateContainer
+
+      property real maximumWidth: view.width
+      property bool isVisible: {
+        // figure out which row am I from Y
+        if ( y === 0 ) return true
+        else if ( y < 3 * height ) return true
+        else return false
+      }
+
+      height: customStyle.relationComponent.textDelegateHeight
+      width: childrenRect.width > maximumWidth ? maximumWidth : childrenRect.width
+
+      visible: isVisible
+
+      Rectangle {
+        id: textDelegateContent
+
+        property real requestedWidth: txt.paintedWidth + 10 * QgsQuick.Utils.dp
+
+        height: parent.height
+        width: requestedWidth > parent.maximumWidth ? parent.maximumWidth : requestedWidth
+
+        color: customStyle.fields.backgroundColorDark
+        radius: customStyle.fields.cornerRadius
+        border.color: customStyle.fields.backgroundColorDarker
+        border.width: 2 * QgsQuick.Utils.dp
+
+        Text {
+          id: txt
+
+          text: model.FeatureTitle
+
+          width: parent.width
+          height: parent.height
+          horizontalAlignment: Qt.AlignHCenter
+          verticalAlignment: Qt.AlignVCenter
+
+          font.pointSize: customStyle.fields.fontPointSize
+          color: customStyle.fields.fontColor
+          clip: true
+        }
+      }
+
+      MouseArea {
+        anchors.fill: parent
+        onReleased: console.log("opening", model.FeatureId)
+      }
+    }
+  }
+
+  Component {
+    id: photoDelegate
+
+    Item {
+      // todo: photo panel delegate
+    }
+  }
+}

--- a/app/qml/editor/inputrelation.qml
+++ b/app/qml/editor/inputrelation.qml
@@ -109,8 +109,6 @@ Item {
     Rectangle {
       id: textModeContainer
 
-      Component.onCompleted: delegateModel.update()
-
       states: [
         State {
           name: "initial"
@@ -177,21 +175,19 @@ Item {
           if ( textModeContainer.state === "initial" )
             textModeContainer.state = "expanded"
           else if ( textModeContainer.state === "expanded" && root.canOpenFeaturesPage )
-            textModeContrainer.state = "page"
+            textModeContainer.state = "page"
         }
       }
 
       Flow {
-        id: view
+        id: flowItemView
 
         anchors.fill: parent
         anchors.margins: customStyle.fields.sideMargin
 
         spacing: customStyle.group.spacing
 
-        Repeater {
-          model: delegateModel
-        }
+        Repeater { model: delegateModel; }
       }
     }
 
@@ -212,7 +208,7 @@ Item {
     Item {
       id: textDelegateContainer
 
-      property real maximumWidth: view.width
+      property real maximumWidth: flowItemView.width
       property bool isVisible: {
         // figure out which row am I from Y
         if ( y === 0 ) return true

--- a/app/qml/editor/inputrelation.qml
+++ b/app/qml/editor/inputrelation.qml
@@ -94,12 +94,12 @@ Item {
     right: parent.right
   }
 
-  height: childrenRect.height
+  height: content.height
 
   Item {
     id: content
 
-    height: childrenRect.height
+    height: mode === "text" ? textModeContainer.height : photoModeContainer.height
     anchors {
       left: parent.left
       right: parent.right
@@ -115,6 +115,10 @@ Item {
           PropertyChanges {
             target: noOfFeaturesText
             visible: true
+          }
+          PropertyChanges {
+            target: textModeContainer
+            height: customStyle.fields.height
           }
         },
         State {

--- a/app/qml/editor/inputrelation.qml
+++ b/app/qml/editor/inputrelation.qml
@@ -134,10 +134,7 @@ Item {
         },
         State {
           name: "page"
-//          PropertyChanges {
-//            target: object
-
-//          }
+          // TODO: page state
         }
       ]
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -443,8 +443,6 @@ ApplicationWindow {
             }
         }
 
-        //Component.onCompleted: __variablesManager.useGpsPoint = digitizing.useGpsPoint
-
         onUseGpsPointChanged: __variablesManager.useGpsPoint = digitizing.useGpsPoint
     }
 

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -71,6 +71,7 @@
         <file>components/Switch.qml</file>
         <file>components/IconTextItem.qml</file>
         <file>components/InputComboBox.qml</file>
+        <file>editor/inputrelation.qml</file>
         <file>editor/inputcheckbox.qml</file>
         <file>editor/inputdatetime.qml</file>
         <file>editor/inputexternalresource.qml</file>

--- a/app/relationfeaturesmodel.cpp
+++ b/app/relationfeaturesmodel.cpp
@@ -1,0 +1,71 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "relationfeaturesmodel.h"
+
+RelationFeaturesModel::RelationFeaturesModel( QObject *parent )
+  : FeaturesListModel( parent )
+{
+}
+
+void RelationFeaturesModel::setup()
+{
+  emptyData();
+}
+
+void RelationFeaturesModel::populate()
+{
+  if ( !mRelation.isValid() || !mParentFeatureLayerPair.isValid() )
+    return;
+
+  beginResetModel();
+  mFeatures.clear();
+
+  QgsFeatureIterator it = mRelation.getRelatedFeatures( mParentFeatureLayerPair.feature() );
+  QgsFeature feat;
+
+  while ( it.nextFeature( feat ) )
+  {
+    mFeatures << FeatureLayerPair( feat, mRelation.referencingLayer() );
+  }
+
+  endResetModel();
+}
+
+void RelationFeaturesModel::setParentFeatureLayerPair( FeatureLayerPair pair )
+{
+  if ( mParentFeatureLayerPair != pair )
+  {
+    mParentFeatureLayerPair = pair;
+    emit parentFeatureLayerPairChanged( mParentFeatureLayerPair );
+
+    populate();
+  }
+}
+
+void RelationFeaturesModel::setRelation( QgsRelation relation )
+{
+  if ( mRelation.id() != relation.id() )
+  {
+    mRelation = relation;
+    emit relationChanged( mRelation );
+
+    populate();
+  }
+}
+
+FeatureLayerPair RelationFeaturesModel::parentFeatureLayerPair() const
+{
+  return mParentFeatureLayerPair;
+}
+
+QgsRelation RelationFeaturesModel::relation() const
+{
+  return mRelation;
+}

--- a/app/relationfeaturesmodel.h
+++ b/app/relationfeaturesmodel.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef RELATIONFEATURESMODEL_H
+#define RELATIONFEATURESMODEL_H
+
+#include "featureslistmodel.h"
+#include "featurelayerpair.h"
+
+#include "qgsrelation.h"
+
+#include <QObject>
+
+class RelationFeaturesModel : public FeaturesListModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QgsRelation relation READ relation WRITE setRelation NOTIFY relationChanged )
+
+    //! parent feature layer pair represents a feature from parent relation layer for which we gather related child features
+    Q_PROPERTY( FeatureLayerPair parentFeatureLayerPair READ parentFeatureLayerPair WRITE setParentFeatureLayerPair NOTIFY parentFeatureLayerPairChanged )
+
+  public:
+
+    explicit RelationFeaturesModel( QObject *parent = nullptr );
+    virtual ~RelationFeaturesModel() {};
+
+    void setup(); // will be override
+    void populate(); // will be override
+
+    void setParentFeatureLayerPair( FeatureLayerPair pair );
+    void setRelation( QgsRelation relation );
+
+    FeatureLayerPair parentFeatureLayerPair() const;
+    QgsRelation relation() const;
+
+  signals:
+    void parentFeatureLayerPairChanged( FeatureLayerPair pair );
+    void relationChanged( QgsRelation relation );
+
+  private:
+
+    QgsRelation mRelation; // associated relation
+    FeatureLayerPair mParentFeatureLayerPair; // parent feature (with relation widget in form)
+};
+
+#endif // RELATIONFEATURESMODEL_H

--- a/app/sources.pri
+++ b/app/sources.pri
@@ -39,7 +39,8 @@ codefilter.cpp \
 qrdecoder.cpp \
 projectsmodel.cpp \
 projectsproxymodel.cpp \
-compass.cpp
+compass.cpp \
+relationfeaturesmodel.cpp
 
 HEADERS += \
 attributes/attributecontroller.h \
@@ -81,7 +82,8 @@ codefilter.h \
 qrdecoder.h \
 projectsmodel.h \
 projectsproxymodel.h \
-compass.h
+compass.h \
+relationfeaturesmodel.h
 
 contains(DEFINES, INPUT_TEST) {
 


### PR DESCRIPTION
We are currently able to show relations in new widget called `inputrelation.qml`

How it work:
 - relation widget type (form qgis) is handled as another form item (see `AttributeController::flatten`)
 - relationFeaturesModel (derived from featureslistmodel) receives `QgsRelation` and provides the data to relation widget
 - relation widget has 3 states: 
    - _initial_ = there is only text saying how many features are linked
    - _expanded_ = widget expands to three lines with features listed (their display text is used). If feature contains more linked features than can be displayed (see attached video in 0:10), we only show the first n.
    - _page_ =  (not yet implemented) separate page with all linked features listed ~> will be implemented in **future PR**, because some qml changes need to be done first

docu: https://docs.google.com/document/d/1hEpfXa59NoKz7tyyFSghZhQ1QELQftGWiVuAAT57Szc/edit

https://user-images.githubusercontent.com/22449698/123085765-eb80de80-d422-11eb-9ffd-80cf7f57695a.mp4

I will create tickets for following tasks.