### PR TITLE
Fix black GPS dot

### DIFF
--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -298,12 +298,12 @@ Item {
   StateGroup {
     id: _gpsState
 
-    property color indicatorColor
+    property color indicatorColor: InputStyle.softRed
 
     states: [
       State {
         name: "good"
-        when: ( _positionKit.accuracy > 0 ) && ( _positionKit.accuracy < __appSettings.gpsAccuracyTolerance )
+        when: ( _positionKit.accuracy > 0 ) && ( _positionKit.accuracy <= __appSettings.gpsAccuracyTolerance )
         PropertyChanges {
           target: _gpsState
           indicatorColor: InputStyle.softGreen


### PR DESCRIPTION
When state of `_gpsState` did not meet any criteria, it defaulted to black color.

Fixed by 1) initializing the gps indicator color and 2) making sure there is always one GPS state valid

Fixes #1601 