### PR TITLE
Fix inifnite loop when config is invalid

### DIFF
--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -72,6 +72,7 @@ class TestMerginApi: public QObject
     void testSelectiveSyncRemoveConfig();
     void testSelectiveSyncDisabledInConfig();
     void testSelectiveSyncChangeSyncFolder();
+    void testSelectiveSyncCorruptedFormat();
 
     void testRegister();
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1986,9 +1986,9 @@ void MerginApi::prepareDownloadConfig( const QString &projectFullName, bool down
 
   if ( !transaction.config.isValid )
   {
-      // if transaction is not valid, consider it as deleted
-      transaction.config.downloadMissingFiles = true;
-      CoreUtils::log( "MerginConfig", "Config has invalid structure, continuing as if project had no config" );
+    // if transaction is not valid, consider it as deleted
+    transaction.config.downloadMissingFiles = true;
+    CoreUtils::log( "MerginConfig", "Config has invalid structure, continuing as if project had no config" );
   }
   else if ( serverContainsConfig && previousVersionContainedConfig )
   {

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -575,7 +575,7 @@ class MerginApi: public QObject
     void startProjectUpdate( const QString &projectFullName );
 
     //! Takes care of finding the correct config file, appends it to current transaction and proceeds with project update
-    void prepareDownloadConfig( const QString &projectFullName );
+    void prepareDownloadConfig( const QString &projectFullName, bool downloaded = false );
     void requestServerConfig( const QString &projectFullName );
 
     //! Starts download request of another item

--- a/test/test_data/mergin-config-corrupted.json
+++ b/test/test_data/mergin-config-corrupted.json
@@ -1,0 +1,4 @@
+{
+  "input-selective-sync": true
+  "input-selective-sync-dir": "photos" 
+}


### PR DESCRIPTION
There was a case when `mergin-config.json` was invalid, Input would repeatedly ask Mergin for new one.

Fixed it by considering invalid config as if it would not exist. 
Fixes #1618 