### PR TITLE
Fix MacOs workflow file name dep

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ on:
     - 'images/**'
     - 'qgsquick/**'
     - 'scripts/**'
-    - '.github/workflows/autotests.yml'
+    - '.github/workflows/macos.yml'
 
   release:
     types:


### PR DESCRIPTION
macos workflow file contained old name of `autotest workflow` and thus did not rerun when only the workflow file changed.