### PR TITLE
Fix network unlimited error message

### DIFF
--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -363,7 +363,7 @@ void MerginApi::downloadItemReplyFinished()
 
     finishProjectSync( projectFullName, false );
 
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: downloadFile" ) );
+    emit networkErrorOccurred( QStringLiteral(), QStringLiteral( "Mergin API error: downloadFile" ) );
   }
 }
 
@@ -1140,7 +1140,8 @@ QString MerginApi::extractServerErrorMsg( const QByteArray &data )
   }
   else
   {
-    serverMsg = data;
+    // take only first 1000 bytes of the message ~ there are situations when data is an unclosed string that would eat the whole log memory
+    serverMsg = data.mid( 0, 1000 );
   }
 
   return serverMsg;


### PR DESCRIPTION
When synchronization is interrupted by loosing internet connection (e.g. turning off the wifi), Qt on Android _sometimes_ (unknown what causes this) returns reply with error message filled with extremely long (sometimes > 80.000 lines) hex message with random characters. Probably they did not put string terminating sign at the end or something similar. 

In Input we show user the response from server. On Android we use toasts for that. Android thus tried to display 80.000 lines of random chars in toast which resulted in ANR. 

Fixed this on two places: 
 - First, limited the number of chars we accept from network response (when the response is not in json format)
 - Second, we no longer show server error messages to user. Instead, general error message is showed in qml to user stating that there was a connection error. 

> NOTE: second fix is applied only on one place now: when user is doing download. We should probably change the code on different places too so that users would not see some NGINX errors coming from server (just like stated here https://github.com/lutraconsulting/input/issues/1523 or here https://github.com/lutraconsulting/input/issues/1558)

Fixes #1523 