### PR TITLE
Add features with geometry from relations widget

### DIFF
--- a/app/qml/editor/inputrelationreference.qml
+++ b/app/qml/editor/inputrelationreference.qml
@@ -18,6 +18,8 @@ import ".."
 AbstractEditor {
   id: root
 
+  property var parentValue: root.parent.value
+
   signal valueChanged( var value, bool isNull )
   signal openLinkedFeature( var linkedFeature )
 
@@ -36,7 +38,7 @@ AbstractEditor {
     page.forceActiveFocus()
   }
 
-  onValueChanged: title.text = rModel.attributeFromValue( FeaturesListModel.FeatureId, value, FeaturesListModel.FeatureTitle ) || ""
+  onParentValueChanged: title.text = rModel.attributeFromValue( FeaturesListModel.FeatureId, value, FeaturesListModel.FeatureTitle ) || ""
 
   RelationReferenceFeaturesModel {
     id: rModel

--- a/app/qml/form/FeatureFormPage.qml
+++ b/app/qml/form/FeatureFormPage.qml
@@ -32,11 +32,11 @@ Item {
   signal openLinkedFeature( var linkedFeature )
   signal createLinkedFeature( var parentController, var relation )
 
-  function isNewFeature() {
+  function updateFeatureGeometry() {
     let f = formStackView.get( 0 )
 
     if ( f ) {
-      return f.form.controller.isNewFeature()
+      f.form.controller.save()
     }
   }
 

--- a/app/qml/form/FormWrapper.qml
+++ b/app/qml/form/FormWrapper.qml
@@ -32,15 +32,21 @@ Item {
   property bool isReadOnly: featureLayerPair ? featureLayerPair.layer.readOnly : false
 
   signal closed()
-  signal closeDrawer()
+  signal editGeometry( var pair )
   signal openLinkedFeature( var linkedFeature )
   signal createLinkedFeature( var parentController, var relation )
 
-  function isNewFeature() {
-    return formContainer.isNewFeature()
+  function updateFeatureGeometry() {
+    formContainer.updateFeatureGeometry()
   }
 
-  onCloseDrawer: drawer.close()
+  function openDrawer() {
+    root.panelState = "form"
+  }
+
+  function closeDrawer() {
+    drawer.close()
+  }
 
   Drawer {
     id: drawer
@@ -66,6 +72,9 @@ Item {
         },
         State {
           name: "closed"
+        },
+        State {
+          name: "editGeometry"
         }
       ]
 
@@ -76,7 +85,10 @@ Item {
             drawer.open();
             break;
           case "closed":
-            root.closed()
+            root.closed();
+            break;
+          case "editGeometry":
+            break;
         }
       }
     }
@@ -92,7 +104,10 @@ Item {
     edge: Qt.BottomEdge
     closePolicy: Popup.CloseOnEscape // prevents the drawer closing while moving canvas
 
-    onClosed: statesManager.state = "closed"
+    onClosed: {
+      if ( statesManager.state !== "editGeometry" )
+        statesManager.state = "closed"
+    }
 
     PreviewPanel {
       id: previewPanel
@@ -124,7 +139,10 @@ Item {
       formState: root.formState
 
       onClose: root.panelState = "closed"
-      onEditGeometryClicked: console.log( "NOT IMPLEMENTED" )
+      onEditGeometryClicked: {
+        root.editGeometry( root.featureLayerPair )
+        root.panelState = "editGeometry"
+      }
       onOpenLinkedFeature: root.openLinkedFeature( linkedFeature )
       onCreateLinkedFeature: root.createLinkedFeature( parentController, relation )
     }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -41,6 +41,9 @@ ApplicationWindow {
             State {
                 name: "record"
             },
+            State {
+                name: "edit"
+            },
             // Listing projects
             State {
                 name: "projects"
@@ -54,6 +57,9 @@ ApplicationWindow {
             }
             else if ( stateManager.state === "record" ) {
               map.state = "recordFeature"
+            }
+            else if ( stateManager.state === "edit" ) {
+              map.state = "editGeometry"
             }
             else if ( stateManager.state === "projects" ) {
               projectPanel.openPanel()
@@ -128,6 +134,16 @@ ApplicationWindow {
 
       onFeatureIdentified: formsStackManager.openForm( pair, "readOnly", "preview" )
       onNothingIdentified: formsStackManager.closeDrawer()
+
+      onEditingGeometryStarted: formsStackManager.geometryEditingStarted()
+      onEditingGeometryFinished: {
+        formsStackManager.geometryEditingFinished( pair )
+        stateManager.state = "view"
+      }
+      onEditingGeometryCanceled: {
+        formsStackManager.geometryEditingFinished( null, false )
+        stateManager.state = "view"
+      }
 
       onRecordingFinished: {
         formsStackManager.openForm( pair, "add", "form" )
@@ -301,6 +317,12 @@ ApplicationWindow {
       onCreateLinkedFeatureRequested: {
         let newPair = map.createFeature( relation.referencingLayer )
         formsStackManager.addLinkedFeature( newPair, parentController, relation )
+      }
+
+      onEditGeometryRequested: {
+        map.featurePairToEdit = pair
+        map.centerToPair( pair )
+        stateManager.state = "edit"
       }
 
       onClosed: {


### PR DESCRIPTION
This PR mainly adds possibility to create linked features in relation widget with geometry. 

Workflow: 
 1. Open form with relations widget 
 2. Click on `edit` (if it is form of existing feature)
 3. Click on `+ add` in relations widget
 4. If the linked layer has geometry, forms will hide and you will see map in record mode. After geometry is recorded, form will show up (including previously opened forms)
 5. If the linked layer is no geometry layer, just new form will be opened 

Technical details:
 - we have one map with different states (`view` / `edit geometry` / `record features` / `record features in specific layer only` <- used to create linked features )
 - we hide opened forms (close them without destroying, in state `hidden` ) when geometry is being edited or new feature is being recorded 

Note: PR also fixes previously not working geometry editing.

I will add video asap

Closes #1551 