### PR TITLE
Fix nested relations - geometry check

### DIFF
--- a/app/featurelayerpair.cpp
+++ b/app/featurelayerpair.cpp
@@ -60,10 +60,10 @@ bool FeatureLayerPair::hasValidGeometry() const
 {
   Q_ASSERT( mLayer );
 
-  if ( !mFeature.hasGeometry() )
-    return false;
+  if ( !mFeature.hasGeometry() && !mLayer->isSpatial() )
+    return true;
 
-  if ( mFeature.geometry().type() != mLayer->geometryType() )
+  if ( !mFeature.hasGeometry() || mFeature.geometry().type() != mLayer->geometryType() )
     return false;
 
   return true;


### PR DESCRIPTION
There was an issue that when you set up project with no geo layer having relation to other no geo layer, relations in forms did not work (you could not see any features).

This issue was actually in a way we check if feature is valid. For no geometry features, we **were always returning False!** 

Resolves #1624 

@wonder-sk could this potentially break something else?