### PR TITLE
Selective sync

### DIFF
--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -1543,7 +1543,7 @@ void TestMerginApi::testSelectiveSync()
 
   // Create photo files
   QDir dir;
-  QString photoPath( projectDir + "/do_not_upload" );
+  QString photoPath( projectDir + "/subdir" );
   if ( !dir.exists( photoPath ) )
     dir.mkpath( photoPath );
 
@@ -1555,10 +1555,10 @@ void TestMerginApi::testSelectiveSync()
 
   // Download the project and copy mergin config file containing selective sync properties
   downloadRemoteProject( mApiExtra, mUsername, projectName );
-  QString configFilePathExtra( projectDirExtra + "/.mergin-config.json" );
+  QString configFilePathExtra( projectDirExtra + "/mergin-config.json" );
   QVERIFY( QFile::copy( mTestDataPath + "/mergin-config-project-dir.json", configFilePathExtra ) );
 
-  // Sync event 1
+  // Sync event 1:
   // Client 1 uploads images
   uploadRemoteProject( mApi, mUsername, projectName );
   // Download project and check
@@ -1567,21 +1567,21 @@ void TestMerginApi::testSelectiveSync()
   QFile fileExtra( projectDirExtra + "/photo.jpg" );
   QVERIFY( !fileExtra.exists() );
 
-  QFile fileExtra1( projectDirExtra + "/do_not_upload/photo.jpg" );
+  QFile fileExtra1( projectDirExtra + "/subdir/photo.jpg" );
   QVERIFY( !fileExtra1.exists() );
 
   // Sync event 2:
-  // Client 2: upload an image
-  QString configFilePath( projectDir + "/.mergin-config.json" );
+  // Client 2 uploads an image
+  QString configFilePath( projectDir + "/mergin-config.json" );
   QVERIFY( QFile::copy( mTestDataPath + "/mergin-config-project-dir.json", configFilePath ) );
 
   QFile fileExtra2( projectDirExtra + "/" + "photoExtra.png" );
   fileExtra2.open( QIODevice::WriteOnly );
 
-  // Client  2 uploads a new image
+  // Client 2 uploads a new image
   uploadRemoteProject( mApiExtra, mUsername, projectName );
 
-  // Client 1: sync without Client 2 new image and without removing own images.
+  // Client 1 syncs without Client 2's new image and without removing own images.
   downloadRemoteProject( mApi, mUsername, projectName );
 
   QVERIFY( file.exists() );
@@ -1639,7 +1639,10 @@ void TestMerginApi::testExludeFromSync()
 
   QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/not-existing.jpg", config ) );
   QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/image.png", config ) );
+  QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/image.PNG", config ) );
   QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/image.jpg", config ) );
+  QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/image.JPG", config ) );
+  QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/image.jpeg", config ) );
   QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/image.JPEG", config ) );
   QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/subdir/image.jpg", config ) );
 

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -108,7 +108,7 @@ void TestMerginApi::initTestCase()
   deleteRemoteProject( mApiExtra, mUsername, "testMigrateDetachProject" );
   deleteRemoteProject( mApiExtra, mUsername, "testSelectiveSync" );
 
-  deleteLocalDir( mApi->projectsPath() + "/testExludeFromSync" );
+  deleteLocalDir( mApi, "testExcludeFromSync" );
 }
 
 void TestMerginApi::cleanupTestCase()
@@ -1609,10 +1609,10 @@ void TestMerginApi::testRegister()
   QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
 }
 
-void TestMerginApi::testExludeFromSync()
+void TestMerginApi::testExcludeFromSync()
 {
   // Set selective sync directory
-  QString selectiveSyncDir( mApi->projectsPath() + "/testExludeFromSync" );
+  QString selectiveSyncDir( mApi->projectsPath() + "/testExcludeFromSync" );
 
   QList<QString> testFiles =
   {
@@ -1705,9 +1705,9 @@ void TestMerginApi::deleteLocalProject( MerginApi *api, const QString &projectNa
   api->localProjectsManager().removeLocalProject( project.id() );
 }
 
-void TestMerginApi::deleteLocalDir( const QString &dirPath )
+void TestMerginApi::deleteLocalDir( MerginApi *api, const QString &dirPath )
 {
-  QDir dir( dirPath );
+  QDir dir( api->projectsPath() + "/" + dirPath );
   QVERIFY( dir.removeRecursively() );
 }
 

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -106,6 +106,9 @@ void TestMerginApi::initTestCase()
   deleteRemoteProject( mApiExtra, mUsername, "testMigrateProject" );
   deleteRemoteProject( mApiExtra, mUsername, "testMigrateProjectAndSync" );
   deleteRemoteProject( mApiExtra, mUsername, "testMigrateDetachProject" );
+  deleteRemoteProject( mApiExtra, mUsername, "testSelectiveSync" );
+
+  deleteLocalDir( mApi->projectsPath() + "/testExludeFromSync" );
 }
 
 void TestMerginApi::cleanupTestCase()
@@ -1062,7 +1065,7 @@ void TestMerginApi::testDiffUpload()
 
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );  // no local changes expected
 
-  // replace gpkg with a new version with a modified geometry
+  // replace gpkg with a ne w version with a modified geometry
   QFile::remove( projectDir + "/base.gpkg" );
   QFile::copy( mTestDataPath + "/modified_1_geom.gpkg", projectDir + "/base.gpkg" );
 
@@ -1524,6 +1527,69 @@ void TestMerginApi::testMigrateDetachProject()
   QVERIFY( !QFileInfo::exists( projectDir + "/.mergin/" ) );
 }
 
+void TestMerginApi::testSelectiveSync()
+{
+  // Case: Clients have following configuration: selective sync on, selective-sync-dir empty (project dir by default)
+  // Action 1: Client 1 uploads some images and Client 2 sync without downloading the images
+  // Action 2: Client 2 uploads an image and do not remove not-synced images. Client 1 syncs without downloading the image, still having own images.
+
+  // Create a project
+  QString projectName = "testSelectiveSync";
+  QString projectDir = mApi->projectsPath() + "/" + projectName;
+  QString projectDirExtra = mApiExtra->projectsPath() + "/" + projectName;
+
+  createRemoteProject( mApiExtra, mUsername, projectName, mTestDataPath + "/" + TEST_PROJECT_NAME + "/" );
+  downloadRemoteProject( mApi, mUsername, projectName );
+
+  // Create photo files
+  QDir dir;
+  QString photoPath( projectDir + "/do_not_upload" );
+  if ( !dir.exists( photoPath ) )
+    dir.mkpath( photoPath );
+
+  QFile file( projectDir + "/" + "photo.jpg" );
+  file.open( QIODevice::WriteOnly );
+
+  QFile file1( photoPath + "/" + "photo.jpg" );
+  file1.open( QIODevice::WriteOnly );
+
+  // Download the project and copy mergin config file containing selective sync properties
+  downloadRemoteProject( mApiExtra, mUsername, projectName );
+  QString configFilePathExtra( projectDirExtra + "/.mergin-config.json" );
+  QVERIFY( QFile::copy( mTestDataPath + "/mergin-config-project-dir.json", configFilePathExtra ) );
+
+  // Sync event 1
+  // Client 1 uploads images
+  uploadRemoteProject( mApi, mUsername, projectName );
+  // Download project and check
+  downloadRemoteProject( mApiExtra, mUsername, projectName );
+
+  QFile fileExtra( projectDirExtra + "/photo.jpg" );
+  QVERIFY( !fileExtra.exists() );
+
+  QFile fileExtra1( projectDirExtra + "/do_not_upload/photo.jpg" );
+  QVERIFY( !fileExtra1.exists() );
+
+  // Sync event 2:
+  // Client 2: upload an image
+  QString configFilePath( projectDir + "/.mergin-config.json" );
+  QVERIFY( QFile::copy( mTestDataPath + "/mergin-config-project-dir.json", configFilePath ) );
+
+  QFile fileExtra2( projectDirExtra + "/" + "photoExtra.png" );
+  fileExtra2.open( QIODevice::WriteOnly );
+
+  // Client  2 uploads a new image
+  uploadRemoteProject( mApiExtra, mUsername, projectName );
+
+  // Client 1: sync without Client 2 new image and without removing own images.
+  downloadRemoteProject( mApi, mUsername, projectName );
+
+  QVERIFY( file.exists() );
+  QVERIFY( file1.exists() );
+  QFile file2( projectDir + "/" + "photoExtra.png" );
+  QVERIFY( !file2.exists() );
+}
+
 void TestMerginApi::testRegister()
 {
   QString password = mApi->userAuth()->password();
@@ -1541,6 +1607,48 @@ void TestMerginApi::testRegister()
   QSignalSpy spy( mApi,  &MerginApi::registrationSucceeded );
   mApi->registerUser( username, email, password, password, true );
   QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
+}
+
+void TestMerginApi::testExludeFromSync()
+{
+  // Set selective sync directory
+  QString selectiveSyncDir( mApi->projectsPath() + "/testExludeFromSync" );
+
+  QList<QString> testFiles =
+  {
+    selectiveSyncDir + "/data.gpkg",
+    selectiveSyncDir + "/image.png",
+    selectiveSyncDir + "/image.jpg",
+    selectiveSyncDir + "/image.HEIF",
+    selectiveSyncDir + "/subdir/image.jpg"
+  };
+
+  for ( QString path : testFiles )
+  {
+    QFile file( path );
+    file.open( QIODevice::WriteOnly );
+  }
+
+  MerginConfig config;
+  config.selectiveSyncEnabled = true;
+  config.selectiveSyncDir = selectiveSyncDir;
+
+  QVERIFY( !mApi->excludeFromSync( selectiveSyncDir, config ) );
+  QVERIFY( !mApi->excludeFromSync( selectiveSyncDir + "/data.gpkg", config ) );
+  QVERIFY( !mApi->excludeFromSync( selectiveSyncDir + "/not-existing.file", config ) );
+
+  QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/not-existing.jpg", config ) );
+  QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/image.png", config ) );
+  QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/image.jpg", config ) );
+  QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/image.JPEG", config ) );
+  QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/subdir/image.jpg", config ) );
+
+  config.selectiveSyncDir = selectiveSyncDir + "/subdir";
+  QVERIFY( !mApi->excludeFromSync( selectiveSyncDir + "/image.jpg", config ) );
+  QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/subdir/image.jpg", config ) );
+
+  config.selectiveSyncDir.clear();
+  QVERIFY( mApi->excludeFromSync( selectiveSyncDir + "/image.jpg", config ) );
 }
 
 //////// HELPER FUNCTIONS ////////
@@ -1590,10 +1698,14 @@ void TestMerginApi::deleteLocalProject( MerginApi *api, const QString &projectNa
   LocalProject project = api->getLocalProject( MerginApi::getFullProjectName( projectNamespace, projectName ) );
   QVERIFY( project.isValid() );
   QVERIFY( project.projectDir.startsWith( api->projectsPath() ) );  // just to make sure we don't delete something wrong (-:
-//  QDir projectDir( project.projectDir );
-//  projectDir.removeRecursively();
 
   api->localProjectsManager().removeLocalProject( project.id() );
+}
+
+void TestMerginApi::deleteLocalDir( const QString &dirPath )
+{
+  QDir dir( dirPath );
+  QVERIFY( dir.removeRecursively() );
 }
 
 void TestMerginApi::downloadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName )

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -1065,7 +1065,7 @@ void TestMerginApi::testDiffUpload()
 
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );  // no local changes expected
 
-  // replace gpkg with a ne w version with a modified geometry
+  // replace gpkg with a new version with a modified geometry
   QFile::remove( projectDir + "/base.gpkg" );
   QFile::copy( mTestDataPath + "/modified_1_geom.gpkg", projectDir + "/base.gpkg" );
 

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -71,7 +71,7 @@ class TestMerginApi: public QObject
     void testRegister();
 
     // mergin functions
-    void testExludeFromSync();
+    void testExcludeFromSync();
 
   private:
     MerginApi *mApi;
@@ -104,7 +104,7 @@ class TestMerginApi: public QObject
     void deleteLocalProject( MerginApi *api, const QString &projectNamespace, const QString &projectName );
 
     //! Recursively deletes directory and its content.
-    void deleteLocalDir( const QString &dirPath );
+    void deleteLocalDir( MerginApi *api, const QString &dirPath );
 
     //! Write all of "data" as the content to the given filename
     void writeFileContent( const QString &filename, const QByteArray &data );

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -66,8 +66,12 @@ class TestMerginApi: public QObject
     void testMigrateProject();
     void testMigrateProjectAndSync();
     void testMigrateDetachProject();
+    void testSelectiveSync();
 
     void testRegister();
+
+    // mergin functions
+    void testExludeFromSync();
 
   private:
     MerginApi *mApi;
@@ -98,6 +102,9 @@ class TestMerginApi: public QObject
 
     //! Deletes a project from the local drive
     void deleteLocalProject( MerginApi *api, const QString &projectNamespace, const QString &projectName );
+
+    //! Recursively deletes directory and its content.
+    void deleteLocalDir( const QString &dirPath );
 
     //! Write all of "data" as the content to the given filename
     void writeFileContent( const QString &filename, const QByteArray &data );

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -29,10 +29,10 @@
 #include <geodiff.h>
 
 const QString MerginApi::sMetadataFile = QStringLiteral( "/.mergin/mergin.json" );
-const QString MerginApi::sMerginConfigFile = QStringLiteral( "/.mergin-config.json" );
+const QString MerginApi::sMerginConfigFile = QStringLiteral( "/mergin-config.json" );
 const QString MerginApi::sDefaultApiRoot = QStringLiteral( "https://public.cloudmergin.com/" );
 const QSet<QString> MerginApi::sIgnoreExtensions = QSet<QString>() << "gpkg-shm" << "gpkg-wal" << "qgs~" << "qgz~" << "pyc" << "swap";
-const QSet<QString> MerginApi::sIgnoreImageExtensions = QSet<QString>() << "jpg" << "JPEG" << "png";
+const QSet<QString> MerginApi::sIgnoreImageExtensions = QSet<QString>() << "jpg" << "jpeg" << "png";
 const QSet<QString> MerginApi::sIgnoreFiles = QSet<QString>() << "mergin.json" << ".DS_Store";
 const int MerginApi::UPLOAD_CHUNK_SIZE = 10 * 1024 * 1024; // Should be the same as on Mergin server
 
@@ -285,13 +285,13 @@ MerginConfig MerginApi::parseMerginConfig( const QString &projectDir )
     }
     else
     {
-      qDebug() << "MerginConfig: invalid content!";
+      qDebug() << "MerginConfig: Invalid content of the config file!";
     }
 
   }
   else
   {
-    qDebug() << "MerginConfig: cannot read a config file!";
+    qDebug() << "MerginConfig: Project does not contain a config file.";
   }
 
   return config;
@@ -1998,10 +1998,6 @@ void MerginApi::uploadInfoReplyFinished()
     QList<MerginFile> diffFiles;
     for ( QString filePath : transaction.diff.localAdded )
     {
-      // filter out files from selective sync
-      if ( excludeFromSync( filePath, merginConfig ) )
-        continue;
-
       MerginFile merginFile = findFile( filePath, localFiles );
       merginFile.chunks = generateChunkIdsForSize( merginFile.size );
       addedMerginFiles.append( merginFile );
@@ -2655,14 +2651,14 @@ bool MerginApi::excludeFromSync( const QString &filePath, const MerginConfig &co
   if ( config.selectiveSyncEnabled )
   {
     QFileInfo info( filePath );
-    bool isImage = sIgnoreImageExtensions.contains( info.suffix() );
+    bool isExcludedFormat = sIgnoreImageExtensions.contains( info.suffix().toLower() );
     if ( config.selectiveSyncDir.isEmpty() )
     {
-      return isImage;
+      return isExcludedFormat;
     }
     else
     {
-      return info.absoluteFilePath().startsWith( config.selectiveSyncDir ) && isImage;
+      return info.absoluteFilePath().startsWith( config.selectiveSyncDir ) && isExcludedFormat;
     }
   }
   return false;

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -285,7 +285,7 @@ MerginConfig MerginApi::parseMerginConfig( const QString &projectDir )
     }
     else
     {
-      qDebug() << "MerginConfig: Invalid content of the config file!";
+      CoreUtils::log( QStringLiteral( "MerginConfig" ), QStringLiteral( "Invalid content of the config file!" ) );
     }
 
   }
@@ -1820,7 +1820,7 @@ void MerginApi::startProjectUpdate( const QString &projectFullName, const QByteA
   transaction.diff = compareProjectFiles( oldServerProject.files, serverProject.files, localFiles, transaction.projectDir );
   CoreUtils::log( "pull " + projectFullName, transaction.diff.dump() );
 
-  MerginConfig merginConfig = parseMerginConfig( transaction.projectDir );
+  const MerginConfig merginConfig = parseMerginConfig( transaction.projectDir );
 
   for ( QString filePath : transaction.diff.remoteAdded )
   {
@@ -2652,6 +2652,7 @@ bool MerginApi::excludeFromSync( const QString &filePath, const MerginConfig &co
   {
     QFileInfo info( filePath );
     bool isExcludedFormat = sIgnoreImageExtensions.contains( info.suffix().toLower() );
+
     if ( config.selectiveSyncDir.isEmpty() )
     {
       return isExcludedFormat;

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -29,8 +29,10 @@
 #include <geodiff.h>
 
 const QString MerginApi::sMetadataFile = QStringLiteral( "/.mergin/mergin.json" );
+const QString MerginApi::sMerginConfigFile = QStringLiteral( "/.mergin-config.json" );
 const QString MerginApi::sDefaultApiRoot = QStringLiteral( "https://public.cloudmergin.com/" );
 const QSet<QString> MerginApi::sIgnoreExtensions = QSet<QString>() << "gpkg-shm" << "gpkg-wal" << "qgs~" << "qgz~" << "pyc" << "swap";
+const QSet<QString> MerginApi::sIgnoreImageExtensions = QSet<QString>() << "jpg" << "JPEG" << "png";
 const QSet<QString> MerginApi::sIgnoreFiles = QSet<QString>() << "mergin.json" << ".DS_Store";
 const int MerginApi::UPLOAD_CHUNK_SIZE = 10 * 1024 * 1024; // Should be the same as on Mergin server
 
@@ -256,6 +258,43 @@ QString MerginApi::getApiKey( const QString &serverName )
     return secretKey;
 #endif
   return "not-secret-key";
+}
+
+MerginConfig MerginApi::parseMerginConfig( const QString &projectDir )
+{
+  QString configFilePath( projectDir + sMerginConfigFile );
+
+  MerginConfig config;
+  QFile file( configFilePath );
+
+  if ( file.open( QIODevice::ReadOnly ) )
+  {
+    QByteArray data = file.readAll();
+    QJsonDocument doc = QJsonDocument::fromJson( data );
+    if ( doc.isObject() )
+    {
+      QJsonObject docObj = doc.object();
+      config.selectiveSyncEnabled = docObj.value( QStringLiteral( "input-selective-sync" ) ).toBool( false );
+      QString selectiveSyncDir = docObj.value( QStringLiteral( "input-selective-sync-dir" ) ).toString();
+
+      if ( !selectiveSyncDir.isEmpty() )
+      {
+        QDir rootDir( projectDir );
+        config.selectiveSyncDir = rootDir.canonicalPath() + "/" + selectiveSyncDir;
+      }
+    }
+    else
+    {
+      qDebug() << "MerginConfig: invalid content!";
+    }
+
+  }
+  else
+  {
+    qDebug() << "MerginConfig: cannot read a config file!";
+  }
+
+  return config;
 }
 
 void MerginApi::downloadItemReplyFinished()
@@ -1781,8 +1820,14 @@ void MerginApi::startProjectUpdate( const QString &projectFullName, const QByteA
   transaction.diff = compareProjectFiles( oldServerProject.files, serverProject.files, localFiles, transaction.projectDir );
   CoreUtils::log( "pull " + projectFullName, transaction.diff.dump() );
 
+  MerginConfig merginConfig = parseMerginConfig( transaction.projectDir );
+
   for ( QString filePath : transaction.diff.remoteAdded )
   {
+    // filter out files from selective sync
+    if ( excludeFromSync( filePath, merginConfig ) )
+      continue;
+
     MerginFile file = serverProject.fileInfo( filePath );
     QList<DownloadQueueItem> items = itemsForFileChunks( file, transaction.version );
     transaction.updateTasks << UpdateTask( UpdateTask::Copy, filePath, items );
@@ -1834,6 +1879,10 @@ void MerginApi::startProjectUpdate( const QString &projectFullName, const QByteA
   // schedule removed files to be deleted
   for ( QString filePath : transaction.diff.remoteDeleted )
   {
+    // filter out files from selective sync
+    if ( excludeFromSync( filePath, merginConfig ) )
+      continue;
+
     transaction.updateTasks << UpdateTask( UpdateTask::Delete, filePath, QList<DownloadQueueItem>() );
   }
 
@@ -1937,6 +1986,7 @@ void MerginApi::uploadInfoReplyFinished()
 
     QList<MerginFile> localFiles = getLocalProjectFiles( transaction.projectDir + "/" );
     MerginProjectMetadata oldServerProject = MerginProjectMetadata::fromCachedJson( transaction.projectDir + "/" + sMetadataFile );
+    MerginConfig merginConfig = parseMerginConfig( transaction.projectDir );
 
     transaction.diff = compareProjectFiles( oldServerProject.files, serverProject.files, localFiles, transaction.projectDir );
     CoreUtils::log( "push " + projectFullName, transaction.diff.dump() );
@@ -1948,6 +1998,10 @@ void MerginApi::uploadInfoReplyFinished()
     QList<MerginFile> diffFiles;
     for ( QString filePath : transaction.diff.localAdded )
     {
+      // filter out files from selective sync
+      if ( excludeFromSync( filePath, merginConfig ) )
+        continue;
+
       MerginFile merginFile = findFile( filePath, localFiles );
       merginFile.chunks = generateChunkIdsForSize( merginFile.size );
       addedMerginFiles.append( merginFile );
@@ -1995,6 +2049,10 @@ void MerginApi::uploadInfoReplyFinished()
     }
     for ( QString filePath : transaction.diff.localDeleted )
     {
+      // filter out files from selective sync
+      if ( excludeFromSync( filePath, merginConfig ) )
+        continue;
+
       MerginFile merginFile = findFile( filePath, serverProject.files );
       deletedMerginFiles.append( merginFile );
     }
@@ -2590,6 +2648,24 @@ void MerginApi::createPathIfNotExists( const QString &filePath )
 bool MerginApi::isInIgnore( const QFileInfo &info )
 {
   return sIgnoreExtensions.contains( info.suffix() ) || sIgnoreFiles.contains( info.fileName() );
+}
+
+bool MerginApi::excludeFromSync( const QString &filePath, const MerginConfig &config )
+{
+  if ( config.selectiveSyncEnabled )
+  {
+    QFileInfo info( filePath );
+    bool isImage = sIgnoreImageExtensions.contains( info.suffix() );
+    if ( config.selectiveSyncDir.isEmpty() )
+    {
+      return isImage;
+    }
+    else
+    {
+      return info.absoluteFilePath().startsWith( config.selectiveSyncDir ) && isImage;
+    }
+  }
+  return false;
 }
 
 QByteArray MerginApi::getChecksum( const QString &filePath )

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -387,6 +387,17 @@ class MerginApi: public QObject
     Transactions transactions() const { return mTransactionalStatus; }
 
     static bool isInIgnore( const QFileInfo &info );
+
+    /**
+     * Performs checks and returns if a given file is excluded from the sync.
+     * If selective-sync-enabled is true, it checks if a file extension is from exlcudeSync extension list.
+     * If selective-sync-dir is defined, additionally checks, if the file is located in selective-sync-dir or in its subdir,
+     * otherwise a project dir is considered as selective-sync-dir and therefore the path check is redundant
+     * (since given filePath is relative to the project dir.).
+     * @param filePath Relative path of a file to project directory.
+     * @param config MerginConfig parsed from JSON, selective-sync properties are read from it.
+     * @return True, if a file at given filePath suppose to be excluded from sync.
+     */
     static bool excludeFromSync( const QString &filePath, const MerginConfig &config );
     static MerginConfig parseMerginConfig( const QString &projectDir );
 

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -172,6 +172,13 @@ typedef QHash<QString, TransactionStatus> Transactions;
 
 Q_DECLARE_METATYPE( Transactions );
 
+//! MerginConfig stored in .mergin-config.json
+struct MerginConfig
+{
+  bool selectiveSyncEnabled = false;
+  QString selectiveSyncDir;
+};
+
 class MerginApi: public QObject
 {
     Q_OBJECT
@@ -315,6 +322,7 @@ class MerginApi: public QObject
     static const int MERGIN_API_VERSION_MAJOR = 2020;
     static const int MERGIN_API_VERSION_MINOR = 4;
     static const QString sMetadataFile;
+    static const QString sMerginConfigFile;
     static const QString sDefaultApiRoot;
 
     static QString defaultApiRoot() { return sDefaultApiRoot; }
@@ -379,6 +387,9 @@ class MerginApi: public QObject
     Transactions transactions() const { return mTransactionalStatus; }
 
     static bool isInIgnore( const QFileInfo &info );
+    static bool excludeFromSync( const QString &filePath, const MerginConfig &config );
+    static MerginConfig parseMerginConfig( const QString &projectDir );
+
     bool apiSupportsSubscriptions() const;
     void setApiSupportsSubscriptions( bool apiSupportsSubscriptions );
 
@@ -419,6 +430,7 @@ class MerginApi: public QObject
     void serverProjectDeleted( const QString &projecFullName, bool result );
     void userInfoChanged();
     void subscriptionInfoChanged();
+    void configChanged();
     void pingMerginFinished( const QString &apiVersion, bool serverSupportsSubscriptions, const QString &msg );
     void pullFilesStarted();
     //! Emitted when started to upload chunks (useful for unit testing)
@@ -563,6 +575,7 @@ class MerginApi: public QObject
 
     Transactions mTransactionalStatus; //projectFullname -> transactionStatus
     static const QSet<QString> sIgnoreExtensions;
+    static const QSet<QString> sIgnoreImageExtensions;
     static const QSet<QString> sIgnoreFiles;
     QEventLoop mAuthLoopEvent;
     MerginApiStatus::VersionStatus mApiVersionStatus = MerginApiStatus::VersionStatus::UNKNOWN;

--- a/test/test_data/mergin-config-project-dir.json
+++ b/test/test_data/mergin-config-project-dir.json
@@ -1,0 +1,4 @@
+{
+  "input-selective-sync": true,
+  "input-selective-sync-dir": "" 
+}


### PR DESCRIPTION
### Description
To prevent download images files to Input client from the server.

Selective sync is supported only on Input (client) and has to be configured manually ATM by defining a config file. The idea is to have a tool for setting a configuration up in the mergin plugin.

Note that only images files (not case sensitive extensions: *.jpg, *.jpeg, *.png) are restricted from the sync which are located at `input-selective-sync-dir` or its subdirectories - a client can upload images, but doesn't download images from the server according the configuration. However, all images files are listed in `.mergin.json`. 

The config file:
- named as `mergin-config.json`
- is located in the project directory
- has JSON format
- is rather generic so can be used not only for selective-sync
- contains following variables:
    - `input-selective-sync`: `true/false`
    - `input-selective-sync-dir`: `<relative-path-to-project-dir>`; if empty, project directory is considered for selective sync.

Related automatic tests have been added.

### To improve:
A) **`mergin-config.json` location**
Since Input ignores hidden files ATM, mergin-config.json is located in the project directory. The best would be to hide it either to .mergin folder or just make it as a hidden file, but with ability to sync. Note that it can be modified over time although Input suppose to only read it.

B) **The initial download use case**
When an Input client downloads a project for the first time, the mergin-config is suppose to be downloaded as well, thus selective sync is not configured at that state. The best would be request mergin config from a server in advance and then continue with download/sync having mergin-config context already set up. Or, request a mergin config as the very first file for the download if its listed in remotely added files.

C) **New status for images in the photo widget**
When some photos are excluded from the sync and therefore not present on client's drive, but actually are used as value for an attachment field, the external resource widget shows it as missing image. The better would be to notify user that the image is stored on server and it only hasn't been synced on the user's device due to selective sync.

close #911 


