### PR TITLE
Fixed of cascaded expression evaluation

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -539,6 +539,8 @@ bool AttributeController::recalculateDefaultValues(
           if ( val != oldVal )
           {
             mFeatureLayerPair.featureRef().setAttribute( item->fieldIndex(), val );
+            // Update also expression context after an attribute change
+            expressionContext.setFeature( featureLayerPair().featureRef() );
             changedFormItems.insert( item->id() );
             hasChanges = true;
           }


### PR DESCRIPTION
The issue seems to be related with evaluation of cascade expressions, when expression value depends on another expression value that has been evaluated just before.
Seems like updating expression context has fixed it.

closes #1543 