### PR TITLE
Fixed value relation widget error

### DIFF
--- a/app/featureslistmodel.cpp
+++ b/app/featureslistmodel.cpp
@@ -356,7 +356,7 @@ QVariant FeaturesListModel::attributeFromValue( const int role, const QVariant &
   for ( int i = 0; i < mFeatures.count(); ++i )
   {
     QVariant d = data( index( i, 0 ), role );
-    if ( d == value )
+    if ( d.toString().trimmed() == value.toString().trimmed() )
     {
       QVariant key = data( index( i, 0 ), requestedRole );
       return key;

--- a/app/qml/editor/inputvaluerelation.qml
+++ b/app/qml/editor/inputvaluerelation.qml
@@ -100,7 +100,7 @@ Item {
     * in order to get values as
     */
   function getCurrentValueAsFeatureId() {
-    if ( allowMultipleValues && widgetValue != null && widgetValue.startsWith('{') )
+    if ( allowMultipleValues && widgetValue != null && widgetValue.toString().startsWith('{') )
     {
       let arr = vrModel.convertMultivalueFormat( widgetValue, FeaturesListModel.FeatureId )
       return Object.values(arr)
@@ -122,7 +122,7 @@ Item {
     let reset = false
 
     if ( widgetType === "textfield" ) {
-      if ( allowMultipleValues && widgetValue.startsWith('{') )
+      if ( allowMultipleValues && widgetValue.toString().startsWith('{') )
       {
         let strings = vrModel.convertMultivalueFormat( widgetValue )
         textField.text = strings.join(", ")


### PR DESCRIPTION
- The widgets generates the error while calling string function on QVariant (with number value): closes #1522 
- Removed white spaces from value comparison: closes #1498 


