### PR TITLE
Cache mergin config before update

### DIFF
--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -1558,6 +1558,9 @@ void TestMerginApi::testSelectiveSync()
   QString configFilePathExtra( projectDirExtra + "/mergin-config.json" );
   QVERIFY( QFile::copy( mTestDataPath + "/mergin-config-project-dir.json", configFilePathExtra ) );
 
+  // Upload config file
+  uploadRemoteProject( mApiExtra, mUsername, projectName );
+
   // Sync event 1:
   // Client 1 uploads images
   uploadRemoteProject( mApi, mUsername, projectName );
@@ -1572,8 +1575,6 @@ void TestMerginApi::testSelectiveSync()
 
   // Sync event 2:
   // Client 2 uploads an image
-  QString configFilePath( projectDir + "/mergin-config.json" );
-  QVERIFY( QFile::copy( mTestDataPath + "/mergin-config-project-dir.json", configFilePath ) );
 
   QFile fileExtra2( projectDirExtra + "/" + "photoExtra.png" );
   fileExtra2.open( QIODevice::WriteOnly );


### PR DESCRIPTION
Changed selective sync behavior to download mergin config file in advance of updating a project.

Current project update behavior:
 a) request project info
 b) if server project contains `mergin-config.json`: 
   1. request it
   2. cache mergin config to transaction
   
 c) proceed with project update and ignore files based on the cached config

Note: we also download the mergin-config file in order to be able to ignore files when doing upload (in this case we read the local version of the config). We also read the local config version when computing project state - because files that are not downloaded would be considered as `local deleted` in next sync

Note 2: If user would create `mergin-config.json` directly on his device, he needs to first sync it to server in order that it works!


 - [x] tests

Closes #1590 