### PR TITLE
Compare qgsquick to latest QGIS again

### DIFF
--- a/.github/workflows/qgsquick.yml
+++ b/.github/workflows/qgsquick.yml
@@ -4,6 +4,7 @@ on:
     paths:
     - 'qgsquick/**'
     - 'scripts/**'
+    - 'app/**'
 
   release:
     types:

--- a/.github/workflows/qgsquick.yml
+++ b/.github/workflows/qgsquick.yml
@@ -9,6 +9,9 @@ on:
   release:
     types:
       - published
+      
+env:
+  QGIS_COMMIT_HASH: a559212bbda3af37300c17997b826751318299cd
 
 jobs:
   qgsquick_up_to_date:
@@ -18,7 +21,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: download qgis
-        run: git clone https://github.com/qgis/QGIS.git --depth 1
+        run: |
+          git clone https://github.com/qgis/QGIS.git --depth 1
+          cd QGIS
+          git fetch --depth 1 origin ${QGIS_COMMIT_HASH}
+          git checkout FETCH_HEAD
+          cd ..
 
       - name: run check the qgsquick is up-to-date
         run: |

--- a/.github/workflows/qgsquick.yml
+++ b/.github/workflows/qgsquick.yml
@@ -9,9 +9,9 @@ on:
   release:
     types:
       - published
-      
+
 env:
-  QGIS_COMMIT_HASH: a559212bbda3af37300c17997b826751318299cd
+  QGIS_COMMIT_HASH: e524574d0e25995fb0c9a543dd96aeb4e2ade727
 
 jobs:
   qgsquick_up_to_date:

--- a/.github/workflows/qgsquick.yml
+++ b/.github/workflows/qgsquick.yml
@@ -5,6 +5,7 @@ on:
     - 'qgsquick/**'
     - 'scripts/**'
     - 'app/**'
+    - '.github/workflows/qgsquick.yml'
 
   release:
     types:

--- a/.github/workflows/qgsquick.yml
+++ b/.github/workflows/qgsquick.yml
@@ -8,9 +8,6 @@ on:
   release:
     types:
       - published
-      
-env:
-  QGIS_COMMIT_HASH: a559212bbda3af37300c17997b826751318299cd
 
 jobs:
   qgsquick_up_to_date:
@@ -20,12 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: download qgis
-        run: |
-          git clone https://github.com/qgis/QGIS.git --depth 1
-          cd QGIS
-          git fetch --depth 1 origin ${QGIS_COMMIT_HASH}
-          git checkout FETCH_HEAD
-          cd ..
+        run: git clone https://github.com/qgis/QGIS.git --depth 1
 
       - name: run check the qgsquick is up-to-date
         run: |


### PR DESCRIPTION
Removed comparison of qgsquick lib from a specific commit to the latest qgis master.
Also changed that qgsquick check now runs on each change in app/* too.