### PR TITLE
Temporary fix qgsquick check by comparing Input-SDK QGIS version

### DIFF
--- a/.github/workflows/qgsquick.yml
+++ b/.github/workflows/qgsquick.yml
@@ -10,6 +10,10 @@ jobs:
       - name: download qgis
         run: |
           git clone https://github.com/qgis/QGIS.git --depth 1
+          cd QGIS
+          git fetch --depth 1 origin 1d17bf5bd35d7872f53c8e1c8b0a1e371616bf07
+          git checkout FETCH_HEAD
+          cd ..
 
       - name: run check the qgsquick is up-to-date
         run: |

--- a/.github/workflows/qgsquick.yml
+++ b/.github/workflows/qgsquick.yml
@@ -1,5 +1,8 @@
 name: QgsQuick
 on: [push]
+env:
+  QGIS_COMMIT_HASH: 1d17bf5bd35d7872f53c8e1c8b0a1e371616bf07
+
 jobs:
   qgsquick_up_to_date:
     if: ( github.repository == 'lutraconsulting/input' ) && (!contains(github.event.head_commit.message, 'Translate '))
@@ -11,7 +14,7 @@ jobs:
         run: |
           git clone https://github.com/qgis/QGIS.git --depth 1
           cd QGIS
-          git fetch --depth 1 origin 1d17bf5bd35d7872f53c8e1c8b0a1e371616bf07
+          git fetch --depth 1 origin ${QGIS_COMMIT_HASH}
           git checkout FETCH_HEAD
           cd ..
 


### PR DESCRIPTION
We are currently not using the most recent qgsquick version from QGIS and so qgsquick check is always failing. 

I changed it to be compared to the version from Input-SDK https://github.com/lutraconsulting/input-sdk/blob/2d4d7623320df72c1c779196d62ccd47305caba5/android/recipes/qgis/recipe.sh#L10