### PR TITLE
Fix value relations binding loops

### DIFF
--- a/app/qml/editor/inputvaluerelationcombobox.qml
+++ b/app/qml/editor/inputvaluerelationcombobox.qml
@@ -15,6 +15,7 @@ AbstractEditor {
   id: root
 
   /*required*/ property var parentValue: root.parent.value
+  /*required*/ property bool parentValueIsNull: root.parent.valueIsNull
   /*required*/ property var fieldConfig: root.parent.config
   /*required*/ property var featureLayerPair: root.parent.featurePair
   /*required*/ property var isReadOnly: root.parent.readOnly
@@ -60,10 +61,15 @@ AbstractEditor {
     pair: root.featureLayerPair
 
     onInvalidate: {
-      if ( !root.isReadOnly )
+      if ( root.parentValueIsNull )
       {
-        root.editorValueChanged( "", true )
+        return // ignore invalidate signal if value is already NULL
       }
+      if ( root.isReadOnly )
+      {
+        return // ignore invalidate signal if form is not in edit mode
+      }
+      root.editorValueChanged( "", true )
     }
   }
 

--- a/app/qml/editor/inputvaluerelationpage.qml
+++ b/app/qml/editor/inputvaluerelationpage.qml
@@ -18,6 +18,7 @@ AbstractEditor {
   id: root
 
   /*required*/ property var parentValue: root.parent.value
+  /*required*/ property bool parentValueIsNull: root.parent.valueIsNull
   /*required*/ property var fieldConfig: root.parent.config
   /*required*/ property var featureLayerPair: root.parent.featurePair
   /*required*/ property bool isReadOnly: root.parent.readOnly
@@ -72,10 +73,15 @@ AbstractEditor {
     pair: root.featureLayerPair
 
     onInvalidate: {
-      if ( !root.isReadOnly )
+      if ( root.parentValueIsNull )
       {
-        root.editorValueChanged( "", true )
+        return // ignore invalidate signal if value is already NULL
       }
+      if ( root.isReadOnly )
+      {
+        return // ignore invalidate signal if form is not in edit mode
+      }
+      root.editorValueChanged( "", true )
     }
   }
 

--- a/app/valuerelationfeaturesmodel.cpp
+++ b/app/valuerelationfeaturesmodel.cpp
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -65,6 +65,7 @@ void ValueRelationFeaturesModel::setup()
       FeaturesModel::setLayer( layer );
 
       mAllowMulti = mConfig.value( QStringLiteral( "AllowMulti" ) ).toBool();
+      mIsInitialized = true;
     }
     else
       CoreUtils::log( QStringLiteral( "ValueRelations" ), QStringLiteral( "Missing referenced fields for value relations." ) );
@@ -79,6 +80,7 @@ void ValueRelationFeaturesModel::reset()
   mTitleField.clear();
   mPair = FeatureLayerPair();
   mConfig = QVariantMap();
+  mIsInitialized = false;
   FeaturesModel::reset();
 }
 
@@ -100,6 +102,11 @@ QVariant ValueRelationFeaturesModel::convertToKey( const QVariant &id )
 
 QVariant ValueRelationFeaturesModel::convertToQgisType( const QVariantList &featureIds )
 {
+  if ( !mIsInitialized )
+  {
+    return QVariant();
+  }
+
   QVariant qgsFormat;
 
   QStringList keys;
@@ -115,6 +122,11 @@ QVariant ValueRelationFeaturesModel::convertToQgisType( const QVariantList &feat
 
 QVariant ValueRelationFeaturesModel::convertFromQgisType( QVariant qgsValue, ModelRoles toRole )
 {
+  if ( !mIsInitialized )
+  {
+    return QVariant();
+  }
+
   QStringList keyList;
 
   if ( mAllowMulti )
@@ -174,7 +186,7 @@ void ValueRelationFeaturesModel::setPair( const FeatureLayerPair &newPair )
   mPair = newPair;
   emit pairChanged( mPair );
 
-  if ( !mConfig.isEmpty() ) // setup already run
+  if ( mIsInitialized )
   {
     populate();
   }

--- a/app/valuerelationfeaturesmodel.h
+++ b/app/valuerelationfeaturesmodel.h
@@ -61,6 +61,8 @@ class ValueRelationFeaturesModel : public FeaturesModel
     QString mKeyField;
     QString mTitleField;
     QString mFilterExpression;
+
+    bool mIsInitialized = false; // model successfully read config and is ready to use
 };
 
 #endif // VALUERELATIONFEATURESMODEL_H


### PR DESCRIPTION
This PR fixes two different issues that led to binding loops and subsequently to app crashes:
 1. When value relation had incorrect path set in `LayerSource` config key (referenced layer was invalid), editor still tried to use convert functions from/to qgis vr format. This however led to unnecessary emission of `invalidate` signal, which resulted in loop and 💥. Fixed this by adding flag to VR model indicating if the model is ready to use ~ found a valid referenced layer.
 2. Emission of `invalidate` signal had one more issue - we emitted it even when value of the editor is already NULL. Added check that prevents emission of the signal in such case.

PR is marked as draft, because we want to imitate QGIS in case of the first issue - QGIS is somehow capable of resolving layer even with wrong path. cc @wonder-sk 

Resolves #1717 and resolves #1705 