### PR TITLE
Added gallery widget for relations

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -635,6 +635,68 @@ bool InputUtils::fileExists( const QString &path )
   return ( check_file.exists() && check_file.isFile() );
 }
 
+QString InputUtils::resolveTargetDir( const QString &homePath, const QVariantMap &config, const FeatureLayerPair &pair, QgsProject *activeProject )
+{
+  QString expression;
+  QMap<QString, QVariant> collection = config.value( QStringLiteral( "PropertyCollection" ) ).toMap();
+  QMap<QString, QVariant> props = collection.value( QStringLiteral( "properties" ) ).toMap();
+
+  if ( !props.isEmpty() )
+  {
+    QMap<QString, QVariant> propertyRootPath = props.value( QStringLiteral( "propertyRootPath" ) ).toMap();
+    expression = propertyRootPath.value( QStringLiteral( "expression" ), QString() ).toString();
+  }
+
+  if ( !expression.isEmpty() )
+  {
+    return evaluateExpression( pair, activeProject, expression );
+  }
+  else
+  {
+    QString defaultRoot = config.value( QStringLiteral( "DefaultRoot" ) ).toString();
+    if ( defaultRoot.isEmpty() )
+    {
+      return homePath;
+    }
+    else
+    {
+      return defaultRoot;
+    }
+  }
+
+
+}
+
+QString InputUtils::resolvePrefixForRelativePath( int relativeStorageMode, const QString &homePath, const QString &targetDir )
+{
+  if ( relativeStorageMode == 1 )
+  {
+    return homePath;
+  }
+  else if ( relativeStorageMode == 2 )
+  {
+    return targetDir;
+  }
+  else
+  {
+    return QString();
+  }
+}
+
+QString InputUtils::getAbsolutePath( const QString &path, const QString &prefixPath )
+{
+  return ( prefixPath.isEmpty() ) ? path : QStringLiteral( "%1/%2" ).arg( prefixPath ).arg( path );
+}
+
+QString InputUtils::resolvePath( const QString &path, const QString &homePath, const QVariantMap &config, const FeatureLayerPair &pair, QgsProject *activeProject )
+{
+  int relativeStorageMode = config.value( QStringLiteral( "RelativeStorage" ) ).toInt();
+  QString targetDir = resolveTargetDir( homePath, config, pair, activeProject );
+  QString prefixToRelativePath = resolvePrefixForRelativePath( relativeStorageMode, homePath, targetDir );
+
+  return getAbsolutePath( path, prefixToRelativePath );
+}
+
 QString InputUtils::getRelativePath( const QString &path, const QString &prefixPath )
 {
   QString modPath = path;

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -195,6 +195,30 @@ class InputUtils: public QObject
       */
     Q_INVOKABLE static bool fileExists( const QString &path );
 
+    // TODO
+    Q_INVOKABLE static QString resolvePath( const QString &path, const QString &homePath, const QVariantMap &config, const FeatureLayerPair &pair, QgsProject *activeProject );
+
+    /**
+     * This evaluates the "default path" with the following order:
+     * 1. evaluate default path expression if defined,
+     * 2. use default path value if not empty,
+     * 3. use project home folder
+     */
+    Q_INVOKABLE static QString resolveTargetDir( const QString &homePath, const QVariantMap &config, const FeatureLayerPair &pair, QgsProject *activeProject );
+
+
+    // TODO homerpath first param
+    Q_INVOKABLE static QString resolvePrefixForRelativePath( int relativeStorageMode, const QString &homePath, const QString &targetDir );
+
+
+    /**
+     * Returns absolute path of the file for given path and its prefix. If prefixPath is empty,
+     * returns given path.
+     * \param path (Relative) path to file,
+     * \param prefixPath Empty or prefix for given path to abtain absolute path.
+     */
+    Q_INVOKABLE static QString getAbsolutePath( const QString &path, const QString &prefixPath );
+
     /**
      * Returns relative path of the file to given prefixPath. If prefixPath does not match a path parameter,
      * returns an empty string. If a path starts with "file://", this prefix is ignored.

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -195,7 +195,15 @@ class InputUtils: public QObject
       */
     Q_INVOKABLE static bool fileExists( const QString &path );
 
-    // TODO
+    /**
+     * Returns working path to load the image from QML.
+     * @param path Path of an image - either relative or absolute
+     * @param homePath Project path
+     * @param config Field widget's config
+     * @param pair FeatureLayerPair - needed for expression evaluation
+     * @param activeProject QgsProject - needed for expression evaluation
+     * @return Path to the image
+     */
     Q_INVOKABLE static QString resolvePath( const QString &path, const QString &homePath, const QVariantMap &config, const FeatureLayerPair &pair, QgsProject *activeProject );
 
     /**
@@ -207,7 +215,15 @@ class InputUtils: public QObject
     Q_INVOKABLE static QString resolveTargetDir( const QString &homePath, const QVariantMap &config, const FeatureLayerPair &pair, QgsProject *activeProject );
 
 
-    // TODO homerpath first param
+    /**
+     * Function used for resolving path of an image for a field with ExternalResource widget type.
+     * Returns prefix which has to be added to the field's value to obtain working path to load the image from QML.
+     * @param relativeStorageMode: 0 - Relative path disabled; 1 - Relative path to project;
+     * 2 - Relative path to defaultRoot defined in the config - Default path field in the widget configuration form
+     * @param homePath Project path
+     * @param targetDir Default path in the widget configuration
+     * @return Returns either homePath, targetDir or empty QString according relativeStorageMode that is configurable in field widget's config
+     */
     Q_INVOKABLE static QString resolvePrefixForRelativePath( int relativeStorageMode, const QString &homePath, const QString &targetDir );
 
 

--- a/app/qml/ExternalResourceBundle.qml
+++ b/app/qml/ExternalResourceBundle.qml
@@ -110,7 +110,7 @@ Item {
         property var imageSelected: function imageSelected(imagePath) {
           var filename = __inputUtils.getFileName(imagePath)
           //! final absolute location of an image.
-          var absolutePath  = externalResourceHandler.itemWidget.getAbsolutePath(externalResourceHandler.itemWidget.targetDir, filename)
+          var absolutePath = __inputUtils.getAbsolutePath( filename, externalResourceHandler.itemWidget.targetDir )
 
           if (!__inputUtils.fileExists(absolutePath)) {
             var success = __inputUtils.copyFile(imagePath, absolutePath)

--- a/app/qml/editor/inputexternalresource.qml
+++ b/app/qml/editor/inputexternalresource.qml
@@ -156,7 +156,7 @@ Item {
 
       MouseArea {
         anchors.fill: parent
-        onClicked: externalResourceHandler.previewImage( getAbsolutePath( prefixToRelativePath, image.currentValue ) )
+        onClicked: externalResourceHandler.previewImage( __inputUtils.getAbsolutePath( image.currentValue, prefixToRelativePath ) )
       }
 
       onCurrentValueChanged: {

--- a/app/qml/editor/inputrelation.qml
+++ b/app/qml/editor/inputrelation.qml
@@ -18,22 +18,18 @@ import ".."
 Item {
   id: root
 
-  property real iconSize: 15
-
-  /**
-   * Property mode sets how the relation widget will look like, there are two options:
-   * - text: features from child layer are placed on grid (cell displayed as rectangle) with display string
-   * - photo: list horizontal/verical of photos
-   */
-  property string mode: "text"
   property int linkedFeaturesCount: rmodel.rowCount()
+  property bool canOpenFeaturesPage: false // if the advanced page for relations should be shown
+  property real expandedHeight: customStyle.fields.height * 3 // three rows
 
   signal valueChanged( var value, bool isNull )
   signal featureLayerPairChanged()
 
   onFeatureLayerPairChanged: {
     // new feature layer pair, revert state and update delegate model
-    textModeContainer.state = "initial"
+    if (rmodel.isTextType) {
+      textModeContainer.state = "initial"
+    }
     delegateModel.update()
   }
 
@@ -42,6 +38,7 @@ Item {
 
     relation: associatedRelation
     parentFeatureLayerPair: featurePair
+    homePath: activeProject.homePath
 
     onModelReset: root.linkedFeaturesCount = rowCount()
   }
@@ -99,7 +96,7 @@ Item {
   Item {
     id: content
 
-    height: mode === "text" ? textModeContainer.height : photoModeContainer.height
+    height: rmodel.isTextType ? textModeContainer.height : photoModeContainer.height
     anchors {
       left: parent.left
       right: parent.right
@@ -125,7 +122,7 @@ Item {
           name: "expanded"
           PropertyChanges {
             target: textModeContainer
-            height: customStyle.fields.height * 3 // three rows
+            height: root.expandedHeight //customStyle.fields.height * 3 // three rows
           }
           PropertyChanges {
             target: noOfFeaturesText
@@ -153,7 +150,7 @@ Item {
 
       onStateChanged: delegateModel.update()
 
-      visible: mode === "text"
+      visible: rmodel.isTextType
       height: customStyle.fields.height
       width: parent.width
       state: "initial"
@@ -198,13 +195,30 @@ Item {
     }
 
     // Photo Mode Widget
-    Item {
+    Rectangle {
       id: photoModeContainer
 
-      visible: mode === "photo"
-      anchors.fill: parent
+      visible: !rmodel.isTextType
+      height: expandedHeight
+      width: parent.width
 
-      // todo: photo panel widget
+      border.color: customStyle.fields.normalColor
+      border.width: 1 * QgsQuick.Utils.dp
+      color: customStyle.fields.backgroundColor
+      radius: customStyle.fields.cornerRadius
+
+      ListView {
+        height: expandedHeight
+        width: parent.width
+        anchors.margins: customStyle.fields.sideMargin
+        anchors.fill: parent
+        spacing: customStyle.group.spacing
+        orientation: ListView.Horizontal
+        clip: true
+
+        model: rmodel
+        delegate: photoDelegate
+      }
     }
   }
 
@@ -267,7 +281,40 @@ Item {
     id: photoDelegate
 
     Item {
-      // todo: photo panel delegate
+      height: expandedHeight
+      width: height
+
+      Image {
+        id: image
+
+        anchors.fill: parent
+        sourceSize.width: image.width
+        sourceSize.height: image.height
+        source: {
+          let absolutePath = model.PhotoPath
+
+          if (image.status === Image.Error) {
+            customStyle.icons.brokenImage
+          }
+          else if (absolutePath !== '' && __inputUtils.fileExists(absolutePath)) {
+            "file://" + absolutePath
+          }
+          else if (absolutePath === '' || absolutePath === undefined) {
+            customStyle.icons.notAvailable
+          } else {
+            customStyle.icons.brokenImage
+          }
+        }
+        mipmap: true
+        fillMode: Image.PreserveAspectFit
+      }
+
+      MouseArea {
+        anchors.fill: parent
+        onClicked: console.log("TODO: Image clicked -> show form")
+        onPressAndHold:console.log("TODO: Image pressed and hold -> show preview")
+      }
+
     }
   }
 

--- a/app/relationfeaturesmodel.cpp
+++ b/app/relationfeaturesmodel.cpp
@@ -8,10 +8,37 @@
  ***************************************************************************/
 
 #include "relationfeaturesmodel.h"
+#include "inpututils.h"
 
 RelationFeaturesModel::RelationFeaturesModel( QObject *parent )
   : FeaturesListModel( parent )
 {
+}
+
+QVariant RelationFeaturesModel::data( const QModelIndex &index, int role ) const
+{
+  int row = index.row();
+  if ( row < 0 || row >= mFeatures.count() )
+    return QVariant();
+
+  if ( !index.isValid() )
+    return QVariant();
+
+  if ( role == PhotoPath )
+  {
+    const FeatureLayerPair pair = mFeatures.at( index.row() );
+    return relationPhotoPath( pair );
+  }
+  else
+    return FeaturesListModel::data( index, role );
+}
+
+QHash<int, QByteArray> RelationFeaturesModel::roleNames() const
+{
+  QHash<int, QByteArray> roles = FeaturesListModel::roleNames();
+  roles[PhotoPath] = QStringLiteral( "PhotoPath" ).toLatin1();
+
+  return roles;
 }
 
 void RelationFeaturesModel::setup()
@@ -36,6 +63,8 @@ void RelationFeaturesModel::populate()
   }
 
   endResetModel();
+
+  setIsTextType( photoFieldIndex( mRelation.referencingLayer() ) == -1 );
 }
 
 void RelationFeaturesModel::setParentFeatureLayerPair( FeatureLayerPair pair )
@@ -68,4 +97,70 @@ FeatureLayerPair RelationFeaturesModel::parentFeatureLayerPair() const
 QgsRelation RelationFeaturesModel::relation() const
 {
   return mRelation;
+}
+
+QVariant RelationFeaturesModel::relationPhotoPath( const FeatureLayerPair &featurePair ) const
+{
+  // Feature title used to get path of the referenced image.
+  QString path = featureTitle( featurePair ).toString();
+
+  QgsAttributeList refFields = mRelation.referencedFields();
+  int fieldIndex = photoFieldIndex( featurePair.layer() );
+  QgsEditorWidgetSetup setup = featurePair.layer()->editorWidgetSetup( fieldIndex );
+  QVariantMap config = setup.config();
+
+  QString finalPath = InputUtils::resolvePath( path, homePath(), config, featurePair, QgsProject::instance() );
+
+  return QVariant( finalPath );
+}
+
+int RelationFeaturesModel::photoFieldIndex( QgsVectorLayer *layer ) const
+{
+
+  QgsFields fields = layer->fields();
+  for ( int i = 0; i < fields.size(); i++ )
+  {
+    // Lets try keyword
+    if ( fields.at( i ).name().contains( IMAGE_FIELD_KEYWORD ) )
+    {
+      return i;
+    }
+
+    // Lets try by widget type
+    QgsEditorWidgetSetup setup = layer->editorWidgetSetup( i );
+    QVariantMap config = setup.config();
+    if ( setup.type() == QStringLiteral( "ExternalResource" ) )
+    {
+      return i;
+    }
+  }
+  return -1;
+}
+
+bool RelationFeaturesModel::isTextType() const
+{
+  return mIsTextType;
+}
+
+void RelationFeaturesModel::setIsTextType( bool isTextType )
+{
+  if ( isTextType != mIsTextType )
+  {
+    mIsTextType = isTextType;
+    emit isTextTypeChanged();
+  }
+}
+
+QString RelationFeaturesModel::homePath() const
+{
+  return mHomePath;
+}
+
+void RelationFeaturesModel::setHomePath( const QString &homePath )
+{
+  if ( homePath != mHomePath )
+  {
+    mHomePath = homePath;
+    emit homePathChanged();
+  }
 }

--- a/app/relationfeaturesmodel.cpp
+++ b/app/relationfeaturesmodel.cpp
@@ -104,7 +104,6 @@ QVariant RelationFeaturesModel::relationPhotoPath( const FeatureLayerPair &featu
   // Feature title used to get path of the referenced image.
   QString path = featureTitle( featurePair ).toString();
 
-  QgsAttributeList refFields = mRelation.referencedFields();
   int fieldIndex = photoFieldIndex( featurePair.layer() );
   QgsEditorWidgetSetup setup = featurePair.layer()->editorWidgetSetup( fieldIndex );
   QVariantMap config = setup.config();
@@ -120,12 +119,6 @@ int RelationFeaturesModel::photoFieldIndex( QgsVectorLayer *layer ) const
   QgsFields fields = layer->fields();
   for ( int i = 0; i < fields.size(); i++ )
   {
-    // Lets try keyword
-    if ( fields.at( i ).name().contains( IMAGE_FIELD_KEYWORD ) )
-    {
-      return i;
-    }
-
     // Lets try by widget type
     QgsEditorWidgetSetup setup = layer->editorWidgetSetup( i );
     QVariantMap config = setup.config();

--- a/app/relationfeaturesmodel.h
+++ b/app/relationfeaturesmodel.h
@@ -23,13 +23,34 @@ class RelationFeaturesModel : public FeaturesListModel
 
     Q_PROPERTY( QgsRelation relation READ relation WRITE setRelation NOTIFY relationChanged )
 
+    //! Home path of the active project used to evaluate absolute path of referencved images
+    Q_PROPERTY( QString homePath READ homePath WRITE setHomePath NOTIFY homePathChanged )
+
     //! parent feature layer pair represents a feature from parent relation layer for which we gather related child features
     Q_PROPERTY( FeatureLayerPair parentFeatureLayerPair READ parentFeatureLayerPair WRITE setParentFeatureLayerPair NOTIFY parentFeatureLayerPairChanged )
 
+    /**
+     * Flag to distinquash what data type suppose to be displayed. By default text data type is expected, otherwise image.
+     * Property is set to False only if there is any photo field (see more: RelationFeaturesModel::photoFieldIndex)
+     */
+    Q_PROPERTY( bool isTextType READ isTextType WRITE setIsTextType NOTIFY isTextTypeChanged )
+
   public:
+
+    //! Roles for RelationFeaturesListModel
+    enum relationModelRoles
+    {
+      PhotoPath = Qt::UserRole + 100,
+    };
+    Q_ENUM( relationModelRoles );
+
 
     explicit RelationFeaturesModel( QObject *parent = nullptr );
     virtual ~RelationFeaturesModel() {};
+
+    // QAbstractItemModel interface
+    QVariant data( const QModelIndex &index, int role ) const override;
+    QHash<int, QByteArray> roleNames() const override;
 
     void setup(); // will be override
     void populate(); // will be override
@@ -40,14 +61,34 @@ class RelationFeaturesModel : public FeaturesListModel
     FeatureLayerPair parentFeatureLayerPair() const;
     QgsRelation relation() const;
 
+    QString homePath() const;
+    void setHomePath( const QString &homePath );
+
+    bool isTextType() const;
+    void setIsTextType( bool isTextType );
+
   signals:
     void parentFeatureLayerPairChanged( FeatureLayerPair pair );
     void relationChanged( QgsRelation relation );
+    void homePathChanged();
+    void isTextTypeChanged();
 
   private:
+    QVariant relationPhotoPath( const FeatureLayerPair &featurePair ) const;
+
+    /**
+     * Searches and returns first index of photo field - either field is type of 'ExternalResource' or field name contains IMAGE_FIELD_KEYWORD.
+     * @param layer Referencing layer of the relation.
+     * @return Index of photo field, otherwise -1 if not found any.
+     */
+    int photoFieldIndex( QgsVectorLayer *layer ) const;
 
     QgsRelation mRelation; // associated relation
     FeatureLayerPair mParentFeatureLayerPair; // parent feature (with relation widget in form)
+    QString mHomePath;
+    bool mIsTextType = true;
+
+    const QString IMAGE_FIELD_KEYWORD = QStringLiteral( "photo" );
 };
 
 #endif // RELATIONFEATURESMODEL_H

--- a/app/relationfeaturesmodel.h
+++ b/app/relationfeaturesmodel.h
@@ -77,7 +77,7 @@ class RelationFeaturesModel : public FeaturesListModel
     QVariant relationPhotoPath( const FeatureLayerPair &featurePair ) const;
 
     /**
-     * Searches and returns first index of photo field - either field is type of 'ExternalResource' or field name contains IMAGE_FIELD_KEYWORD.
+     * Searches and returns first index of photo field if the field is type of 'ExternalResource'.
      * @param layer Referencing layer of the relation.
      * @return Index of photo field, otherwise -1 if not found any.
      */
@@ -87,8 +87,6 @@ class RelationFeaturesModel : public FeaturesListModel
     FeatureLayerPair mParentFeatureLayerPair; // parent feature (with relation widget in form)
     QString mHomePath;
     bool mIsTextType = true;
-
-    const QString IMAGE_FIELD_KEYWORD = QStringLiteral( "photo" );
 };
 
 #endif // RELATIONFEATURESMODEL_H

--- a/app/test/testutilsfunctions.h
+++ b/app/test/testutilsfunctions.h
@@ -31,6 +31,8 @@ class TestUtilsFunctions: public QObject
     void fileExists();
     void loadQmlComponent();
     void getRelativePath();
+    void resolvePhotoPath();
+    void resolveTargetDir();
 
   private:
     void testFormatDuration( const QDateTime &t0, qint64 diffSecs, const QString &expectedResult );


### PR DESCRIPTION
Added gallery widget for relations with images.

**When is shown:** (can be discussed)
The widget is shown if there is an image field if field widget type is 'ExternalResource'.
Note that it can be also beneficial to use some keyword as part of a field name, to clearly specify which field suppose to be used to show relation image. Input would give it priority before the first 'ExternalResource' field.
If we want to have it, what would be the keyword?
 
**Behaviour:**
Gallery can be browsed from left to right. Opening related feature or showing a preview is not implemented yet.
If image is not available or is missing, an icon is shown instead.

In order to resolve path for images, some functions were moved from inputexternalresource.qml to input utils.
Also test have been added for those functions. 
 
Can be tested with: `viktor/test_image_relations`
 
Note that purchasing tests failed
  
To improve:
* more love for icons if an image is not available
* to center images in the gallery row
* interaction events (click, hold)

![IMG_3E785B13480F-1](https://user-images.githubusercontent.com/6735606/124002028-92421d80-d9d5-11eb-889b-d9c3a8276778.jpeg)

 
closes #1511 