### PR TITLE
Show relation name when no label is provided

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -289,7 +289,11 @@ void AttributeController::flatten(
         }
 
         const QString groupName = container->isGroupBox() ? container->name() : QString();
-        const QString label = relationField->label();
+        QString label = relationField->label();
+        if ( label.isEmpty() )
+        {
+          label = associatedRelation.name();
+        }
 
         std::shared_ptr<FormItem> formItemData =
           std::shared_ptr<FormItem>(


### PR DESCRIPTION
Uses `QgsRelation::name` when label is empty.

fixes #1569 