### PR TITLE
iOS CI build after AAB

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -171,6 +171,15 @@ jobs:
           echo -e "}"  >> ./app/config.pri
           cat ./app/config.pri
 
+      # Parse Input-SDK version run number - it is used as middle integer in version number in CF_BUNDLE_VERSION
+      - uses: rishabhgupta/split-by@v1
+        id: split
+        with:
+          string: ${{ env.INPUT_SDK_VERSION }}
+          split-by: '-'
+      - run: |
+          echo "${{ steps.split.outputs._0}} ${{ steps.split.outputs._1}} ${{ steps.split.outputs._2}}"
+
       - name: Create build system with qmake
         run: |
           INPUT_DIR=`pwd`
@@ -180,7 +189,7 @@ jobs:
           TIMESTAMP=`date "+%y%m%d%H%M%S"`
           GIT_BRANCH_NAME=`git rev-parse --abbrev-ref HEAD`
           BRANCH_NUMBER=`if [ "X$GIT_BRANCH_NAME" == "Xmaster" ]; then echo "2"; else echo "1"; fi`
-          CF_BUNDLE_VERSION=${BRANCH_NUMBER}.${IOS_SDK_VERSION}.${TIMESTAMP}
+          CF_BUNDLE_VERSION=${BRANCH_NUMBER}.${{ steps.split.outputs._2 }}.${TIMESTAMP}
 
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CF_BUNDLE_VERSION" "$INPUT_DIR/app/ios/Info.plist"
 
@@ -244,5 +253,5 @@ jobs:
           xcrun altool --upload-app -t ios -f build-INPUT/Input.ipa -u "$INPUTAPP_BOT_APPLEID_USER" -p "$INPUTAPP_BOT_APPLEID_PASS" --verbose
 
           # Add comment to GitHub
-          GITHUB_API=https://api.github.com/repos/lutraconsulting/input/commits/${GITHUB_SHA}/comments
-          curl -u inputapp-bot:${INPUTAPP_BOT_GITHUB_TOKEN} -X POST --data '{"body": "ios-'${CF_BUNDLE_VERSION}' (SDK: [ios-'${IOS_SDK_VERSION}'](https://github.com/lutraconsulting/input-sdk/releases/tag/ios-'${IOS_SDK_VERSION}'))"}' ${GITHUB_API}
+          # GITHUB_API=https://api.github.com/repos/lutraconsulting/input/commits/${GITHUB_SHA}/comments
+          # curl -u inputapp-bot:${INPUTAPP_BOT_GITHUB_TOKEN} -X POST --data '{"body": "ios-'${CF_BUNDLE_VERSION}' (SDK: [ios-'${IOS_SDK_VERSION}'](https://github.com/lutraconsulting/input-sdk/releases/tag/ios-'${IOS_SDK_VERSION}'))"}' ${GITHUB_API}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -142,11 +142,16 @@ jobs:
       # Do this only until we move from 5.14.2!!
       - name: Patch Qt!
         if: ${{ env.QT_VERSION }} == '5.14.2'
+        continue-on-error: true
         run: |
           echo "Patch 5.14.2 see https://github.com/lutraconsulting/input-sdk/issues/34"
           which $SHELL
           env
-          cp ./app/scripts/ci/ios/toolchain5.14.2_xcode12.prf ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/mkspecs/features/toolchain.prf
+          echo "copy from ${{ github.workspace }}/app/scripts/ci/ios/toolchain5.14.2_xcode12.prf"
+          echo "copy to ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/mkspecs/features/toolchain.prf"
+
+          cp ${{ github.workspace }}/app/scripts/ci/ios/toolchain5.14.2_xcode12.prf ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/mkspecs/features/toolchain.prf
+          echo $?
           echo "Qt patched!"
 
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -155,6 +155,8 @@ jobs:
         run: |
           INPUT_DIR=`pwd`
 
+          echo "ARCHS: $ARCHS_STANDARD"
+
           # patch the Info.plist
           CF_BUNDLE_SHORT_VERSION=`/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" $INPUT_DIR/app/ios/Info.plist`
           TIMESTAMP=`date "+%y%m%d%H%M%S"`
@@ -217,6 +219,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "starting!"
+          echo $ARCHS_STANDARD
           find . -name "*.o"
           find . -name "*.o" | head -n 1 | xargs otool -lv | grep -A 4 -B 4 platform
           echo "Looking at ../build-INPUT"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -71,14 +71,6 @@ jobs:
           ccache --set-config=max_size=2.0G
           ccache -s
 
-      - name: d
-        if: always()
-        continue-on-error: true
-        run: |
-          which clang
-          which clang++
-          which c++
-
       - name: Extract Mergin API_KEY
         env:
           MERGINSECRETS_DECRYPT_KEY: ${{ secrets.MERGINSECRETS_DECRYPT_KEY }}
@@ -149,6 +141,7 @@ jobs:
 
       # Do this only until we move from 5.14.2!!
       - name: Patch Qt!
+        shell: bash
         run: |
           echo "Patch 5.14.2 see https://github.com/lutraconsulting/input-sdk/issues/34"
 
@@ -160,7 +153,12 @@ jobs:
           cp ${{ github.workspace }}/scripts/ci/ios/toolchain5.14.2_xcode12.prf ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/mkspecs/features/toolchain.prf
 
       # Build Input App
+      # !! ccache_clang is a custom script which runs ccache and default XCode clang.
+      # !! It has been created due to a bug in Qt when QMAKE_CXX ignored everything after
+      # !! whitespace chars. In that case in the string 'ccache clang++' clang was ignored
+      # !! and ccache received all of the compilation flags that were supposed to go to clang.
       - name: Export app/config.pri
+        shell: bash
         run: |
           touch ./app/config.pri
           echo -e "ios {"  >> ./app/config.pri
@@ -171,14 +169,20 @@ jobs:
           echo -e "}"  >> ./app/config.pri
           cat ./app/config.pri
 
+          if [ ! ${{ env.QT_VERSION }} == "5.14.2" ]; then
+            echo "Qt version has changed! Double check if we still need custom script 'ccache_clang' for QMAKE_CXX."
+            echo "  - If yes, change this condition to the new Qt version"
+            echo "  - If no, remove the 'ccache_clang' script and this check too"
+            exit 1
+          fi
+
       # Parse Input-SDK version run number - it is used as middle integer in version number in CF_BUNDLE_VERSION
-      - uses: rishabhgupta/split-by@v1
+      - name: Parse SDK version run number
+        uses: rishabhgupta/split-by@v1
         id: split
         with:
           string: ${{ env.INPUT_SDK_VERSION }}
           split-by: '-'
-      - run: |
-          echo "${{ steps.split.outputs._0}} ${{ steps.split.outputs._1}} ${{ steps.split.outputs._2}}"
 
       - name: Create build system with qmake
         run: |
@@ -191,6 +195,7 @@ jobs:
           BRANCH_NUMBER=`if [ "X$GIT_BRANCH_NAME" == "Xmaster" ]; then echo "2"; else echo "1"; fi`
           CF_BUNDLE_VERSION=${BRANCH_NUMBER}.${{ steps.split.outputs._2 }}.${TIMESTAMP}
 
+          echo "Building version: $CF_BUNDLE_VERSION"
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CF_BUNDLE_VERSION" "$INPUT_DIR/app/ios/Info.plist"
 
           mkdir -p build-INPUT
@@ -253,5 +258,5 @@ jobs:
           xcrun altool --upload-app -t ios -f build-INPUT/Input.ipa -u "$INPUTAPP_BOT_APPLEID_USER" -p "$INPUTAPP_BOT_APPLEID_PASS" --verbose
 
           # Add comment to GitHub
-          # GITHUB_API=https://api.github.com/repos/lutraconsulting/input/commits/${GITHUB_SHA}/comments
-          # curl -u inputapp-bot:${INPUTAPP_BOT_GITHUB_TOKEN} -X POST --data '{"body": "ios-'${CF_BUNDLE_VERSION}' (SDK: [ios-'${IOS_SDK_VERSION}'](https://github.com/lutraconsulting/input-sdk/releases/tag/ios-'${IOS_SDK_VERSION}'))"}' ${GITHUB_API}
+          GITHUB_API=https://api.github.com/repos/lutraconsulting/input/commits/${GITHUB_SHA}/comments
+          curl -u inputapp-bot:${INPUTAPP_BOT_GITHUB_TOKEN} -X POST --data '{"body": "iOS - version '${CF_BUNDLE_VERSION}' just submitted!"}' ${GITHUB_API}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -216,6 +216,7 @@ jobs:
         if: always()
         run: |
           echo "Looking at ."
+          find . -name "*.o"
           find . -name "*.o" | head -n 1 | xargs otool -lv | grep -A 4 -B 4 platform
           echo "Looking at ../build-INPUT"
           find ../build-INPUT -name "*.o" | head -n 1 | xargs otool -lv | grep -A 4 -B 4 platform

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -167,8 +167,9 @@ jobs:
           echo -e "  INPUT_SDK_PATH=${{ github.workspace }}/input-sdk/arm64"  >> ./app/config.pri
           echo -e "  QGIS_QUICK_DATA_PATH = INPUT"  >> ./app/config.pri
           echo -e "  QMAKE_IOS_DEPLOYMENT_TARGET = ${{ env.IOS_MIN_SDK_VERSION }}"  >> ./app/config.pri
-          echo -e "  QMAKE_CXX = ccache clang++"  >> ./app/config.pri
-          echo -e "  QMAKE_LINK = clang++" >> ./app/config.pri
+          echo -e "  message($$QMAKE_CXX)" >> ./app/config.pri
+          echo -e "  QMAKE_CXX = ccache \$\$QMAKE_CXX"  >> ./app/config.pri
+          echo -e "  message($$QMAKE_CXX)" >> ./app/config.pri
           echo -e "}"  >> ./app/config.pri
           cat ./app/config.pri
           echo $QMAKE_CXX
@@ -216,8 +217,6 @@ jobs:
         run: |
           INPUT_DIR=`pwd`
           cd build-INPUT
-
-          echo $QMAKE_CXX
 
           xcodebuild \
             -project Input.xcodeproj/ \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -139,6 +139,17 @@ jobs:
           dir: ${{ github.workspace }}
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
+      # Do this only until we move from 5.14.2!!
+      - name: Patch Qt!
+        if: ${{ env.QT_VERSION }} == '5.14.2'
+        run: |
+          echo "Patch 5.14.2 see https://github.com/lutraconsulting/input-sdk/issues/34"
+          which $SHELL
+          env
+          cp ./app/scripts/ci/ios/toolchain5.14.2_xcode12.prf ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/mkspecs/features/toolchain.prf
+          echo "Qt patched!"
+
+
       # Build Input App
       - name: Export app/config.pri
         run: |
@@ -213,20 +224,6 @@ jobs:
             -exportPath $PWD \
             -allowProvisioningUpdates \
             -exportArchive
-
-      - name: debug
-        if: always()
-        continue-on-error: true
-        run: |
-          echo "starting!"
-          echo $ARCHS_STANDARD
-          find . -name "*.o"
-          find . -name "*.o" | head -n 1 | xargs otool -lv | grep -A 4 -B 4 platform
-          echo "Looking at ../build-INPUT"
-          find ../build-INPUT -name "*.o" | head -n 1 | xargs otool -lv | grep -A 4 -B 4 platform
-          echo "Done looking"
-
-
 
       - name: Upload .ipa to TestFlight
         env:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -167,9 +167,6 @@ jobs:
           echo -e "  INPUT_SDK_PATH=${{ github.workspace }}/input-sdk/arm64"  >> ./app/config.pri
           echo -e "  QGIS_QUICK_DATA_PATH = INPUT"  >> ./app/config.pri
           echo -e "  QMAKE_IOS_DEPLOYMENT_TARGET = ${{ env.IOS_MIN_SDK_VERSION }}"  >> ./app/config.pri
-          echo -e "  message(\$\$QMAKE_CXX)" >> ./app/config.pri
-          echo -e "  QMAKE_CXX = ccache \$\$QMAKE_CXX"  >> ./app/config.pri
-          echo -e "  message(\$\$QMAKE_CXX)" >> ./app/config.pri
           echo -e "}"  >> ./app/config.pri
           cat ./app/config.pri
 
@@ -198,6 +195,7 @@ jobs:
             CONFIG+=release \
             CONFIG+=iphoneos \
             CONFIG+=device \
+            CONFIG+=ccache \
             CONFIG+=qtquickcompiler \
             QMAKE_MAC_XCODE_SETTINGS+=qprofile \
             qprofile.name=PROVISIONING_PROFILE_SPECIFIER \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -178,8 +178,8 @@ jobs:
 
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $CF_BUNDLE_VERSION" "$INPUT_DIR/app/ios/Info.plist"
 
-          mkdir -p ../build-INPUT
-          cd ../build-INPUT
+          mkdir -p build-INPUT
+          cd build-INPUT
 
           # run qmake
           ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/bin/qmake \
@@ -205,7 +205,7 @@ jobs:
       - name: Build Input
         run: |
           INPUT_DIR=`pwd`
-          cd ../build-INPUT
+          cd build-INPUT
 
           xcodebuild \
             -project Input.xcodeproj/ \
@@ -218,7 +218,7 @@ jobs:
       - name: Create Input Package
         run: |
           INPUT_DIR=`pwd`
-          cd ../build-INPUT
+          cd build-INPUT
           xcodebuild \
             -archivePath Input.xcarchive \
             -exportOptionsPlist $INPUT_DIR/scripts/ci/ios/exportOptions.plist \
@@ -235,7 +235,7 @@ jobs:
         run: |
           CF_BUNDLE_VERSION=`/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" app/ios/Info.plist`
           echo "Publishing ios ${CF_BUNDLE_VERSION}"
-          xcrun altool --upload-app -t ios -f ../build-INPUT/Input.ipa -u "$INPUTAPP_BOT_APPLEID_USER" -p "$INPUTAPP_BOT_APPLEID_PASS" --verbose
+          xcrun altool --upload-app -t ios -f build-INPUT/Input.ipa -u "$INPUTAPP_BOT_APPLEID_USER" -p "$INPUTAPP_BOT_APPLEID_PASS" --verbose
 
           # Add comment to GitHub
           GITHUB_API=https://api.github.com/repos/lutraconsulting/input/commits/${GITHUB_SHA}/comments

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -71,6 +71,14 @@ jobs:
           ccache --set-config=max_size=2.0G
           ccache -s
 
+      - name: d
+        if: always()
+        continue-on-error: true
+        run: |
+          which clang
+          which clang++
+          which c++
+
       - name: Extract Mergin API_KEY
         env:
           MERGINSECRETS_DECRYPT_KEY: ${{ secrets.MERGINSECRETS_DECRYPT_KEY }}
@@ -163,6 +171,7 @@ jobs:
           echo -e "  QMAKE_LINK = clang++" >> ./app/config.pri
           echo -e "}"  >> ./app/config.pri
           cat ./app/config.pri
+          echo $QMAKE_CXX
 
       - name: Create build system with qmake
         run: |
@@ -207,6 +216,8 @@ jobs:
         run: |
           INPUT_DIR=`pwd`
           cd build-INPUT
+
+          echo $QMAKE_CXX
 
           xcodebuild \
             -project Input.xcodeproj/ \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -141,7 +141,6 @@ jobs:
 
       # Do this only until we move from 5.14.2!!
       - name: Patch Qt!
-        continue-on-error: true
         run: |
           echo "Patch 5.14.2 see https://github.com/lutraconsulting/input-sdk/issues/34"
 
@@ -150,20 +149,14 @@ jobs:
             exit 1
           fi
 
-          echo "copy from ${{ github.workspace }}/scripts/ci/ios/toolchain5.14.2_xcode12.prf"
-          echo "copy to ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/mkspecs/features/toolchain.prf"
-
           cp ${{ github.workspace }}/scripts/ci/ios/toolchain5.14.2_xcode12.prf ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/mkspecs/features/toolchain.prf
-          echo $?
-          echo "Qt patched!"
-
 
       # Build Input App
       - name: Export app/config.pri
         run: |
           touch ./app/config.pri
           echo -e "ios {"  >> ./app/config.pri
-          echo -e "  INPUT_SDK_PATH=${{ github.workspace }}/input-sdk"  >> ./app/config.pri
+          echo -e "  INPUT_SDK_PATH=${{ github.workspace }}/input-sdk/arm64"  >> ./app/config.pri
           echo -e "  QGIS_QUICK_DATA_PATH = INPUT"  >> ./app/config.pri
           echo -e "  QMAKE_IOS_DEPLOYMENT_TARGET = ${{ env.IOS_MIN_SDK_VERSION }}"  >> ./app/config.pri
           echo -e "  QMAKE_CXX = ccache \$\$QMAKE_CXX "  >> ./app/config.pri

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -141,16 +141,19 @@ jobs:
 
       # Do this only until we move from 5.14.2!!
       - name: Patch Qt!
-        if: ${{ env.QT_VERSION }} == '5.14.2'
         continue-on-error: true
         run: |
           echo "Patch 5.14.2 see https://github.com/lutraconsulting/input-sdk/issues/34"
-          which $SHELL
-          env
-          echo "copy from ${{ github.workspace }}/app/scripts/ci/ios/toolchain5.14.2_xcode12.prf"
+
+          if [ ! ${{ env.QT_VERSION }} == "5.14.2" ]; then
+            echo "Can not patch other Qt version than 5.14.2. Remove this step in case of higher Qt version!"
+            exit 1
+          fi
+
+          echo "copy from ${{ github.workspace }}/scripts/ci/ios/toolchain5.14.2_xcode12.prf"
           echo "copy to ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/mkspecs/features/toolchain.prf"
 
-          cp ${{ github.workspace }}/app/scripts/ci/ios/toolchain5.14.2_xcode12.prf ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/mkspecs/features/toolchain.prf
+          cp ${{ github.workspace }}/scripts/ci/ios/toolchain5.14.2_xcode12.prf ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/mkspecs/features/toolchain.prf
           echo $?
           echo "Qt patched!"
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -167,12 +167,11 @@ jobs:
           echo -e "  INPUT_SDK_PATH=${{ github.workspace }}/input-sdk/arm64"  >> ./app/config.pri
           echo -e "  QGIS_QUICK_DATA_PATH = INPUT"  >> ./app/config.pri
           echo -e "  QMAKE_IOS_DEPLOYMENT_TARGET = ${{ env.IOS_MIN_SDK_VERSION }}"  >> ./app/config.pri
-          echo -e "  message($$QMAKE_CXX)" >> ./app/config.pri
+          echo -e "  message(\$\$QMAKE_CXX)" >> ./app/config.pri
           echo -e "  QMAKE_CXX = ccache \$\$QMAKE_CXX"  >> ./app/config.pri
-          echo -e "  message($$QMAKE_CXX)" >> ./app/config.pri
+          echo -e "  message(\$\$QMAKE_CXX)" >> ./app/config.pri
           echo -e "}"  >> ./app/config.pri
           cat ./app/config.pri
-          echo $QMAKE_CXX
 
       - name: Create build system with qmake
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -167,6 +167,7 @@ jobs:
           echo -e "  INPUT_SDK_PATH=${{ github.workspace }}/input-sdk/arm64"  >> ./app/config.pri
           echo -e "  QGIS_QUICK_DATA_PATH = INPUT"  >> ./app/config.pri
           echo -e "  QMAKE_IOS_DEPLOYMENT_TARGET = ${{ env.IOS_MIN_SDK_VERSION }}"  >> ./app/config.pri
+          echo -e "  QMAKE_CXX = ccache\\ \$\$QMAKE_CXX"  >> ./app/config.pri
           echo -e "}"  >> ./app/config.pri
           cat ./app/config.pri
 
@@ -195,7 +196,6 @@ jobs:
             CONFIG+=release \
             CONFIG+=iphoneos \
             CONFIG+=device \
-            CONFIG+=ccache \
             CONFIG+=qtquickcompiler \
             QMAKE_MAC_XCODE_SETTINGS+=qprofile \
             qprofile.name=PROVISIONING_PROFILE_SPECIFIER \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -159,7 +159,7 @@ jobs:
           echo -e "  INPUT_SDK_PATH=${{ github.workspace }}/input-sdk/arm64"  >> ./app/config.pri
           echo -e "  QGIS_QUICK_DATA_PATH = INPUT"  >> ./app/config.pri
           echo -e "  QMAKE_IOS_DEPLOYMENT_TARGET = ${{ env.IOS_MIN_SDK_VERSION }}"  >> ./app/config.pri
-          echo -e "  QMAKE_CXX = ccache \$\$QMAKE_CXX "  >> ./app/config.pri
+          echo -e "  QMAKE_CXX = ccache clang++"  >> ./app/config.pri
           echo -e "}"  >> ./app/config.pri
           cat ./app/config.pri
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -214,7 +214,9 @@ jobs:
 
       - name: debug
         if: always()
+        continue-on-error: true
         run: |
+          echo "starting!"
           find . -name "*.o"
           find . -name "*.o" | head -n 1 | xargs otool -lv | grep -A 4 -B 4 platform
           echo "Looking at ../build-INPUT"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -160,6 +160,7 @@ jobs:
           echo -e "  QGIS_QUICK_DATA_PATH = INPUT"  >> ./app/config.pri
           echo -e "  QMAKE_IOS_DEPLOYMENT_TARGET = ${{ env.IOS_MIN_SDK_VERSION }}"  >> ./app/config.pri
           echo -e "  QMAKE_CXX = ccache clang++"  >> ./app/config.pri
+          echo -e "  QMAKE_LINK = clang++" >> ./app/config.pri
           echo -e "}"  >> ./app/config.pri
           cat ./app/config.pri
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -212,6 +212,17 @@ jobs:
             -allowProvisioningUpdates \
             -exportArchive
 
+      - name: debug
+        if: always()
+        run: |
+          echo "Looking at ."
+          find . -name "*.o" | head -n 1 | xargs otool -lv | grep -A 4 -B 4 platform
+          echo "Looking at ../build-INPUT"
+          find ../build-INPUT -name "*.o" | head -n 1 | xargs otool -lv | grep -A 4 -B 4 platform
+          echo "Done looking"
+
+
+
       - name: Upload .ipa to TestFlight
         env:
           INPUTAPP_BOT_APPLEID_PASS: ${{ secrets.INPUTAPP_BOT_APPLEID_PASS }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -167,15 +167,13 @@ jobs:
           echo -e "  INPUT_SDK_PATH=${{ github.workspace }}/input-sdk/arm64"  >> ./app/config.pri
           echo -e "  QGIS_QUICK_DATA_PATH = INPUT"  >> ./app/config.pri
           echo -e "  QMAKE_IOS_DEPLOYMENT_TARGET = ${{ env.IOS_MIN_SDK_VERSION }}"  >> ./app/config.pri
-          echo -e "  QMAKE_CXX = ccache\\ \$\$QMAKE_CXX"  >> ./app/config.pri
+          echo -e "  QMAKE_CXX = ${{ github.workspace }}/scripts/ci/ios/ccache_clang"  >> ./app/config.pri
           echo -e "}"  >> ./app/config.pri
           cat ./app/config.pri
 
       - name: Create build system with qmake
         run: |
           INPUT_DIR=`pwd`
-
-          echo "ARCHS: $ARCHS_STANDARD"
 
           # patch the Info.plist
           CF_BUNDLE_SHORT_VERSION=`/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" $INPUT_DIR/app/ios/Info.plist`

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -168,7 +168,7 @@ jobs:
           cd ../build-INPUT
 
           # run qmake
-          /opt/Qt/${QT_VERSION}/ios/bin/qmake \
+          ${{ github.workspace }}/Qt/${{ env.QT_VERSION }}/ios/bin/qmake \
             ${INPUT_DIR}/app/input.pro \
             -spec macx-ios-clang \
             CONFIG+=release \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -215,7 +215,6 @@ jobs:
       - name: debug
         if: always()
         run: |
-          echo "Looking at ."
           find . -name "*.o"
           find . -name "*.o" | head -n 1 | xargs otool -lv | grep -A 4 -B 4 platform
           echo "Looking at ../build-INPUT"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -64,8 +64,6 @@ jobs:
           brew install openssl@1.1
           brew install python3
           brew install ccache
-          pip3 install dropbox
-
 
       - name: Install ccache
         run: |
@@ -156,9 +154,6 @@ jobs:
       - name: Create build system with qmake
         run: |
           INPUT_DIR=`pwd`
-
-          # setup config environment
-          cp scripts/ci/config.pri app/config.pri
 
           # patch the Info.plist
           CF_BUNDLE_SHORT_VERSION=`/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" $INPUT_DIR/app/ios/Info.plist`

--- a/app/ios/Info.plist
+++ b/app/ios/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-        <string>1.1.0</string>
+  <string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>${QMAKE_PKGINFO_TYPEINFO}</string>
 	<key>CFBundleVersion</key>

--- a/app/ios/Info.plist
+++ b/app/ios/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-  <string>1.2.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>${QMAKE_PKGINFO_TYPEINFO}</string>
 	<key>CFBundleVersion</key>

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -51,7 +51,6 @@ QString CoreUtils::localizedDateFromUTFString( QString timestamp )
   }
   else
   {
-    qDebug() << "Unable to convert UTF " << timestamp << " to QDateTime";
     return QString();
   }
 }

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -51,6 +51,7 @@ QString CoreUtils::localizedDateFromUTFString( QString timestamp )
   }
   else
   {
+    qDebug() << "Unable to convert UTF " << timestamp << " to QDateTime";
     return QString();
   }
 }

--- a/scripts/ci/ios/ccache_clang
+++ b/scripts/ci/ios/ccache_clang
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-ccache clang++ "$@"
-
+ccache `xcode-select -p`/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang "$@"

--- a/scripts/ci/ios/ccache_clang
+++ b/scripts/ci/ios/ccache_clang
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ccache clang++ "$@"
+


### PR DESCRIPTION
PR fixes iOS build after changing infrastructure of SDK to static builds.

**Important change**
We changed the way of constructing version numbers if IPAs. 
 - Previous format: `<1/2 depending if branch is master or not>.<ios sdk version>.<timestamp>` 
 - New format `<1/2 depending if branch is master or not>.<input sdk run number of used sdk release>.<timestamp>`