### PR TITLE
Add, edit and remove features in relation

### DIFF
--- a/app/attributes/attributecontroller.h
+++ b/app/attributes/attributecontroller.h
@@ -87,14 +87,14 @@ class  AttributeController : public QObject
     Q_PROPERTY( bool fieldValuesValid READ fieldValuesValid NOTIFY fieldValuesValidChanged )
 
     /**
-     * If featureLayerPair is a child feature in relation, it will have associated parent featureLayerPair saved in this property
-     * parent together with linkedRelation is used to automatically prefill fields containing foreign key to parent table
+     * If the featureLayerPair in this controller is a child feature in relation, it will have associated parent AttributeController saved in this property.
+     * parent together with linkedRelation is used to automatically prefill fields containing foreign key to parent table (relation reference fields)
      */
-    Q_PROPERTY( FeatureLayerPair parentFeatureLayerPair READ parentFeatureLayerPair WRITE setParentFeatureLayerPair NOTIFY parentFeatureLayerPairChanged )
+    Q_PROPERTY( AttributeController *parentController READ parentController WRITE setParentController NOTIFY parentControllerChanged )
 
     /**
      * If featureLayerPair is a child feature in relation, it will have associated relation saved in this property
-     * see parentFeatureLayerPair documentation for more info
+     * see parentController documentation for more info
      */
     Q_PROPERTY( QgsRelation linkedRelation READ linkedRelation WRITE setLinkedRelation NOTIFY linkedRelationChanged )
 
@@ -123,6 +123,7 @@ class  AttributeController : public QObject
     Q_INVOKABLE bool create();
     Q_INVOKABLE bool save();
     Q_INVOKABLE bool isNewFeature() const;
+    Q_INVOKABLE void acquireId();
 
     int tabCount() const;
 
@@ -148,11 +149,14 @@ class  AttributeController : public QObject
     VariablesManager *variablesManager() const;
     void setVariablesManager( VariablesManager *variablesManager );
 
-    const FeatureLayerPair& parentFeatureLayerPair() const;
-    void setParentFeatureLayerPair( const FeatureLayerPair &newParentFeatureLayerPair );
+    AttributeController *parentController() const;
+    void setParentController( AttributeController *newParentController );
 
-    const QgsRelation& linkedRelation() const;
+    const QgsRelation &linkedRelation() const;
     void setLinkedRelation( const QgsRelation &newLinkedRelation );
+
+  public slots:
+    void onFeatureAdded( QgsFeatureId newFeatureId );
 
   signals:
     void hasAnyChangesChanged();
@@ -164,11 +168,13 @@ class  AttributeController : public QObject
     void hasTabsChanged();
     void variablesManagerChanged();
     void fieldValuesValidChanged();
-    void parentFeatureLayerPairChanged();
+    void parentControllerChanged();
     void linkedRelationChanged();
 
     void formDataChanged( QUuid uuid, QVector<int> roles = QVector<int>() );
     void tabDataChanged( int id );
+    void featureIdChanged();
+
   private:
     void clearAll();
 
@@ -233,7 +239,7 @@ class  AttributeController : public QObject
     RememberAttributesController *mRememberAttributesController = nullptr; // not owned
     VariablesManager *mVariablesManager = nullptr; // not owned
 
-    FeatureLayerPair mParentFeatureLayerPair;
+    AttributeController *mParentController = nullptr; // not owned
     QgsRelation mLinkedRelation;
 };
 #endif // ATTRIBUTECONTROLLER_H

--- a/app/attributes/attributecontroller.h
+++ b/app/attributes/attributecontroller.h
@@ -86,6 +86,18 @@ class  AttributeController : public QObject
      */
     Q_PROPERTY( bool fieldValuesValid READ fieldValuesValid NOTIFY fieldValuesValidChanged )
 
+    /**
+     * If featureLayerPair is a child feature in relation, it will have associated parent featureLayerPair saved in this property
+     * parent together with linkedRelation is used to automatically prefill fields containing foreign key to parent table
+     */
+    Q_PROPERTY( FeatureLayerPair parentFeatureLayerPair READ parentFeatureLayerPair WRITE setParentFeatureLayerPair NOTIFY parentFeatureLayerPairChanged )
+
+    /**
+     * If featureLayerPair is a child feature in relation, it will have associated relation saved in this property
+     * see parentFeatureLayerPair documentation for more info
+     */
+    Q_PROPERTY( QgsRelation linkedRelation READ linkedRelation WRITE setLinkedRelation NOTIFY linkedRelationChanged )
+
   public:
     AttributeController( QObject *parent = nullptr );
     ~AttributeController() override;
@@ -136,6 +148,12 @@ class  AttributeController : public QObject
     VariablesManager *variablesManager() const;
     void setVariablesManager( VariablesManager *variablesManager );
 
+    const FeatureLayerPair& parentFeatureLayerPair() const;
+    void setParentFeatureLayerPair( const FeatureLayerPair &newParentFeatureLayerPair );
+
+    const QgsRelation& linkedRelation() const;
+    void setLinkedRelation( const QgsRelation &newLinkedRelation );
+
   signals:
     void hasAnyChangesChanged();
     void rememberAttributesChanged();
@@ -146,6 +164,8 @@ class  AttributeController : public QObject
     void hasTabsChanged();
     void variablesManagerChanged();
     void fieldValuesValidChanged();
+    void parentFeatureLayerPairChanged();
+    void linkedRelationChanged();
 
     void formDataChanged( QUuid uuid, QVector<int> roles = QVector<int>() );
     void tabDataChanged( int id );
@@ -188,6 +208,9 @@ class  AttributeController : public QObject
     //! Returns editor widget setup according params. If is empty, returns a default setup according field's type.
     QgsEditorWidgetSetup getEditorWidgetSetup( QgsVectorLayer *layer, int fieldIndex ) const;
 
+    //! Fills up relation reference (foreign key) field with parent id
+    void prefillRelationReferenceField();
+
     /**
      * Checks if tab layout is allowed for given container. Function is not recursive and checks only first level elements.
      * @param container Suppose to be the root of attributeEditor container.
@@ -210,5 +233,7 @@ class  AttributeController : public QObject
     RememberAttributesController *mRememberAttributesController = nullptr; // not owned
     VariablesManager *mVariablesManager = nullptr; // not owned
 
+    FeatureLayerPair mParentFeatureLayerPair;
+    QgsRelation mLinkedRelation;
 };
 #endif // ATTRIBUTECONTROLLER_H

--- a/app/digitizingcontroller.cpp
+++ b/app/digitizingcontroller.cpp
@@ -215,15 +215,18 @@ QgsGeometry DigitizingController::getPointGeometry( const QgsPoint &point, bool 
   return geom;
 }
 
-FeatureLayerPair DigitizingController::createFeatureLayerPair( const QgsGeometry &geometry )
+FeatureLayerPair DigitizingController::createFeatureLayerPair( const QgsGeometry &geometry, QgsVectorLayer *layer )
 {
-  QgsAttributes attrs( featureLayerPair().layer()->fields().count() );
-  QgsExpressionContext context = featureLayerPair().layer()->createExpressionContext();
+  if ( layer == nullptr || !layer->isValid() )
+    layer = featureLayerPair().layer();
+
+  QgsAttributes attrs( layer->fields().count() );
+  QgsExpressionContext context = layer->createExpressionContext();
   if ( mVariablesManager )
     context << mVariablesManager->positionScope();
-  QgsFeature feat = QgsVectorLayerUtils::createFeature( featureLayerPair().layer(), geometry, attrs.toMap(), &context );
+  QgsFeature feat = QgsVectorLayerUtils::createFeature( layer, geometry, attrs.toMap(), &context );
 
-  return FeatureLayerPair( feat, featureLayerPair().layer() );
+  return FeatureLayerPair( feat, layer );
 }
 
 FeatureLayerPair DigitizingController::pointFeatureFromPoint( const QgsPoint &point, bool isGpsPoint )
@@ -311,9 +314,9 @@ FeatureLayerPair DigitizingController::lineOrPolygonFeature()
   return createFeatureLayerPair( geom );
 }
 
-FeatureLayerPair DigitizingController::featureWithoutGeometry()
+FeatureLayerPair DigitizingController::featureWithoutGeometry( QgsVectorLayer *layer )
 {
-  return createFeatureLayerPair( QgsGeometry() );
+  return createFeatureLayerPair( QgsGeometry(), layer );
 }
 
 QgsPoint DigitizingController::pointFeatureMapCoordinates( FeatureLayerPair pair )

--- a/app/digitizingcontroller.h
+++ b/app/digitizingcontroller.h
@@ -56,8 +56,8 @@ class DigitizingController : public QObject
     Q_INVOKABLE FeatureLayerPair pointFeatureFromPoint( const QgsPoint &point, bool isGpsPoint );
     //! Creates a new QgsFeature with line/polygon geometry from the points stored since the start of recording
     Q_INVOKABLE FeatureLayerPair lineOrPolygonFeature();
-    //! Creates a new QgsFeature without geometry
-    Q_INVOKABLE FeatureLayerPair featureWithoutGeometry();
+    //! Creates a new QgsFeature without geometry in layer. If layer is null, it creates the feature on currently edited layer
+    Q_INVOKABLE FeatureLayerPair featureWithoutGeometry( QgsVectorLayer *layer = nullptr );
     //! Returns (point geom) featurePair coords in map coordinates.
     Q_INVOKABLE QgsPoint pointFeatureMapCoordinates( FeatureLayerPair pair );
     //! Changes point geometry of given pair according given point.
@@ -72,7 +72,7 @@ class DigitizingController : public QObject
 
     std::unique_ptr<QgsPoint> getLayerPoint( const QgsPoint &point, bool isGpsPoint );
     QgsGeometry getPointGeometry( const QgsPoint &point, bool isGpsPoint );
-    FeatureLayerPair createFeatureLayerPair( const QgsGeometry &geometry );
+    FeatureLayerPair createFeatureLayerPair( const QgsGeometry &geometry, QgsVectorLayer *layer = nullptr );
 
     int lineRecordingInterval() const;
     void setLineRecordingInterval( int lineRecordingInterval );

--- a/app/featureslistmodel.cpp
+++ b/app/featureslistmodel.cpp
@@ -76,6 +76,7 @@ QVariant FeaturesListModel::data( const QModelIndex &index, int role ) const
     case FeatureTitle: return featureTitle( pair );
     case FeatureId: return QVariant( pair.feature().id() );
     case Feature: return QVariant::fromValue<QgsFeature>( pair.feature() );
+    case FeaturePair: return QVariant::fromValue<FeatureLayerPair>( pair );
     case Description: return QVariant( QString( "Feature ID %1" ).arg( pair.feature().id() ) );
     case KeyColumn: return mKeyField.isEmpty() ? QVariant() : pair.feature().attribute( mKeyField );
     case FoundPair: return foundPair( pair );
@@ -275,6 +276,7 @@ QHash<int, QByteArray> FeaturesListModel::roleNames() const
   roleNames[FeatureTitle] = QStringLiteral( "FeatureTitle" ).toLatin1();
   roleNames[FeatureId] = QStringLiteral( "FeatureId" ).toLatin1();
   roleNames[Feature] = QStringLiteral( "Feature" ).toLatin1();
+  roleNames[FeaturePair] = QStringLiteral( "FeaturePair" ).toLatin1();
   roleNames[Description] = QStringLiteral( "Description" ).toLatin1();
   roleNames[FoundPair] = QStringLiteral( "FoundPair" ).toLatin1();
   roleNames[KeyColumn] = QStringLiteral( "KeyColumn" ).toLatin1();

--- a/app/featureslistmodel.h
+++ b/app/featureslistmodel.h
@@ -65,6 +65,7 @@ class  FeaturesListModel : public QAbstractListModel
       FeatureTitle = Qt::UserRole + 1,
       FeatureId,
       Feature,
+      FeaturePair,
       Description, //! secondary text in list view
       KeyColumn, //! key in value relation
       FoundPair //! pair of attribute and its value by which the feature was found, empty if search expression is empty

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -36,6 +36,7 @@
 #include "qgsquickmapsettings.h"
 #include "qgsquickutils.h"
 #include "qgsunittypes.h"
+#include "qgsfeatureid.h"
 
 #include <Qt>
 #include <QDir>
@@ -1025,4 +1026,9 @@ QString InputUtils::dateTimeFieldFormat( const QString &fieldFormat )
 QModelIndex InputUtils::invalidIndex()
 {
   return QModelIndex();
+}
+
+bool InputUtils::isFeatureIdValid( qint64 featureId )
+{
+  return !FID_IS_NEW( featureId ) && !FID_IS_NULL( featureId );
 }

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -375,7 +375,7 @@ class InputUtils: public QObject
     Q_INVOKABLE static QModelIndex invalidIndex();
 
     /**
-     * Returns if provided Id is valid ( >0 )
+     * Returns if provided Id is valid ( >= 0 )
      */
     Q_INVOKABLE static bool isFeatureIdValid( qint64 featureId );
 

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -335,6 +335,11 @@ class InputUtils: public QObject
     Q_INVOKABLE static QModelIndex invalidIndex();
 
     /**
+     * Returns if provided Id is valid ( >0 )
+     */
+    Q_INVOKABLE static bool isFeatureIdValid( qint64 featureId );
+
+    /**
      * Returns widget setup according the field type - supports only basic types.
      * Note that external widget cannot be guessed from type since its the very same as text.
      * @param field QgsField

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -269,6 +269,7 @@ void initDeclarative()
   qmlRegisterUncreatableType<AttributePreviewModel>( "lc", 1, 0, "AttributePreviewModel", "" );
   qmlRegisterUncreatableMetaObject( ProjectStatus::staticMetaObject, "lc", 1, 0, "ProjectStatus", "ProjectStatus Enum" );
   qRegisterMetaType< FeatureLayerPair >( "FeatureLayerPair" );
+  qRegisterMetaType< AttributeController * >( "AttributeController*" );
 
   qRegisterMetaType< QList<QgsMapLayer *> >( "QList<QgsMapLayer*>" );
   qRegisterMetaType< QgsAttributes > ( "QgsAttributes" );

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -278,6 +278,8 @@ void initDeclarative()
   qRegisterMetaType< QgsFeatureId > ( "QgsFeatureId" );
   qRegisterMetaType< QgsPoint >( "QgsPoint" );
   qRegisterMetaType< QgsPointXY >( "QgsPointXY" );
+  qRegisterMetaType< QgsRelation >( "QgsRelation" );
+  qRegisterMetaType< QgsPolymorphicRelation >( "QgsPolymorphicRelation" );
   qRegisterMetaType< QgsUnitTypes::SystemOfMeasurement >( "QgsUnitTypes::SystemOfMeasurement" );
   qRegisterMetaType< QgsUnitTypes::DistanceUnit >( "QgsUnitTypes::DistanceUnit" );
   qRegisterMetaType< QgsCoordinateFormatter::FormatFlags >( "QgsCoordinateFormatter::FormatFlags" );

--- a/app/qml/BrowseDataFeaturesPanel.qml
+++ b/app/qml/BrowseDataFeaturesPanel.qml
@@ -19,6 +19,7 @@ Item {
   signal searchTextChanged( string text )
 
   property bool layerHasGeometry: true
+  property bool toolbarVisible: true
   property bool allowMultiselect: false
   property bool allowSearch: true
   property string layerName: ""
@@ -109,7 +110,7 @@ Item {
 
     footer: BrowseDataToolbar {
       id: browseDataToolbar
-      visible: !layerHasGeometry || allowMultiselect
+      visible: toolbarVisible && ( !layerHasGeometry || allowMultiselect )
       addButtonVisible: !layerHasGeometry
       doneButtonVisible: allowMultiselect
 

--- a/app/qml/FormsStackManager.qml
+++ b/app/qml/FormsStackManager.qml
@@ -157,6 +157,8 @@ Item {
         root.closed() // this is the top most form, we want to keep it instantiated, just invisible
     }
 
+    focus: true
+
     anchors.fill: parent
   }
 

--- a/app/qml/FormsStackManager.qml
+++ b/app/qml/FormsStackManager.qml
@@ -26,6 +26,7 @@ Item {
 
   property var project
   property real previewHeight
+  property DigitizingController digitizingController
 
   property int activeFormIndex: 0
 
@@ -41,7 +42,7 @@ Item {
         panelState: panelState
       }
 
-      var latest = formsStack.push( formComponent, props)
+      var latest = formsStack.push( formComponent, props )
     }
     else
     {
@@ -120,6 +121,32 @@ Item {
     formsStack.visible = false
   }
 
+  function openLinkedFeature( linkedFeature ) {
+    let props = {
+      featureLayerPair: linkedFeature,
+      formState: "ReadOnly",
+      panelState: "form"
+    }
+
+    let latest = formsStack.push( formComponent, props )
+    root.activeFormIndex = latest.StackView.index
+  }
+
+  function createLinkedFeature( parentFeature, relation ) {
+    let newFeaturePair = digitizingController.featureWithoutGeometry( relation.referencingLayer )
+
+    let props = {
+      featureLayerPair: newFeaturePair,
+      formState: "Add",
+      panelState: "form",
+      parentFeatureLayerPair: parentFeature,
+      linkedRelation: relation
+    }
+
+    let latest = formsStack.push( formComponent, props )
+    root.activeFormIndex = latest.StackView.index
+  }
+
   StackView {
     id: formsStack
 
@@ -145,10 +172,8 @@ Item {
 
       onClosed: formsStack.popOneOrClose()
       onEditGeometry: root.geometryEditingStarted( StackView.index )
-
-      onCreateFeature: {
-        // TODO
-      }
+      onOpenLinkedFeature: root.openLinkedFeature( linkedFeature )
+      onCreateLinkedFeature: root.createLinkedFeature( parentFeature, relation )
     }
   }
 }

--- a/app/qml/FormsStackManager.qml
+++ b/app/qml/FormsStackManager.qml
@@ -132,14 +132,14 @@ Item {
     root.activeFormIndex = latest.StackView.index
   }
 
-  function createLinkedFeature( parentFeature, relation ) {
+  function createLinkedFeature( parentController, relation ) {
     let newFeaturePair = digitizingController.featureWithoutGeometry( relation.referencingLayer )
 
     let props = {
       featureLayerPair: newFeaturePair,
       formState: "Add",
       panelState: "form",
-      parentFeatureLayerPair: parentFeature,
+      parentController: parentController,
       linkedRelation: relation
     }
 
@@ -173,7 +173,7 @@ Item {
       onClosed: formsStack.popOneOrClose()
       onEditGeometry: root.geometryEditingStarted( StackView.index )
       onOpenLinkedFeature: root.openLinkedFeature( linkedFeature )
-      onCreateLinkedFeature: root.createLinkedFeature( parentFeature, relation )
+      onCreateLinkedFeature: root.createLinkedFeature( parentController, relation )
     }
   }
 }

--- a/app/qml/editor/inputrelation.qml
+++ b/app/qml/editor/inputrelation.qml
@@ -31,6 +31,9 @@ Item {
   signal valueChanged( var value, bool isNull )
   signal featureLayerPairChanged()
 
+  signal openLinkedFeature( var linkedFeature )
+  signal createLinkedFeature( var parentFeature, var relation )
+
   onFeatureLayerPairChanged: {
     // new feature layer pair, revert state and update delegate model
     textModeContainer.state = "initial"
@@ -44,6 +47,8 @@ Item {
     parentFeatureLayerPair: featurePair
 
     onModelReset: root.linkedFeaturesCount = rowCount()
+
+    onFeaturesCountChanged: delegateModel.update()
   }
 
   DelegateModel {
@@ -55,9 +60,6 @@ Item {
     property var filterAcceptsItem: function( item ) {
       if ( textModeContainer.state === "initial" ) {
         return false
-      }
-      else if ( textModeContainer.state === "expanded" ) {
-        return true
       }
       return true
     }
@@ -258,7 +260,7 @@ Item {
 
       MouseArea {
         anchors.fill: parent
-        // ToDo: show feature form: onReleased
+        onClicked: root.openLinkedFeature( model.FeaturePair )
       }
     }
   }
@@ -279,13 +281,20 @@ Item {
 
       pageTitle: qsTr( "Linked features" )
       allowSearch: false //TODO search
+      layerHasGeometry: false
+      toolbarVisible: !root.parent.readOnly
+      focus: true
 
       onBackButtonClicked: {
         root.parent.formView.pop()
         textModeContainer.state = "expanded"
       }
 
-//      onFeatureClicked: //TODO
+      onAddFeatureClicked: root.createLinkedFeature( root.parent.featurePair, root.parent.associatedRelation )
+      onFeatureClicked: {
+        let clickedFeature = featuresModel.attributeFromValue( FeaturesListModel.FeatureId, featureIds, FeaturesListModel.FeaturePair)
+        root.openLinkedFeature( clickedFeature )
+      }
 
       Keys.onReleased: {
         if ( event.key === Qt.Key_Back || event.key === Qt.Key_Escape ) {

--- a/app/qml/form/FeatureForm.qml
+++ b/app/qml/form/FeatureForm.qml
@@ -28,6 +28,10 @@ Item {
    */
   signal canceled
 
+  signal openLinkedFeature( var linkedFeature )
+
+  signal createLinkedFeature( var parentFeature, var relation )
+
    /**
     * A handler for extra events in externalSourceWidget.
     */
@@ -556,6 +560,21 @@ Item {
           ignoreUnknownSignals: true
           onImportDataRequested: {
            importDataHandler.importData(attributeEditorLoader.item)
+          }
+
+          onOpenLinkedFeature: {
+            form.openLinkedFeature( linkedFeature )
+          }
+
+          onCreateLinkedFeature: {
+            if ( form.state === "Add" ) {
+              // parent feature do not have a valid ID yet, we first need to save it and acquire ID
+              // TODO
+            }
+            else if ( form.state === "Edit" ) {
+              // parent feature in this case already have valid id, so we can open new form
+              form.createLinkedFeature( parentFeature, relation )
+            }
           }
         }
 

--- a/app/qml/form/FeatureFormPage.qml
+++ b/app/qml/form/FeatureFormPage.qml
@@ -63,6 +63,11 @@ Item {
     anchors.fill: parent
 
     initialItem: formPageComponent
+    focus: true
+
+    onCurrentItemChanged: {
+      currentItem.forceActiveFocus()
+    }
   }
 
   Component {
@@ -76,7 +81,6 @@ Item {
       header: PanelHeader {
         id: header
 
-        Component.onCompleted: backHandler.forceActiveFocus()
 
         height: InputStyle.rowHeightHeader
         rowHeight: InputStyle.rowHeightHeader
@@ -129,7 +133,13 @@ Item {
             else {
               root.close()
             }
+            event.accepted = true;
           }
+        }
+
+        onVisibleChanged: {
+          if ( visible )
+            backHandler.forceActiveFocus()
         }
       }
 

--- a/app/qml/form/FeatureFormPage.qml
+++ b/app/qml/form/FeatureFormPage.qml
@@ -22,14 +22,14 @@ Item {
   property var featureLayerPair
 
   property var linkedRelation
-  property var parentFeatureLayerPair
+  property var parentController
 
   property string formState
 
   signal close()
   signal editGeometryClicked()
   signal openLinkedFeature( var linkedFeature )
-  signal createLinkedFeature( var parentFeature, var relation )
+  signal createLinkedFeature( var parentController, var relation )
 
   function updateFeatureGeometry() {
     let f = formStackView.get( 0 )
@@ -88,7 +88,7 @@ Item {
         backIconVisible: !saveButtonText.visible
         backTextVisible: saveButtonText.visible
 
-        onBack: root.close()
+        onBack: featureForm.cancel()
 
         Text {
           id: saveButtonText
@@ -157,7 +157,7 @@ Item {
         onSaved: root.close()
         onCanceled: root.close()
         onOpenLinkedFeature: root.openLinkedFeature( linkedFeature )
-        onCreateLinkedFeature: root.createLinkedFeature( parentFeature, relation )
+        onCreateLinkedFeature: root.createLinkedFeature( parentController, relation )
 
         extraView: formPage.StackView.view
         customWidgetCallback: valueRelationWidget.handler
@@ -166,9 +166,10 @@ Item {
           target: root
           onFormStateChanged: featureForm.state = root.formState
         }
+
         Component.onCompleted: {
-          if ( root.parentFeatureLayerPair && root.linkedRelation ) {
-            featureForm.controller.parentFeatureLayerPair = root.parentFeatureLayerPair
+          if ( root.parentController && root.linkedRelation ) {
+            featureForm.controller.parentController = root.parentController
             featureForm.controller.linkedRelation = root.linkedRelation
           }
         }

--- a/app/qml/form/FeatureFormPage.qml
+++ b/app/qml/form/FeatureFormPage.qml
@@ -20,12 +20,16 @@ Item {
 
   property var project
   property var featureLayerPair
+
+  property var linkedRelation
   property var parentFeatureLayerPair
+
   property string formState
 
-  signal openNewForm( var i, var myParent )
   signal close()
   signal editGeometryClicked()
+  signal openLinkedFeature( var linkedFeature )
+  signal createLinkedFeature( var parentFeature, var relation )
 
   function updateFeatureGeometry() {
     let f = formStackView.get( 0 )
@@ -152,6 +156,8 @@ Item {
 
         onSaved: root.close()
         onCanceled: root.close()
+        onOpenLinkedFeature: root.openLinkedFeature( linkedFeature )
+        onCreateLinkedFeature: root.createLinkedFeature( parentFeature, relation )
 
         extraView: formPage.StackView.view
         customWidgetCallback: valueRelationWidget.handler
@@ -159,6 +165,12 @@ Item {
         Connections {
           target: root
           onFormStateChanged: featureForm.state = root.formState
+        }
+        Component.onCompleted: {
+          if ( root.parentFeatureLayerPair && root.linkedRelation ) {
+            featureForm.controller.parentFeatureLayerPair = root.parentFeatureLayerPair
+            featureForm.controller.linkedRelation = root.linkedRelation
+          }
         }
       }
 

--- a/app/qml/form/FormWrapper.qml
+++ b/app/qml/form/FormWrapper.qml
@@ -67,7 +67,6 @@ Item {
           PropertyChanges { target: drawer; height: root.height }
           PropertyChanges { target: drawer; interactive: false }
           PropertyChanges { target: formContainer; visible: true }
-          PropertyChanges { target: formContainer; focus: true }
           PropertyChanges { target: previewPanel; visible: false }
         },
         State {

--- a/app/qml/form/FormWrapper.qml
+++ b/app/qml/form/FormWrapper.qml
@@ -16,9 +16,13 @@ import ".."
 Item {
   id: root
 
-  property var featureLayerPair
-  property var parentFeatureLayerPair
   property var project
+  property var featureLayerPair
+
+  // for child features in relation:
+  property var linkedRelation
+  property var parentFeatureLayerPair
+
   property alias formState: formContainer.formState // add, edit or ReadOnly
   property alias panelState: statesManager.state
 
@@ -27,10 +31,11 @@ Item {
 
   property bool isReadOnly: featureLayerPair ? featureLayerPair.layer.readOnly : false
 
-  signal createFeature( var layer )
+  signal closed()
   signal closeDrawer()
   signal editGeometry( var pair )
-  signal closed()
+  signal openLinkedFeature( var linkedFeature )
+  signal createLinkedFeature( var parentFeature, var relation )
 
   function updateFeatureGeometry() {
     formContainer.updateFeatureGeometry()
@@ -123,15 +128,20 @@ Item {
     FeatureFormPage {
       id: formContainer
 
+      anchors.fill: parent
+
       project: root.project
       featureLayerPair: root.featureLayerPair
-      parentFeatureLayerPair: root.parentFeatureLayerPair
-      formState: root.formState
 
-      anchors.fill: parent
+      linkedRelation: root.linkedRelation
+      parentFeatureLayerPair: root.parentFeatureLayerPair
+
+      formState: root.formState
 
       onClose: root.panelState = "closed"
       onEditGeometryClicked: root.panelState = "editingGeometry"
+      onOpenLinkedFeature: root.openLinkedFeature( linkedFeature )
+      onCreateLinkedFeature: root.createLinkedFeature( parentFeature, relation )
     }
   }
 }

--- a/app/qml/form/FormWrapper.qml
+++ b/app/qml/form/FormWrapper.qml
@@ -21,7 +21,7 @@ Item {
 
   // for child features in relation:
   property var linkedRelation
-  property var parentFeatureLayerPair
+  property var parentController
 
   property alias formState: formContainer.formState // add, edit or ReadOnly
   property alias panelState: statesManager.state
@@ -35,7 +35,7 @@ Item {
   signal closeDrawer()
   signal editGeometry( var pair )
   signal openLinkedFeature( var linkedFeature )
-  signal createLinkedFeature( var parentFeature, var relation )
+  signal createLinkedFeature( var parentController, var relation )
 
   function updateFeatureGeometry() {
     formContainer.updateFeatureGeometry()
@@ -134,14 +134,14 @@ Item {
       featureLayerPair: root.featureLayerPair
 
       linkedRelation: root.linkedRelation
-      parentFeatureLayerPair: root.parentFeatureLayerPair
+      parentController: root.parentController
 
       formState: root.formState
 
       onClose: root.panelState = "closed"
       onEditGeometryClicked: root.panelState = "editingGeometry"
       onOpenLinkedFeature: root.openLinkedFeature( linkedFeature )
-      onCreateLinkedFeature: root.createLinkedFeature( parentFeature, relation )
+      onCreateLinkedFeature: root.createLinkedFeature( parentController, relation )
     }
   }
 }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -748,6 +748,7 @@ ApplicationWindow {
         width: window.width
         previewHeight: window.height/3
 
+        digitizingController: digitizing
         project: __loader.project
 
         onEditGeometry: {

--- a/app/relationfeaturesmodel.cpp
+++ b/app/relationfeaturesmodel.cpp
@@ -17,7 +17,6 @@ RelationFeaturesModel::RelationFeaturesModel( QObject *parent )
 
 RelationFeaturesModel::~RelationFeaturesModel()
 {
-  QObject::disconnect( mRelation.referencingLayer(), nullptr, nullptr, nullptr );
 }
 
 void RelationFeaturesModel::setup()

--- a/app/relationfeaturesmodel.h
+++ b/app/relationfeaturesmodel.h
@@ -40,7 +40,7 @@ class RelationFeaturesModel : public FeaturesListModel
     FeatureLayerPair parentFeatureLayerPair() const;
     QgsRelation relation() const;
 
-public slots:
+  public slots:
     void onChildLayerChanged();
 
   signals:

--- a/app/relationfeaturesmodel.h
+++ b/app/relationfeaturesmodel.h
@@ -29,7 +29,7 @@ class RelationFeaturesModel : public FeaturesListModel
   public:
 
     explicit RelationFeaturesModel( QObject *parent = nullptr );
-    virtual ~RelationFeaturesModel() {};
+    virtual ~RelationFeaturesModel();
 
     void setup(); // will be override
     void populate(); // will be override
@@ -39,6 +39,9 @@ class RelationFeaturesModel : public FeaturesListModel
 
     FeatureLayerPair parentFeatureLayerPair() const;
     QgsRelation relation() const;
+
+public slots:
+    void onChildLayerChanged();
 
   signals:
     void parentFeatureLayerPairChanged( FeatureLayerPair pair );


### PR DESCRIPTION
Added ability to work with child features in relations. 

When creating new child feature, `Relation Reference` field is automatically prefilled with its parent id. This is done by assigning the AttributeController with `parentController` (of type AttributeController) and `linkedRelation` (of type QgsRelation). When both properties are assigned, (child) controller looks for relation reference field and updates its value with parent's id.

However, if parent id is not yet valid (in case the parent feature is also being just created), we first commit the parent feature to get its id and then update the child feature relation reference field. To be able to do this, child controller is listening on `featureIdChanged` signal from parent controller.

When you cancel creation of parent feature that was already committed due to a child feature creation, we detect this and remove the parent feature. **However, child features remain created and also their relation reference fields are assigned**.

Todo:
 - [x] fix conflicts (incorporate photo widget)
 - [x] fix focus management (back button)

Further UI changes together with missing _Add feature_ and _More_ icons will be added in #1530

https://user-images.githubusercontent.com/22449698/124115199-ca953a80-da6d-11eb-91bd-dbbee7eb5bb6.mp4

Closes #1514 