### PR TITLE
Use specific macos version for CI

### DIFF
--- a/.github/workflows/autotests.yml
+++ b/.github/workflows/autotests.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   tests:
     if: ( github.repository == 'lutraconsulting/input' ) && (!contains(github.event.head_commit.message, 'Translate '))
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - name: Checkout Input
         uses: actions/checkout@v2
@@ -100,4 +100,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: build-Input/coverage.info
-

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   ios_build:
     if: ( github.repository == 'lutraconsulting/input' ) && (!contains(github.event.head_commit.message, 'Translate '))
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - name: Select latest Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XC_VERSION.app"


### PR DESCRIPTION
Use specific `macos-10.15` for iOS builds, latest is not working. Created bug #1690 