### PR TITLE
Autocommit input text only on Android to avoid iOs double typing

### DIFF
--- a/app/qml/editor/inputtextedit.qml
+++ b/app/qml/editor/inputtextedit.qml
@@ -71,6 +71,6 @@ AbstractEditor {
       editorValueChanged( val, val === "" )
     }
 
-    onPreeditTextChanged: Qt.inputMethod.commit() // to avoid Android's uncommited text
+    onPreeditTextChanged: if ( __androidUtils.isAndroid ) Qt.inputMethod.commit() // to avoid Android's uncommited text
   }
 }


### PR DESCRIPTION
We used to commit text right after user typed in a character to avoid uncommitted text on Android. This however made iOS to input characters on some keyboards twice. Fixed it to apply commit only on Android devices

Resolves #1708 