### PR TITLE
Add attention banner

### DIFF
--- a/app/i18n/input_en.ts
+++ b/app/i18n/input_en.ts
@@ -349,12 +349,12 @@ Won&apos;t be added to the project.</source>
 <context>
     <name>InputHelp</name>
     <message>
-        <location filename="../inputhelp.cpp" line="216"/>
+        <location filename="../inputhelp.cpp" line="228"/>
         <source>Report submitted.%1Please contact us on%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../inputhelp.cpp" line="221"/>
+        <location filename="../inputhelp.cpp" line="233"/>
         <source>Failed to submit report.%1Please check your internet connection.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,6 +764,14 @@ Won&apos;t be added to the project.</source>
     </message>
 </context>
 <context>
+    <name>ProjectListPage</name>
+    <message>
+        <location filename="../qml/ProjectListPage.qml" line="50"/>
+        <source>Your attention is required. Please visit the %1Mergin dashboard%2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ProjectLoadingScreen</name>
     <message>
         <location filename="../qml/ProjectLoadingScreen.qml" line="31"/>
@@ -774,37 +782,37 @@ Won&apos;t be added to the project.</source>
 <context>
     <name>ProjectPanel</name>
     <message>
-        <location filename="../qml/ProjectPanel.qml" line="128"/>
+        <location filename="../qml/ProjectPanel.qml" line="135"/>
         <source>No Changes</source>
         <translation type="unfinished">No Changes</translation>
     </message>
     <message>
-        <location filename="../qml/ProjectPanel.qml" line="153"/>
+        <location filename="../qml/ProjectPanel.qml" line="160"/>
         <source>Projects</source>
         <translation type="unfinished">Projects</translation>
     </message>
     <message>
-        <location filename="../qml/ProjectPanel.qml" line="350"/>
+        <location filename="../qml/ProjectPanel.qml" line="357"/>
         <source>Home</source>
         <translation type="unfinished">Home</translation>
     </message>
     <message>
-        <location filename="../qml/ProjectPanel.qml" line="372"/>
+        <location filename="../qml/ProjectPanel.qml" line="379"/>
         <source>My projects</source>
         <translation type="unfinished">My projects</translation>
     </message>
     <message>
-        <location filename="../qml/ProjectPanel.qml" line="396"/>
+        <location filename="../qml/ProjectPanel.qml" line="403"/>
         <source>Shared with me</source>
         <translation type="unfinished">Shared with me</translation>
     </message>
     <message>
-        <location filename="../qml/ProjectPanel.qml" line="396"/>
+        <location filename="../qml/ProjectPanel.qml" line="403"/>
         <source>Shared</source>
         <translation type="unfinished">Shared</translation>
     </message>
     <message>
-        <location filename="../qml/ProjectPanel.qml" line="416"/>
+        <location filename="../qml/ProjectPanel.qml" line="423"/>
         <source>Explore</source>
         <translation type="unfinished">Explore</translation>
     </message>
@@ -1306,7 +1314,7 @@ Won&apos;t be added to the project.</source>
 <context>
     <name>inputvaluerelationpage</name>
     <message>
-        <location filename="../qml/editor/inputvaluerelationpage.qml" line="123"/>
+        <location filename="../qml/editor/inputvaluerelationpage.qml" line="129"/>
         <source>Features</source>
         <translation type="unfinished"></translation>
     </message>

--- a/app/inputhelp.cpp
+++ b/app/inputhelp.cpp
@@ -30,6 +30,8 @@ const QString inputWeb = QStringLiteral( "https://inputapp.io" );
 const QString utmTagHelp = QStringLiteral( "?utm_source=input-help&utm_medium=help&utm_campaign=input" );
 const QString utmTagSubscription = QStringLiteral( "?utm_source=input-subs&utm_medium=subs&utm_campaign=input" );
 const QString utmTagOther = QStringLiteral( "?utm_source=input-other&utm_medium=other&utm_campaign=input" );
+const QString utmTagAttention = QStringLiteral( "?utm_source=input-app&utm_medium=attention-required" );
+
 
 InputHelp::InputHelp( MerginApi *merginApi, InputUtils *utils ):
   mMerginApi( merginApi ),
@@ -58,6 +60,16 @@ QString InputHelp::merginWebLink() const
   }
 
   return MerginApi::defaultApiRoot() + utmTagOther;
+}
+
+QString InputHelp::merginDashboardLink() const
+{
+  if ( !mMerginApi || mMerginApi->apiRoot() != MerginApi::defaultApiRoot() )
+  {
+    return mMerginApi->apiRoot() + "dashboard";  // UTM tags are included only for production server
+  }
+
+  return MerginApi::defaultApiRoot() + "dashboard" + utmTagAttention;
 }
 
 QString InputHelp::privacyPolicyLink() const

--- a/app/inputhelp.h
+++ b/app/inputhelp.h
@@ -25,6 +25,7 @@ class InputHelp: public QObject
     Q_PROPERTY( QString helpRootLink READ helpRootLink )
     Q_PROPERTY( QString inputWebLink READ inputWebLink NOTIFY linkChanged )
     Q_PROPERTY( QString merginWebLink READ merginWebLink NOTIFY merginLinkChanged )
+    Q_PROPERTY( QString merginDashboardLink READ merginDashboardLink NOTIFY merginLinkChanged )
     Q_PROPERTY( QString merginSubscriptionDetailsLink READ merginSubscriptionDetailsLink NOTIFY linkChanged )
     Q_PROPERTY( QString howToEnableDigitizingLink READ howToEnableDigitizingLink NOTIFY linkChanged )
     Q_PROPERTY( QString howToEnableBrowsingDataLink READ howToEnableBrowsingDataLink NOTIFY linkChanged )
@@ -51,6 +52,7 @@ class InputHelp: public QObject
     QString helpRootLink() const;
     QString inputWebLink() const;
     QString merginWebLink() const;
+    QString merginDashboardLink() const;
     QString privacyPolicyLink() const;
     QString merginSubscriptionDetailsLink() const;
     QString howToEnableDigitizingLink() const;

--- a/app/qml/ProjectListPage.qml
+++ b/app/qml/ProjectListPage.qml
@@ -30,6 +30,7 @@ Item {
 
   AttentionBanner {
     id: attentionBanner
+    visible: __merginApi.subscriptionInfo ? __merginApi.subscriptionInfo.actionRequired : false
     anchors {
       top: parent.top
       left: parent.left
@@ -41,7 +42,7 @@ Item {
     id: searchBar
 
     anchors {
-      top: (__merginApi.subscriptionInfo && __merginApi.subscriptionInfo.actionRequired) ? attentionBanner.bottom : parent.top
+      top: attentionBanner.visible ? attentionBanner.bottom : parent.top
       left: parent.left
       right: parent.right
     }

--- a/app/qml/ProjectListPage.qml
+++ b/app/qml/ProjectListPage.qml
@@ -17,7 +17,7 @@ Item {
 
   property int projectModelType: ProjectsModel.EmptyProjectsModel
   property string activeProjectId: ""
-
+  property bool actionRequired: __merginApi.subscriptionInfo.actionRequired
   property alias list: projectlist
 
   signal openProjectRequested( string projectId, string projectFilePath )
@@ -28,14 +28,46 @@ Item {
     projectlist.refreshProjectList( searchBar.text )
   }
 
+  Rectangle {
+      id: attentionBanner
+      color: '#ff4f4f'
+      height: InputStyle.rowHeight
+      visible: parent.actionRequired
+
+      anchors {
+        top: parent.top
+        left: parent.left
+        right: parent.right
+      }
+
+      TextWithIcon {
+          width: parent.width
+          fontColor: 'white'
+          bgColor: '#ff4f4f'
+          iconColor: 'white'
+          linkColor: 'white'
+          source: InputStyle.exclamationTriangleIcon
+          text: qsTr("Your attention is required. Please visit the %1Mergin dashboard%2.")
+                    .arg("<a href='" + __inputHelp.merginDashboardLink + "'>")
+                    .arg("</a>")
+
+      }
+
+      MouseArea {
+        anchors.fill: parent
+        onClicked: Qt.openUrlExternally( __inputHelp.merginDashboardLink )
+      }
+  }
+
+
+
   SearchBar {
     id: searchBar
 
     anchors {
-      top: parent.top
+      top: parent.actionRequired ? attentionBanner.bottom : parent.top
       left: parent.left
       right: parent.right
-      bottom: projectlist.top
     }
 
     allowTimer: true

--- a/app/qml/ProjectListPage.qml
+++ b/app/qml/ProjectListPage.qml
@@ -11,13 +11,13 @@ import QtQuick 2.12
 import lc 1.0
 
 import "./components"
+import "./misc"
 
 Item {
   id: root
 
   property int projectModelType: ProjectsModel.EmptyProjectsModel
   property string activeProjectId: ""
-  property bool actionRequired: __merginApi.subscriptionInfo.actionRequired
   property alias list: projectlist
 
   signal openProjectRequested( string projectId, string projectFilePath )
@@ -28,44 +28,20 @@ Item {
     projectlist.refreshProjectList( searchBar.text )
   }
 
-  Rectangle {
-      id: attentionBanner
-      color: '#ff4f4f'
-      height: InputStyle.rowHeight
-      visible: parent.actionRequired
-
-      anchors {
-        top: parent.top
-        left: parent.left
-        right: parent.right
-      }
-
-      TextWithIcon {
-          width: parent.width
-          fontColor: 'white'
-          bgColor: '#ff4f4f'
-          iconColor: 'white'
-          linkColor: 'white'
-          source: InputStyle.exclamationTriangleIcon
-          text: qsTr("Your attention is required. Please visit the %1Mergin dashboard%2.")
-                    .arg("<a href='" + __inputHelp.merginDashboardLink + "'>")
-                    .arg("</a>")
-
-      }
-
-      MouseArea {
-        anchors.fill: parent
-        onClicked: Qt.openUrlExternally( __inputHelp.merginDashboardLink )
-      }
+  AttentionBanner {
+    id: attentionBanner
+    anchors {
+      top: parent.top
+      left: parent.left
+      right: parent.right
+    }
   }
-
-
 
   SearchBar {
     id: searchBar
 
     anchors {
-      top: parent.actionRequired ? attentionBanner.bottom : parent.top
+      top: (__merginApi.subscriptionInfo && __merginApi.subscriptionInfo.actionRequired) ? attentionBanner.bottom : parent.top
       left: parent.left
       right: parent.right
     }

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -29,7 +29,8 @@ Item {
 
   function openPanel() {
     root.visible = true
-    stackView.visible = true
+    stackView.visible = true  
+    getServiceInfo() // ensure attention banner status is refreshed
   }
 
   function hidePanel() {
@@ -43,6 +44,12 @@ Item {
       stackView.push( subscribePanelComp)
     } else {
       Qt.openUrlExternally(__purchasing.subscriptionManageUrl);
+    }
+  }
+
+  function getServiceInfo() {
+    if (__merginApi.userAuth.hasAuthData() && __merginApi.apiVersionStatus === MerginApiStatus.OK && __merginApi.apiSupportsSubscriptions) {
+        __merginApi.getSubscriptionInfo()
     }
   }
 

--- a/app/qml/components/TextWithIcon.qml
+++ b/app/qml/components/TextWithIcon.qml
@@ -21,6 +21,7 @@ Row {
   property color bgColor: "white"
   property color fontColor: InputStyle.fontColor
   property color iconColor: InputStyle.fontColor
+  property color linkColor: InputStyle.highlightColor
 
   property alias textItem: textItem
 
@@ -59,7 +60,7 @@ Row {
     font.pixelSize: InputStyle.fontPixelSizeNormal
     onLinkActivated: root.linkActivated(link)
     color: root.fontColor
-    text: "<style>a:link { color: " + InputStyle.highlightColor
+    text: "<style>a:link { color: " + root.linkColor
           + "; text-decoration: underline; }</style>" + root.text
     textFormat: Text.RichText
     wrapMode: Text.WordWrap

--- a/app/qml/misc/AttentionBanner.qml
+++ b/app/qml/misc/AttentionBanner.qml
@@ -1,0 +1,26 @@
+import QtQuick 2.0
+import ".."
+import "../components"
+
+Rectangle {
+  color: '#ff4f4f'
+  height: InputStyle.rowHeight
+  visible: __merginApi.subscriptionInfo ? __merginApi.subscriptionInfo.actionRequired : false
+
+  TextWithIcon {
+    width: parent.width
+    fontColor: 'white'
+    bgColor: '#ff4f4f'
+    iconColor: 'white'
+    linkColor: 'white'
+    source: InputStyle.exclamationTriangleIcon
+    text: qsTr("Your attention is required. Please visit the %1Mergin dashboard%2.")
+               .arg("<a href='" + __inputHelp.merginDashboardLink + "'>")
+               .arg("</a>")
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    onClicked: Qt.openUrlExternally( __inputHelp.merginDashboardLink )
+  }
+}

--- a/app/qml/misc/AttentionBanner.qml
+++ b/app/qml/misc/AttentionBanner.qml
@@ -1,3 +1,12 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 import QtQuick 2.0
 import ".."
 import "../components"
@@ -5,7 +14,6 @@ import "../components"
 Rectangle {
   color: '#ff4f4f'
   height: InputStyle.rowHeight
-  visible: __merginApi.subscriptionInfo ? __merginApi.subscriptionInfo.actionRequired : false
 
   TextWithIcon {
     width: parent.width

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -95,5 +95,6 @@
         <file>map/ScaleBar.qml</file>
         <file>qmldir</file>
         <file>misc/LegacyFolderMigration.qml</file>
+        <file>misc/AttentionBanner.qml</file>
     </qresource>
 </RCC>

--- a/core/merginsubscriptioninfo.cpp
+++ b/core/merginsubscriptioninfo.cpp
@@ -111,6 +111,8 @@ void MerginSubscriptionInfo::setFromJson( QJsonObject docObj )
     emit planProductIdChanged();
   }
 
+  // check if some user action is required
+  mActionRequired = docObj.value( QStringLiteral( "action_required" ) ).toBool();
   emit subscriptionInfoChanged();
 }
 
@@ -166,4 +168,9 @@ int MerginSubscriptionInfo::subscriptionStatus() const
 QString MerginSubscriptionInfo::subscriptionTimestamp() const
 {
   return mSubscriptionTimestamp;
+}
+
+bool MerginSubscriptionInfo::actionRequired() const
+{
+  return mActionRequired;
 }

--- a/core/merginsubscriptioninfo.cpp
+++ b/core/merginsubscriptioninfo.cpp
@@ -112,7 +112,12 @@ void MerginSubscriptionInfo::setFromJson( QJsonObject docObj )
   }
 
   // check if some user action is required
-  mActionRequired = docObj.value( QStringLiteral( "action_required" ) ).toBool();
+  bool isActionRequired = docObj.value( QStringLiteral( "action_required" ) ).toBool();
+  if ( isActionRequired != mActionRequired )
+  {
+    mActionRequired = isActionRequired;
+  }
+
   emit subscriptionInfoChanged();
 }
 

--- a/core/merginsubscriptioninfo.h
+++ b/core/merginsubscriptioninfo.h
@@ -28,6 +28,7 @@ class MerginSubscriptionInfo: public QObject
     Q_PROPERTY( QString subscriptionTimestamp READ subscriptionTimestamp NOTIFY subscriptionInfoChanged )
     Q_PROPERTY( QString nextBillPrice READ nextBillPrice NOTIFY subscriptionInfoChanged ) // in Bytes
     Q_PROPERTY( bool ownsActiveSubscription READ ownsActiveSubscription NOTIFY subscriptionInfoChanged )
+    Q_PROPERTY( bool actionRequired READ actionRequired NOTIFY subscriptionInfoChanged )
 
   public:
     explicit MerginSubscriptionInfo( QObject *parent = nullptr );
@@ -50,6 +51,7 @@ class MerginSubscriptionInfo: public QObject
     void setLocalizedPrice( const QString &price );
     void setFromJson( QJsonObject docObj );
     void setSubscriptionInfoFromJson( QJsonObject docObj );
+    bool actionRequired() const;
 
   signals:
     void subscriptionInfoChanged();
@@ -66,6 +68,7 @@ class MerginSubscriptionInfo: public QObject
     QString mNextBillPrice;
     MerginSubscriptionStatus::SubscriptionStatus mSubscriptionStatus = MerginSubscriptionStatus::FreeSubscription;
     QString mSubscriptionTimestamp;
+    bool mActionRequired = false;
 };
 
 #endif // MERGINSUBSCRIPTIONINFO_H


### PR DESCRIPTION
PR adds 'Attention required' banner in Project Panel. Its purpose is to draw attention of user that there is some issue which needs to be resolved in Mergin dashboard.

Appearance of the banner depends on flag coming from server response (`/v1/user/service`). Status is refreshed on panel open action to ensure current state is reflected before sync.

Resolves #1731 

![input_banner](https://user-images.githubusercontent.com/23185498/141299302-3f681b77-8de2-46ae-b0a6-6a436b24eced.png)




