### PR TITLE
Height issue for TextWithIcon

### DIFF
--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -7,9 +7,9 @@
  *                                                                         *
  ***************************************************************************/
 
-import QtQuick 2.7
-import QtQuick.Controls 2.2
-import QtGraphicalEffects 1.0
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtGraphicalEffects 1.14
 import lc 1.0
 import "."  // import InputStyle singleton
 import "./components"
@@ -108,34 +108,39 @@ Page {
 
       TextWithIcon {
         width: parent.width
+        height: InputStyle.rowHeight
         source: InputStyle.accountIcon
         text: root.username
       }
 
       TextWithIcon {
         width: parent.width
+        height: InputStyle.rowHeight
         source: InputStyle.envelopeIcon
         text: root.email
       }
 
       TextWithIcon {
-        visible: root.apiSupportsSubscriptions
         width: parent.width
+        height: InputStyle.rowHeight
+        visible: root.apiSupportsSubscriptions
         source: InputStyle.editIcon
         text: root.planAlias
       }
 
       TextWithIcon {
-        visible: root.subscriptionStatus === MerginSubscriptionStatus.SubscriptionUnsubscribed
         width: parent.width
+        height: InputStyle.rowHeight
+        visible: root.subscriptionStatus === MerginSubscriptionStatus.SubscriptionUnsubscribed
         source: InputStyle.infoIcon
         text: qsTr("Your subscription will not auto-renew after %1")
               .arg(root.subscriptionsTimestamp)
       }
 
       TextWithIcon {
-        visible: root.subscriptionStatus === MerginSubscriptionStatus.SubscriptionInGracePeriod
         width: parent.width
+        height: InputStyle.rowHeight
+        visible: root.subscriptionStatus === MerginSubscriptionStatus.SubscriptionInGracePeriod
         source: InputStyle.exclamationTriangleIcon
         onLinkActivated: Qt.openUrlExternally(link)
         text: qsTr("Please update your %1billing details%2 as soon as possible")
@@ -145,8 +150,9 @@ Page {
       }
 
       TextWithIcon {
-        visible: root.subscriptionStatus === MerginSubscriptionStatus.ValidSubscription
         width: parent.width
+        height: InputStyle.rowHeight
+        visible: root.subscriptionStatus === MerginSubscriptionStatus.ValidSubscription
         source: InputStyle.todayIcon
         text: qsTr("Your next bill will be for %1 on %2")
         .arg(root.nextBillPrice)
@@ -154,8 +160,9 @@ Page {
       }
 
       TextWithIcon {
-        visible: root.subscriptionStatus === MerginSubscriptionStatus.CanceledSubscription
         width: parent.width
+        height: InputStyle.rowHeight
+        visible: root.subscriptionStatus === MerginSubscriptionStatus.CanceledSubscription
         source: InputStyle.todayIcon
         text: qsTr("Your subscription was cancelled on %1")
               .arg(root.subscriptionsTimestamp)

--- a/app/qml/SubscribePlanItem.qml
+++ b/app/qml/SubscribePlanItem.qml
@@ -33,36 +33,42 @@ Item {
 
     TextWithIcon {
       width: parent.width
+      height: InputStyle.rowHeight
       source: InputStyle.infoIcon
       text: "Mergin " + root.name + " " + qsTr("Plan")
     }
 
     TextWithIcon {
       width: parent.width
+      height: InputStyle.rowHeight
       source: InputStyle.todayIcon
       text: hasPlan ? "Custom billing period" : root.plan.period /* Do not translate, only used for test subscriptions */
     }
 
     TextWithIcon {
       width: parent.width
+      height: InputStyle.rowHeight
       source: InputStyle.databaseIcon
       text: hasPlan ? "Custom storage" : root.plan.storage /* Do not translate, only used for test subscriptions */
     }
 
     TextWithIcon {
       width: parent.width
+      height: InputStyle.rowHeight
       source: InputStyle.accountMultiIcon
       text: qsTr("Unlimited collaborators")
     }
 
     TextWithIcon {
       width: parent.width
+      height: InputStyle.rowHeight
       source: InputStyle.projectIcon
       text: qsTr("Unlimited projects")
     }
 
     TextWithIcon {
       width: parent.width
+      height: InputStyle.rowHeight
       source: InputStyle.envelopeIcon
       text: qsTr("Email support")
     }

--- a/app/qml/misc/AttentionBanner.qml
+++ b/app/qml/misc/AttentionBanner.qml
@@ -17,6 +17,7 @@ Rectangle {
 
   TextWithIcon {
     width: parent.width
+    height: InputStyle.rowHeight
     fontColor: 'white'
     bgColor: '#ff4f4f'
     iconColor: 'white'


### PR DESCRIPTION
TextWithIcon has changed and we missed to upload its needed properties. PR sets height to all occurences of `TextWithIcon`.

<img src="https://user-images.githubusercontent.com/22449698/144816612-4a45e9eb-211d-497f-a757-2590eb24ca64.png" width=300>


Resolves #1773 