### PR TITLE
Replace datetime(calendar) widget from controls1

### DIFF
--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -46,6 +46,7 @@ QtObject {
 
     property int fontPointSizeSmall: 12
     property int fontPointSizeNormal: 15
+    property int fontPointSizeBig: 18
 
     property int borderSize: scale(1)
 

--- a/app/qml/components/DateTimePicker.qml
+++ b/app/qml/components/DateTimePicker.qml
@@ -1,635 +1,626 @@
 import QtQuick 2.14
-import QtQuick.Window 2.2
+import QtQuick.Layouts 1.14
 import QtQuick.Controls 2.14
 import Qt.labs.calendar 1.0
+import QtGraphicalEffects 1.14
+
+// Inspired by https://gist.github.com/ilnuribat/5cc6010aea7e35708ff90c65d7be5bcf
 
 Item {
-    id: root
+  id: root
 
-    property bool hasTimePicker: true
-    property bool hasDatePicker: true
+  property bool hasTimePicker: true
+  property bool hasDatePicker: true
 
-    property date dateToSelect: new Date()
+  property date dateToSelect: new Date()
 
-    property int fontPointSizeBig: 15
-    property int fontPointSizeNormal: 12
+  property int fontPointSizeBig: 18
+  property int fontPointSizeNormal: 15
+  property int fontPointSizeSmall: 12
 
-    signal selected(date selectedDate)
-    signal canceled()
+  signal selected(date selectedDate)
+  signal canceled()
 
-    onSelected: console.log("DATE:", selectedDate)
-    onCanceled: console.log("CANCEL")
-
-    function getSelectedTime() {
-        if (hasDatePicker && hasTimePicker) {
-            let ddate = datepicker.date
-            let time = timepicker.time
-            var newDate = new Date(
-                ddate.getFullYear(),
-                ddate.getMonth(),
-                ddate.getDate(),
-                time.getHours(),
-                time.getMinutes(),
-                time.getSeconds(),
-                time.getMilliseconds()
+  function getSelectedTime() {
+    if (hasDatePicker && hasTimePicker) {
+      let ddate = calendar.selectedDate
+      let time = timepicker.time
+      var newDate = new Date(
+            ddate.getFullYear(),
+            ddate.getMonth(),
+            ddate.getDate(),
+            time.getHours(),
+            time.getMinutes(),
+            time.getSeconds(),
+            time.getMilliseconds()
             )
-            return newDate
-        } else if (hasDatePicker) {
-            return datepicker.date
-        } else if (hasTimePicker) {
-            return timepicker.time
+      return newDate
+    } else if (hasDatePicker) {
+      return calendar.selectedDate
+    } else if (hasTimePicker) {
+      return timepicker.time
+    }
+    return new Date()
+  }
+
+  function setDate(toDate) {
+    calendar.selectDate(toDate)
+    calendar.navigateToDate(toDate)
+    timepicker.setTime(toDate)
+  }
+
+  onDateToSelectChanged: {
+    setDate(dateToSelect)
+  }
+
+  focus: true
+
+  Keys.onReleased: {
+    if ( event.key === Qt.Key_Back || event.key === Qt.Key_Escape ) {
+      event.accepted = true
+      root.canceled()
+    }
+  }
+
+  height: 400
+  width: 400
+
+  QtObject {
+    id: palette
+    property color primary: "#006146"
+    property color primary_dark: "#006146"
+    property color primary_light: "#B2EBF2"
+    property color accent: "#FF5722"
+    property color primary_text: "#212121"
+    property color secondary_text: "#757575"
+    property color icons: "#FFFFFF"
+    property color divider: "#BDBDBD"
+  }
+
+  ColumnLayout {
+    anchors.fill: parent
+
+    spacing: 0
+
+    Rectangle {
+      id: header
+
+      Layout.fillWidth: true
+      Layout.minimumHeight: 40
+      Layout.preferredHeight: 50
+      Layout.maximumHeight: 55
+
+      color: palette.primary_dark
+
+      Rectangle {
+        id: cancelBtn
+
+        height: parent.height
+        width: cancelBtnText.contentWidth + 15
+
+        anchors {
+          left: parent.left
+          leftMargin: 10
+          verticalCenter: parent.verticalCenter
         }
-        return new Date()
-    }
 
-    function setDate(toDate) {
-        datepicker.setDate(toDate)
-        timepicker.set(toDate)
-    }
+        color: palette.primary_dark
+        Text {
+          id: cancelBtnText
+          anchors.centerIn: parent
+          font.pointSize: root.fontPointSizeBig
+          font.bold: true
+          color: "#FD9626"
+          text: "Cancel"
+        }
+        MouseArea {
+          anchors.fill: parent
+          onClicked: {
+            root.canceled();
+          }
+        }
+      }
 
-    Component.onCompleted: {
-        timepicker.set(dateToSelect)
-    }
+      Column {
+        id: yearDayContainer
 
-    height: 400
-    width: 400
+        width: parent.width / 4
+        height: parent.height
 
-    Column {
-        anchors.fill: parent
-        spacing: 0
+        anchors {
+          horizontalCenter: parent.horizontalCenter
+        }
 
         Rectangle {
-                id: titleOfDate
+          id: selectedYear
 
-                width: parent.width
-                height: 55 // HEADER HEIGHT!
+          visible: root.hasDatePicker
+          height: parent.height / 2
+          width: parent.width
+          color: palette.primary_dark
+          Text {
+            id: yearTitle
 
-                color: palette.primary_dark
+            anchors.centerIn: parent
 
-                Rectangle {
-                    id: selectedYear
+            font.pointSize: root.fontPointSizeBig
+            opacity: yearsList.visible ? 1 : 0.7
+            color: "white"
+            text: calendar.selectedDate.getFullYear()
+          }
+          MouseArea {
+            anchors.fill: parent
+            onClicked: {
+              yearsList.show();
+            }
+          }
+        }
 
-                    anchors {
-                        top: parent.top
-                        left: parent.left
-                        right: parent.right
-                    }
+        Text {
+          id: selectedWeekDayMonth
 
-                    visible: root.hasDatePicker
-                    height: parent.height / 2
-                    color: parent.color
-                    Text {
-                        id: yearTitle
+          visible: root.hasDatePicker
 
-                        anchors.fill: parent
+          height: parent.height / 2
+          width: parent.width
 
-                        leftPadding: 10
-                        topPadding: 10
+          horizontalAlignment: Text.AlignHCenter
+          verticalAlignment: Text.AlignVCenter
 
-                        horizontalAlignment: Text.AlignLeft
-                        verticalAlignment: Text.AlignVCenter
+          font.pointSize: root.fontPointSizeNormal
+          text: calendar.weekNames[calendar.selectedDate.getDay()].slice(0, 3) + ", " + calendar.selectedDate.getDate() + " " + calendar.months[calendar.selectedDate.getMonth()].slice(0, 3)
+          color: "white"
+          opacity: yearsList.visible ? 0.7 : 1
 
-                        font.pointSize: root.fontPointSizeBig
-                        opacity: yearsList.visible ? 1 : 0.7
-                        color: "white"
-                        text: calendar.currentYear
-                    }
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: {
-                            yearsList.show();
-                        }
-                    }
+          MouseArea {
+            anchors.fill: parent
+            onClicked: {
+              yearsList.hide();
+            }
+          }
+        }
+      }
+
+      Rectangle {
+        id: okBtn
+
+        height: parent.height
+        width: okBtnText.contentWidth + 15
+
+        anchors {
+          right: parent.right
+          rightMargin: 10
+          verticalCenter: parent.verticalCenter
+        }
+
+        color: palette.primary_dark
+
+        Text {
+          id: okBtnText
+
+          anchors.centerIn: parent
+
+          font.pointSize: root.fontPointSizeBig
+          font.bold: true
+
+          color: "#FD9626"
+          text: "Ok"
+        }
+        MouseArea {
+          anchors.fill: parent
+          onClicked: {
+            root.selected(getSelectedTime())
+          }
+        }
+      }
+    }
+
+    Rectangle {
+      id: placeholder // placeholder that consumes all white space when we only show timepicker
+
+      property bool isActive: !root.hasDatePicker && hasTimePicker
+
+      color: "transparent"
+      Layout.fillWidth: isActive ? true : false
+      Layout.fillHeight: isActive ? true : false
+    }
+
+    Rectangle {
+      id: datepickerContainer
+
+      Layout.fillWidth: root.hasDatePicker ? true : false
+      Layout.fillHeight: root.hasDatePicker ? true : false
+
+      Item {
+        id: calendar
+
+        property date selectedDate: new Date()
+
+        property int startYear: 1940
+        property int endYear: 2040
+
+        property var months: [
+          qsTr("January"), qsTr("February"), qsTr("March"), qsTr("April"),
+          qsTr("May"), qsTr("June"), qsTr("July"), qsTr("August"),
+          qsTr("September"), qsTr("October"), qsTr("November"), qsTr("December")
+        ]
+
+        property var weekNames: [
+          qsTr("Sunday"), qsTr("Monday"), qsTr("Tuesday"), qsTr("Wednesday"),
+          qsTr("Thursday"), qsTr("Friday"), qsTr("Saturday")
+        ]
+
+        function selectDate(ddate) {
+          calendar.selectedDate = ddate
+        }
+
+        function navigateToDate(ddate) {
+          monthGrid.year = ddate.getFullYear()
+          monthGrid.month = ddate.getMonth()
+        }
+
+        anchors.fill: parent
+
+        ColumnLayout {
+
+          anchors.fill: parent
+
+          spacing: 5
+
+          Rectangle {
+            id: monthYearTitle
+
+            Layout.preferredHeight: parent.height / 10
+            Layout.maximumHeight: parent.height / 9
+            Layout.fillWidth: true
+
+            Image {
+              id: leftArrow
+
+              anchors.left: parent.left
+              anchors.leftMargin: 20
+              anchors.verticalCenter: parent.verticalCenter
+
+              source: customStyle.icons.valueRelationMore
+
+              width: parent.height * 0.5
+              sourceSize.width: parent.height * 0.5
+
+              rotation: 180
+
+              MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                  if (monthGrid.month !== Calendar.January) {
+                    monthGrid.month -= 1;
+                  } else {
+                    monthGrid.year -= 1;
+                    monthGrid.month = Calendar.December;
+                  }
                 }
-                Text {
-                    id: selectedWeekDayMonth
-
-                    anchors {
-                        left: parent.left
-                        right: parent.right
-                        top: selectedYear.bottom
-                        bottom: parent.bottom
-                    }
-
-                    visible: root.hasDatePicker
-                    leftPadding: root.fontPointSizeNormal
-                    verticalAlignment: Text.AlignVCenter
-                    font.pointSize: root.fontPointSizeNormal
-                    text: calendar.weekNames[calendar.week].slice(0, 3) + ", " + calendar.currentDay + " " + calendar.months[calendar.currentMonth].slice(0, 3)
-                    color: "white"
-                    opacity: yearsList.visible ? 0.7 : 1
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: {
-                            yearsList.hide();
-                        }
-                    }
-                }
-
-                Row {
-                    layoutDirection: "RightToLeft"
-
-                    anchors {
-                        right: parent.right
-                        rightMargin: 10
-                    }
-
-                    height: parent.height
-
-                    Rectangle {
-                        id: okBtn
-
-                        height: parent.height
-                        width: okBtnText.contentWidth + 15
-
-                        color: palette.primary_dark
-
-                        Text {
-                            id: okBtnText
-
-                            anchors.centerIn: parent
-
-                            font.pointSize: root.fontPointSizeBig
-                            font.bold: true
-
-                            color: "#FD9626"
-                            text: "Ok"
-                        }
-                        MouseArea {
-                            anchors.fill: parent
-                            onClicked: {
-                                root.selected(getSelectedTime())
-                            }
-                        }
-                    }
-
-                    Rectangle {
-                        id: cancelBtn
-
-                        height: parent.height
-                        width: cancelBtnText.contentWidth + 15
-                        color: palette.primary_dark
-                        Text {
-                            id: cancelBtnText
-                            anchors.centerIn: parent
-                            font.pointSize: root.fontPointSizeBig
-                            font.bold: true
-                            color: "#FD9626"
-                            text: "Cancel"
-                        }
-                        MouseArea {
-                            anchors.fill: parent
-                            onClicked: {
-                                root.canceled();
-                            }
-                        }
-                    }
-                }
+              }
             }
 
-        // TIMEPICKER
-        Row {
-
-            height: {
-                if (!root.hasTimePicker) return 0
-                else if (root.hasDatePicker) return parent.height * 1/5
-                else return parent.height / 2
+            ColorOverlay {
+              anchors.fill: leftArrow
+              source: leftArrow
+              rotation: 180
+              color: customStyle.fields.fontColor
             }
-
-            width: root.width
-            visible: root.hasTimePicker
-
-            spacing: 20
-
-            leftPadding: 50
 
             Text {
-                id: timetext
+              anchors.centerIn: parent
+              font.pointSize: root.fontPointSizeNormal
+              text: calendar.months[monthGrid.month] + " " + monthGrid.year;
+            }
 
-                text: qsTr("Time")
+            Image {
+              id: rightArrow
+
+              anchors.right: parent.right
+              anchors.rightMargin: 20
+              anchors.verticalCenter: parent.verticalCenter
+
+              source: customStyle.icons.valueRelationMore
+
+              width: parent.height * 0.5
+              sourceSize.width: parent.height * 0.5
+
+              MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                  if (monthGrid.month != Calendar.December) {
+                    monthGrid.month += 1;
+                  } else {
+                    monthGrid.month = Calendar.January
+                    monthGrid.year += 1;
+                  }
+                }
+              }
+            }
+
+            ColorOverlay {
+              anchors.fill: rightArrow
+              source: rightArrow
+              color: customStyle.fields.fontColor
+            }
+          }
+
+          DayOfWeekRow {
+            id: weekTitles
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: parent.height / 10
+            Layout.maximumHeight: parent.height / 9
+
+            locale: monthGrid.locale
+
+            delegate: Text {
+              text: model.shortName
+              horizontalAlignment: Text.AlignHCenter
+              verticalAlignment: Text.AlignVCenter
+              font.pointSize: root.fontPointSizeSmall
+            }
+          }
+
+          MonthGrid {
+            id: monthGrid
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            month: 10
+            year: 2020
+
+            spacing: 0
+
+            locale: Qt.locale()
+
+            delegate: Rectangle {
+              property bool highlighted: enabled
+                                         && model.day === calendar.selectedDate.getDate()
+                                         && model.month === calendar.selectedDate.getMonth()
+                                         && model.year === calendar.selectedDate.getFullYear()
+
+              height: 10
+              width: 10
+              radius: height * 0.5
+
+              enabled: model.month === monthGrid.month
+              color: enabled && highlighted ? palette.primary_dark : "white"
+
+              Text {
+                anchors.centerIn: parent
+                text: model.day
                 font.pointSize: root.fontPointSizeNormal
-                color: "black"
-                anchors.verticalCenter: parent.verticalCenter
+                scale: highlighted ? 1.25 : 1
+                Behavior on scale {
+                  NumberAnimation {
+                    duration: 150
+                  }
+                }
+                visible: parent.enabled
+                color: parent.highlighted ? "white" : "black"
+              }
+
+              MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                  calendar.selectDate(model.date)
+                }
+              }
             }
+          }
+        }
+      }
 
-            Item {
-                id: timepicker
+      ListView {
+        id: yearsList
 
-                property date time: new Date()
-                property int rows: 3 // number of rows on the screen     (must be odd). Also change model ''
-                property int repetitions: 5 // number of times data is repeated (must be odd)
+        property int currentYear
+        property int startYear: calendar.startYear
+        property int endYear: calendar.endYear
 
-                // public
-                function set(toDate) {
-                    // e.g. new Date(0, 0, 0,  0, 0)) // 12:00 AM
+        anchors.fill: calendar
 
-                    repeater.itemAt(0).positionViewAtIndex(24 * (repetitions - 1) / 2 + toDate.getHours(), ListView.Center) // hour
-                    repeater.itemAt(1).positionViewAtIndex(60 / interval * (repetitions - 1) / 2 + toDate.getMinutes() / interval, ListView.Center) // minute
-                    repeater.itemAt(2).positionViewAtIndex(60 / interval * (repetitions - 1) / 2 + toDate.getSeconds() / interval, ListView.Center) // am/pm
+        orientation: ListView.Vertical
+        visible: false
+        clip: true
+        spacing: 10
 
-                    for (var column = 0; column < repeater.count; column++) select(repeater.itemAt(column))
-                }
-
-                function get() {
-                    return new Date(0, 0, 0,
-                        repeater.itemAt(0).get(repeater.itemAt(0).currentIndex), // hour
-                        repeater.itemAt(1).get(repeater.itemAt(1).currentIndex), // minute
-                        repeater.itemAt(2).get(repeater.itemAt(2).currentIndex)) // second
-                }
-
-                function select(view) {
-                    view.currentIndex = view.indexAt(0, view.contentY + 0.5 * view.height)
-                } // index at vertical center
-
-                signal clicked(date d); //onClicked: print('onClicked', date.toTimeString())
-
-                property int interval: 1 // 30 20 15 10 5 2 1 minutes
-
-                width: parent.width - timetext.width - parent.spacing - parent.leftPadding
-                height: parent.height // default size
-
-                // Rectangle {anchors.fill: parent; color:"blue"; opacity:.1}
-
-                clip: true
-
-                // onHeightChanged: resizeTimer.start() // resize
-
-                // Timer {
-                //     // ensure same value is selected after resize
-                //     id: resizeTimer;
-                //     interval: 1000;
-                //     onTriggered: timepicker.set(timepicker.get())
-                // }
-
-                Row {
-                    id: numberspinner
-
-                    anchors.right: parent.right
-                    anchors.rightMargin: 50
-                    spacing: 10
-
-                    Repeater {
-                        id: repeater
-
-                        model: [24*5, 60*5, 60*5] // 1-12 hour, 0-59 minute, am/pm
-
-                        delegate: ListView {
-                            // hours minutes am/pm
-                            id: view
-
-                            property int column: index // outer index
-                            width: timepicker.width / 10
-                            height: timepicker.height
-
-                            snapMode: ListView.SnapToItem
-
-                            spacing: 0
-
-                            model: modelData
-
-                            delegate: Item {
-
-                                property bool isSelected: view.currentIndex === index
-
-                                width: 20
-                                height: timepicker.height / 3
-
-                                Text {
-                                    text: view.get(index)
-
-                                    font.bold: isSelected ? true : false
-                                    font.pointSize: isSelected ? root.fontPointSizeBig : fontPointSizeNormal
-
-                                    color: isSelected ? palette.primary_dark :"black"
-                                    opacity: isSelected? 1: 0.3
-
-                                    anchors {
-                                        verticalCenter: parent.verticalCenter
-                                        right: column == 0? parent.right: undefined
-                                        horizontalCenter: column == 1? parent.horizontalCenter: undefined
-                                        left: column == 2? parent.left: undefined
-                                    }
-                                }
-                            }
-
-                            onMovementEnded: {
-                                timepicker.select(view)
-                                timer.restart()
-                            }
-                            onFlickEnded: {
-                                timepicker.select(view)
-                                timer.restart()
-                            }
-
-                            Timer {
-                                id: timer
-                                interval: 1
-                                onTriggered: {
-                                    timepicker.time = timepicker.get()
-                                    getSelectedTime()
-                                }
-                            } // emit only once
-
-                            function get(index) {
-                                // returns e.g. '00' given row
-                                if (column == 0) return ('0' + (index * 1) % 24).slice(-2) // hour
-                                else if (column == 1) return ('0' + (index * 1) % 60).slice(-2) // minute
-                                else return ('0' + (index * 1) % 60).slice(-2) // seconds
-                            }
-                        }
-                    }
-                }
-
-                Text {
-                    // separator
-                    text: ":"
-                    anchors.verticalCenter: numberspinner.verticalCenter
-                    anchors.left: numberspinner.left
-                    anchors.leftMargin: 29
-
-                    font.bold: true
-                    font.pointSize: root.fontPointSizeNormal
-                    color: "black"
-                }
-                Text {
-                    // separator
-                    text: ":"
-                    anchors.verticalCenter: numberspinner.verticalCenter
-                    anchors.left: numberspinner.left
-                    anchors.leftMargin: 65
-
-                    font.bold: true
-                    font.pointSize: root.fontPointSizeNormal
-                    color: "black"
-                }
-            }
+        model: ListModel {
+          id: yearsModel
         }
 
-        Rectangle {
-            id: separator
-
+        delegate: Rectangle {
+          width: parent.width
+          height: 30
+          Text {
+            anchors.centerIn: parent
+            font.pointSize: root.fontPointSizeNormal
+            text: name
+            scale: index === (yearsList.currentYear - yearsList.startYear) ? 1.5 : 1
             color: palette.primary_dark
-            width: parent.width
-            height: 1
+          }
+          MouseArea {
+            anchors.fill: parent
+            onClicked: {
+              calendar.navigateToDate(new Date(yearsList.startYear + index, calendar.selectedDate.getMonth()));
+              yearsList.hide();
+            }
+          }
         }
 
-        Rectangle {
-            id: datepicker
-
-            property double cellSize: root.height / 20
-            property int fontSizePx
-            property var date: new Date(calendar.currentYear, calendar.currentMonth, calendar.currentDay);
-
-            function setCurrentDate() {
-                datepicker.date = new Date(calendar.currentYear, calendar.currentMonth, calendar.currentDay);
-                root.getSelectedTime()
-            }
-
-            function setDate(ddate) {
-                calendar.currentDay = ddate.getDate();
-                calendar.currentMonth = ddate.getMonth();
-                calendar.week = ddate.getDay();
-                calendar.currentYear = ddate.getFullYear();
-                calendarModel.setYear(ddate.getFullYear())
-            }
-
-            width: parent.width
-            height: {
-                if (!root.hasDatePicker) return 0
-                else if (root.hasTimePicker) return parent.height * 4/5
-                else return parent.height
-            }
-
-            clip: true
-
-            QtObject {
-                id: palette
-                property color primary: "#006146"
-                property color primary_dark: "#006146"
-                property color primary_light: "#B2EBF2"
-                property color accent: "#FF5722"
-                property color primary_text: "#212121"
-                property color secondary_text: "#757575"
-                property color icons: "#FFFFFF"
-                property color divider: "#BDBDBD"
-            }
-
-            ListView {
-                id: calendar
-
-                property int currentDay: new Date().getDate()
-                property int currentMonth: new Date().getMonth()
-                property int currentYear: new Date().getFullYear()
-                property int week: new Date().getDay()
-
-                property var months: [
-                    qsTr("January"), qsTr("February"), qsTr("March"), qsTr("April"),
-                    qsTr("May"), qsTr("June"), qsTr("July"), qsTr("August"),
-                    qsTr("September"), qsTr("October"), qsTr("November"), qsTr("December")
-                ]
-
-                property var weekNames: [
-                    qsTr("Sunday"), qsTr("Monday"), qsTr("Tuesday"), qsTr("Wednesday"),
-                    qsTr("Thursday"), qsTr("Friday"), qsTr("Saturday")
-                ]
-
-                anchors {
-                    left: parent.left
-                    right: parent.right
-                }
-
-                height: parent.height - titleOfDate.height
-                visible: true
-
-                snapMode: ListView.SnapOneItem
-                orientation: ListView.Horizontal
-
-                model: CalendarModel {
-                    id: calendarModel
-
-                    function setYear(newYear) {
-                        if (calendarModel.from.getFullYear() > newYear) {
-                            calendarModel.from = new Date(newYear, 0, 1);
-                            calendarModel.to = new Date(newYear, 11, 31);
-                        } else {
-                            calendarModel.to = new Date(newYear, 11, 31);
-                            calendarModel.from = new Date(newYear, 0, 1);
-                        }
-                        calendar.currentYear = newYear;
-                        calendar.goToLastPickedDate();
-                        datepicker.setCurrentDate();
-                    }
-
-                    from: new Date(new Date().getFullYear(), 0, 1);
-                    to: new Date(new Date().getFullYear(), 11, 31);
-                }
-
-                delegate: Rectangle {
-                    height: datepicker.cellSize * 8.5
-                    width: datepicker.width
-
-                    Rectangle {
-                        id: monthYearTitle
-
-                        anchors {
-                            top: parent.top
-                        }
-
-                        height: datepicker.cellSize * 1.3
-                        width: parent.width
-
-                        Text {
-                            anchors.centerIn: parent
-                            font.pointSize: root.fontPointSizeNormal
-                            text: calendar.months[model.month] + " " + model.year;
-                        }
-                    }
-
-                    DayOfWeekRow {
-                        id: weekTitles
-
-                        locale: monthGrid.locale
-
-                        anchors {
-                            top: monthYearTitle.bottom
-                        }
-
-                        height: datepicker.cellSize
-                        width: parent.width
-
-                        delegate: Text {
-                            text: model.shortName
-                            horizontalAlignment: Text.AlignHCenter
-                            verticalAlignment: Text.AlignVCenter
-                            font.pointSize: root.fontPointSizeNormal
-                        }
-                    }
-
-                    MonthGrid {
-                        id: monthGrid
-
-                        month: model.month
-                        year: model.year
-
-                        spacing: 0
-
-                        anchors {
-                            top: weekTitles.bottom
-                        }
-
-                        width: parent.width
-                        height: datepicker.height - titleOfDate.height
-
-                        locale: Qt.locale()
-
-                        delegate: Rectangle {
-                            property bool highlighted: enabled && model.day === calendar.currentDay && model.month === calendar.currentMonth
-
-                            height: datepicker.cellSize
-                            width: datepicker.cellSize
-                            radius: height * 0.5
-
-                            enabled: model.month === monthGrid.month
-                            color: enabled && highlighted ? palette.primary_dark : "white"
-
-                            Text {
-                                anchors.centerIn: parent
-                                text: model.day
-                                font.pointSize: root.fontPointSizeNormal
-                                scale: highlighted ? 1.25 : 1
-                                Behavior on scale {
-                                    NumberAnimation {
-                                        duration: 150
-                                    }
-                                }
-                                visible: parent.enabled
-                                color: parent.highlighted ? "white" : "black"
-                            }
-
-                            MouseArea {
-                                anchors.fill: parent
-                                onClicked: {
-                                    calendar.currentDay = model.date.getDate();
-                                    calendar.currentMonth = model.date.getMonth();
-                                    calendar.week = model.date.getDay();
-                                    calendar.currentYear = model.date.getFullYear();
-                                    datepicker.setCurrentDate();
-                                }
-                            }
-                        }
-                    }
-                }
-
-                Component.onCompleted: goToLastPickedDate()
-
-                function goToLastPickedDate() {
-                    positionViewAtIndex(calendar.currentMonth, ListView.SnapToItem)
-                }
-            }
-
-            ListView {
-                id: yearsList
-
-                property int currentYear
-                property int startYear: 1940
-                property int endYear : new Date().getFullYear() + 50;
-
-                anchors.fill: calendar
-
-                orientation: ListView.Vertical
-                visible: false
-                clip: true
-
-                model: ListModel {
-                    id: yearsModel
-                }
-
-                delegate: Rectangle {
-                    width: parent.width
-                    height: datepicker.cellSize * 1.5
-                    Text {
-                        anchors.centerIn: parent
-                        font.pointSize: root.fontPointSizeNormal
-                        text: name
-                        scale: index === (yearsList.currentYear - yearsList.startYear) ? 1.5 : 1
-                        color: palette.primary_dark
-                    }
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: {
-                            calendarModel.setYear(yearsList.startYear + index);
-                            yearsList.hide();
-                        }
-                    }
-                }
-
-                Component.onCompleted: {
-                    for (var year = startYear; year <= endYear; year ++)
-                        yearsModel.append({
-                        name: year
-                    });
-                }
-                function show() {
-                    visible = true
-                    calendar.visible = false
-                    currentYear = calendar.currentYear
-                    yearsList.positionViewAtIndex(currentYear - startYear, ListView.SnapToItem)
-                }
-                function hide() {
-                    visible = false;
-                    calendar.visible = true;
-                }
-            }
-
-            Rectangle {
-                height: datepicker.cellSize * 1.5
-                anchors {
-                    top: calendar.bottom
-                    right: parent.right
-                    rightMargin: datepicker.cellSize * 0.5
-                }
-                color: "black"
-            }
+        Component.onCompleted: {
+          for (var year = startYear; year <= endYear; year ++)
+            yearsModel.append({
+                                name: year
+                              });
         }
+
+        function show() {
+          visible = true
+          calendar.visible = false
+          currentYear = calendar.selectedDate.getFullYear()
+          yearsList.positionViewAtIndex(currentYear - startYear, ListView.SnapToItem)
+        }
+
+        function hide() {
+          visible = false;
+          calendar.visible = true;
+        }
+      }
     }
+
+    Rectangle {
+      id: separator
+
+      color: palette.primary_dark
+
+      visible: root.hasDatePicker
+
+      Layout.preferredWidth: parent.width
+      Layout.maximumHeight: 1
+      Layout.minimumHeight: 1
+    }
+
+    Rectangle {
+      id: timepicker
+
+      property date time: new Date()
+
+      function setTime(ddatetime) {
+        let hour = ddatetime.getHours()
+        let minutes = ddatetime.getMinutes()
+        let seconds = ddatetime.getSeconds()
+
+        hoursTumbler.currentIndex = hour
+        minutesTumbler.currentIndex = minutes
+        secondsTumbler.currentIndex = seconds
+      }
+
+      function constructTime() {
+        let ddate = new Date (
+              2000, 1, 1,
+              hoursTumbler.currentIndex,
+              minutesTumbler.currentIndex,
+              secondsTumbler.currentIndex
+              )
+        timepicker.time = ddate
+      }
+
+      Layout.fillWidth: true
+      Layout.minimumHeight: root.hasTimePicker ? parent.height / 6 : 0
+      Layout.preferredHeight: {
+        if (!root.hasTimePicker) return 0
+        if (root.hasDatePicker) return parent.height * 3 / 10
+        return parent.height
+      }
+      Layout.maximumHeight: {
+        if (!root.hasTimePicker) return 0
+        if (root.hasDatePicker) return parent.height / 4
+        return 200
+      }
+
+      visible: root.hasTimePicker
+
+      FontMetrics {
+        id: fontMetrics
+      }
+
+      Component {
+        id: delegateComponent
+
+        Label {
+          property bool isActive: modelData === Tumbler.tumbler.currentIndex
+
+          text: modelData.toString().length < 2 ? "0" + modelData : modelData;
+
+          opacity: 1.0 - Math.abs(Tumbler.displacement) / (Tumbler.tumbler.visibleItemCount / 2)
+
+          horizontalAlignment: Text.AlignHCenter
+          verticalAlignment: Text.AlignVCenter
+          font.pointSize: root.fontPointSizeNormal
+
+          color: isActive ? "#006146" : "black"
+        }
+      }
+
+      Item {
+        id: frame
+
+        width: parent.width
+        height: parent.height
+
+        Row {
+
+          anchors.centerIn: parent
+
+          Tumbler {
+            id: hoursTumbler
+
+            onCurrentIndexChanged: timepicker.constructTime()
+
+            width: frame.width/8
+            height: frame.height * .8
+            anchors.verticalCenter: parent.verticalCenter
+
+            model: 24
+            visibleItemCount: 3
+
+            delegate: delegateComponent
+          }
+
+          Text {
+            // separator
+            text: ":"
+            anchors.verticalCenter: parent.verticalCenter
+
+            font.bold: true
+            font.pointSize: root.fontPointSizeNormal
+            color: "black"
+          }
+
+          Tumbler {
+            id: minutesTumbler
+
+            onCurrentIndexChanged: timepicker.constructTime()
+
+            model: 60
+            visibleItemCount: 3
+            width: frame.width/8
+            height: frame.height * .8
+            delegate: delegateComponent
+            anchors.verticalCenter: parent.verticalCenter
+          }
+
+          Text {
+            // separator
+            text: ":"
+            anchors.verticalCenter: parent.verticalCenter
+
+            font.bold: true
+            font.pointSize: root.fontPointSizeNormal
+            color: "black"
+          }
+
+          Tumbler {
+            id: secondsTumbler
+
+            onCurrentIndexChanged: timepicker.constructTime()
+
+            model: 60
+            visibleItemCount: 3
+
+            width: frame.width/8
+            height: frame.height * .8
+
+            delegate: delegateComponent
+
+            anchors.verticalCenter: parent.verticalCenter
+          }
+        }
+      }
+    }
+  }
 }

--- a/app/qml/components/DateTimePicker.qml
+++ b/app/qml/components/DateTimePicker.qml
@@ -1,0 +1,635 @@
+import QtQuick 2.14
+import QtQuick.Window 2.2
+import QtQuick.Controls 2.14
+import Qt.labs.calendar 1.0
+
+Item {
+    id: root
+
+    property bool hasTimePicker: true
+    property bool hasDatePicker: true
+
+    property date dateToSelect: new Date()
+
+    property int fontPointSizeBig: 15
+    property int fontPointSizeNormal: 12
+
+    signal selected(date selectedDate)
+    signal canceled()
+
+    onSelected: console.log("DATE:", selectedDate)
+    onCanceled: console.log("CANCEL")
+
+    function getSelectedTime() {
+        if (hasDatePicker && hasTimePicker) {
+            let ddate = datepicker.date
+            let time = timepicker.time
+            var newDate = new Date(
+                ddate.getFullYear(),
+                ddate.getMonth(),
+                ddate.getDate(),
+                time.getHours(),
+                time.getMinutes(),
+                time.getSeconds(),
+                time.getMilliseconds()
+            )
+            return newDate
+        } else if (hasDatePicker) {
+            return datepicker.date
+        } else if (hasTimePicker) {
+            return timepicker.time
+        }
+        return new Date()
+    }
+
+    function setDate(toDate) {
+        datepicker.setDate(toDate)
+        timepicker.set(toDate)
+    }
+
+    Component.onCompleted: {
+        timepicker.set(dateToSelect)
+    }
+
+    height: 400
+    width: 400
+
+    Column {
+        anchors.fill: parent
+        spacing: 0
+
+        Rectangle {
+                id: titleOfDate
+
+                width: parent.width
+                height: 55 // HEADER HEIGHT!
+
+                color: palette.primary_dark
+
+                Rectangle {
+                    id: selectedYear
+
+                    anchors {
+                        top: parent.top
+                        left: parent.left
+                        right: parent.right
+                    }
+
+                    visible: root.hasDatePicker
+                    height: parent.height / 2
+                    color: parent.color
+                    Text {
+                        id: yearTitle
+
+                        anchors.fill: parent
+
+                        leftPadding: 10
+                        topPadding: 10
+
+                        horizontalAlignment: Text.AlignLeft
+                        verticalAlignment: Text.AlignVCenter
+
+                        font.pointSize: root.fontPointSizeBig
+                        opacity: yearsList.visible ? 1 : 0.7
+                        color: "white"
+                        text: calendar.currentYear
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            yearsList.show();
+                        }
+                    }
+                }
+                Text {
+                    id: selectedWeekDayMonth
+
+                    anchors {
+                        left: parent.left
+                        right: parent.right
+                        top: selectedYear.bottom
+                        bottom: parent.bottom
+                    }
+
+                    visible: root.hasDatePicker
+                    leftPadding: root.fontPointSizeNormal
+                    verticalAlignment: Text.AlignVCenter
+                    font.pointSize: root.fontPointSizeNormal
+                    text: calendar.weekNames[calendar.week].slice(0, 3) + ", " + calendar.currentDay + " " + calendar.months[calendar.currentMonth].slice(0, 3)
+                    color: "white"
+                    opacity: yearsList.visible ? 0.7 : 1
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            yearsList.hide();
+                        }
+                    }
+                }
+
+                Row {
+                    layoutDirection: "RightToLeft"
+
+                    anchors {
+                        right: parent.right
+                        rightMargin: 10
+                    }
+
+                    height: parent.height
+
+                    Rectangle {
+                        id: okBtn
+
+                        height: parent.height
+                        width: okBtnText.contentWidth + 15
+
+                        color: palette.primary_dark
+
+                        Text {
+                            id: okBtnText
+
+                            anchors.centerIn: parent
+
+                            font.pointSize: root.fontPointSizeBig
+                            font.bold: true
+
+                            color: "#FD9626"
+                            text: "Ok"
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                root.selected(getSelectedTime())
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        id: cancelBtn
+
+                        height: parent.height
+                        width: cancelBtnText.contentWidth + 15
+                        color: palette.primary_dark
+                        Text {
+                            id: cancelBtnText
+                            anchors.centerIn: parent
+                            font.pointSize: root.fontPointSizeBig
+                            font.bold: true
+                            color: "#FD9626"
+                            text: "Cancel"
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                root.canceled();
+                            }
+                        }
+                    }
+                }
+            }
+
+        // TIMEPICKER
+        Row {
+
+            height: {
+                if (!root.hasTimePicker) return 0
+                else if (root.hasDatePicker) return parent.height * 1/5
+                else return parent.height / 2
+            }
+
+            width: root.width
+            visible: root.hasTimePicker
+
+            spacing: 20
+
+            leftPadding: 50
+
+            Text {
+                id: timetext
+
+                text: qsTr("Time")
+                font.pointSize: root.fontPointSizeNormal
+                color: "black"
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Item {
+                id: timepicker
+
+                property date time: new Date()
+                property int rows: 3 // number of rows on the screen     (must be odd). Also change model ''
+                property int repetitions: 5 // number of times data is repeated (must be odd)
+
+                // public
+                function set(toDate) {
+                    // e.g. new Date(0, 0, 0,  0, 0)) // 12:00 AM
+
+                    repeater.itemAt(0).positionViewAtIndex(24 * (repetitions - 1) / 2 + toDate.getHours(), ListView.Center) // hour
+                    repeater.itemAt(1).positionViewAtIndex(60 / interval * (repetitions - 1) / 2 + toDate.getMinutes() / interval, ListView.Center) // minute
+                    repeater.itemAt(2).positionViewAtIndex(60 / interval * (repetitions - 1) / 2 + toDate.getSeconds() / interval, ListView.Center) // am/pm
+
+                    for (var column = 0; column < repeater.count; column++) select(repeater.itemAt(column))
+                }
+
+                function get() {
+                    return new Date(0, 0, 0,
+                        repeater.itemAt(0).get(repeater.itemAt(0).currentIndex), // hour
+                        repeater.itemAt(1).get(repeater.itemAt(1).currentIndex), // minute
+                        repeater.itemAt(2).get(repeater.itemAt(2).currentIndex)) // second
+                }
+
+                function select(view) {
+                    view.currentIndex = view.indexAt(0, view.contentY + 0.5 * view.height)
+                } // index at vertical center
+
+                signal clicked(date d); //onClicked: print('onClicked', date.toTimeString())
+
+                property int interval: 1 // 30 20 15 10 5 2 1 minutes
+
+                width: parent.width - timetext.width - parent.spacing - parent.leftPadding
+                height: parent.height // default size
+
+                // Rectangle {anchors.fill: parent; color:"blue"; opacity:.1}
+
+                clip: true
+
+                // onHeightChanged: resizeTimer.start() // resize
+
+                // Timer {
+                //     // ensure same value is selected after resize
+                //     id: resizeTimer;
+                //     interval: 1000;
+                //     onTriggered: timepicker.set(timepicker.get())
+                // }
+
+                Row {
+                    id: numberspinner
+
+                    anchors.right: parent.right
+                    anchors.rightMargin: 50
+                    spacing: 10
+
+                    Repeater {
+                        id: repeater
+
+                        model: [24*5, 60*5, 60*5] // 1-12 hour, 0-59 minute, am/pm
+
+                        delegate: ListView {
+                            // hours minutes am/pm
+                            id: view
+
+                            property int column: index // outer index
+                            width: timepicker.width / 10
+                            height: timepicker.height
+
+                            snapMode: ListView.SnapToItem
+
+                            spacing: 0
+
+                            model: modelData
+
+                            delegate: Item {
+
+                                property bool isSelected: view.currentIndex === index
+
+                                width: 20
+                                height: timepicker.height / 3
+
+                                Text {
+                                    text: view.get(index)
+
+                                    font.bold: isSelected ? true : false
+                                    font.pointSize: isSelected ? root.fontPointSizeBig : fontPointSizeNormal
+
+                                    color: isSelected ? palette.primary_dark :"black"
+                                    opacity: isSelected? 1: 0.3
+
+                                    anchors {
+                                        verticalCenter: parent.verticalCenter
+                                        right: column == 0? parent.right: undefined
+                                        horizontalCenter: column == 1? parent.horizontalCenter: undefined
+                                        left: column == 2? parent.left: undefined
+                                    }
+                                }
+                            }
+
+                            onMovementEnded: {
+                                timepicker.select(view)
+                                timer.restart()
+                            }
+                            onFlickEnded: {
+                                timepicker.select(view)
+                                timer.restart()
+                            }
+
+                            Timer {
+                                id: timer
+                                interval: 1
+                                onTriggered: {
+                                    timepicker.time = timepicker.get()
+                                    getSelectedTime()
+                                }
+                            } // emit only once
+
+                            function get(index) {
+                                // returns e.g. '00' given row
+                                if (column == 0) return ('0' + (index * 1) % 24).slice(-2) // hour
+                                else if (column == 1) return ('0' + (index * 1) % 60).slice(-2) // minute
+                                else return ('0' + (index * 1) % 60).slice(-2) // seconds
+                            }
+                        }
+                    }
+                }
+
+                Text {
+                    // separator
+                    text: ":"
+                    anchors.verticalCenter: numberspinner.verticalCenter
+                    anchors.left: numberspinner.left
+                    anchors.leftMargin: 29
+
+                    font.bold: true
+                    font.pointSize: root.fontPointSizeNormal
+                    color: "black"
+                }
+                Text {
+                    // separator
+                    text: ":"
+                    anchors.verticalCenter: numberspinner.verticalCenter
+                    anchors.left: numberspinner.left
+                    anchors.leftMargin: 65
+
+                    font.bold: true
+                    font.pointSize: root.fontPointSizeNormal
+                    color: "black"
+                }
+            }
+        }
+
+        Rectangle {
+            id: separator
+
+            color: palette.primary_dark
+            width: parent.width
+            height: 1
+        }
+
+        Rectangle {
+            id: datepicker
+
+            property double cellSize: root.height / 20
+            property int fontSizePx
+            property var date: new Date(calendar.currentYear, calendar.currentMonth, calendar.currentDay);
+
+            function setCurrentDate() {
+                datepicker.date = new Date(calendar.currentYear, calendar.currentMonth, calendar.currentDay);
+                root.getSelectedTime()
+            }
+
+            function setDate(ddate) {
+                calendar.currentDay = ddate.getDate();
+                calendar.currentMonth = ddate.getMonth();
+                calendar.week = ddate.getDay();
+                calendar.currentYear = ddate.getFullYear();
+                calendarModel.setYear(ddate.getFullYear())
+            }
+
+            width: parent.width
+            height: {
+                if (!root.hasDatePicker) return 0
+                else if (root.hasTimePicker) return parent.height * 4/5
+                else return parent.height
+            }
+
+            clip: true
+
+            QtObject {
+                id: palette
+                property color primary: "#006146"
+                property color primary_dark: "#006146"
+                property color primary_light: "#B2EBF2"
+                property color accent: "#FF5722"
+                property color primary_text: "#212121"
+                property color secondary_text: "#757575"
+                property color icons: "#FFFFFF"
+                property color divider: "#BDBDBD"
+            }
+
+            ListView {
+                id: calendar
+
+                property int currentDay: new Date().getDate()
+                property int currentMonth: new Date().getMonth()
+                property int currentYear: new Date().getFullYear()
+                property int week: new Date().getDay()
+
+                property var months: [
+                    qsTr("January"), qsTr("February"), qsTr("March"), qsTr("April"),
+                    qsTr("May"), qsTr("June"), qsTr("July"), qsTr("August"),
+                    qsTr("September"), qsTr("October"), qsTr("November"), qsTr("December")
+                ]
+
+                property var weekNames: [
+                    qsTr("Sunday"), qsTr("Monday"), qsTr("Tuesday"), qsTr("Wednesday"),
+                    qsTr("Thursday"), qsTr("Friday"), qsTr("Saturday")
+                ]
+
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                }
+
+                height: parent.height - titleOfDate.height
+                visible: true
+
+                snapMode: ListView.SnapOneItem
+                orientation: ListView.Horizontal
+
+                model: CalendarModel {
+                    id: calendarModel
+
+                    function setYear(newYear) {
+                        if (calendarModel.from.getFullYear() > newYear) {
+                            calendarModel.from = new Date(newYear, 0, 1);
+                            calendarModel.to = new Date(newYear, 11, 31);
+                        } else {
+                            calendarModel.to = new Date(newYear, 11, 31);
+                            calendarModel.from = new Date(newYear, 0, 1);
+                        }
+                        calendar.currentYear = newYear;
+                        calendar.goToLastPickedDate();
+                        datepicker.setCurrentDate();
+                    }
+
+                    from: new Date(new Date().getFullYear(), 0, 1);
+                    to: new Date(new Date().getFullYear(), 11, 31);
+                }
+
+                delegate: Rectangle {
+                    height: datepicker.cellSize * 8.5
+                    width: datepicker.width
+
+                    Rectangle {
+                        id: monthYearTitle
+
+                        anchors {
+                            top: parent.top
+                        }
+
+                        height: datepicker.cellSize * 1.3
+                        width: parent.width
+
+                        Text {
+                            anchors.centerIn: parent
+                            font.pointSize: root.fontPointSizeNormal
+                            text: calendar.months[model.month] + " " + model.year;
+                        }
+                    }
+
+                    DayOfWeekRow {
+                        id: weekTitles
+
+                        locale: monthGrid.locale
+
+                        anchors {
+                            top: monthYearTitle.bottom
+                        }
+
+                        height: datepicker.cellSize
+                        width: parent.width
+
+                        delegate: Text {
+                            text: model.shortName
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            font.pointSize: root.fontPointSizeNormal
+                        }
+                    }
+
+                    MonthGrid {
+                        id: monthGrid
+
+                        month: model.month
+                        year: model.year
+
+                        spacing: 0
+
+                        anchors {
+                            top: weekTitles.bottom
+                        }
+
+                        width: parent.width
+                        height: datepicker.height - titleOfDate.height
+
+                        locale: Qt.locale()
+
+                        delegate: Rectangle {
+                            property bool highlighted: enabled && model.day === calendar.currentDay && model.month === calendar.currentMonth
+
+                            height: datepicker.cellSize
+                            width: datepicker.cellSize
+                            radius: height * 0.5
+
+                            enabled: model.month === monthGrid.month
+                            color: enabled && highlighted ? palette.primary_dark : "white"
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: model.day
+                                font.pointSize: root.fontPointSizeNormal
+                                scale: highlighted ? 1.25 : 1
+                                Behavior on scale {
+                                    NumberAnimation {
+                                        duration: 150
+                                    }
+                                }
+                                visible: parent.enabled
+                                color: parent.highlighted ? "white" : "black"
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: {
+                                    calendar.currentDay = model.date.getDate();
+                                    calendar.currentMonth = model.date.getMonth();
+                                    calendar.week = model.date.getDay();
+                                    calendar.currentYear = model.date.getFullYear();
+                                    datepicker.setCurrentDate();
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Component.onCompleted: goToLastPickedDate()
+
+                function goToLastPickedDate() {
+                    positionViewAtIndex(calendar.currentMonth, ListView.SnapToItem)
+                }
+            }
+
+            ListView {
+                id: yearsList
+
+                property int currentYear
+                property int startYear: 1940
+                property int endYear : new Date().getFullYear() + 50;
+
+                anchors.fill: calendar
+
+                orientation: ListView.Vertical
+                visible: false
+                clip: true
+
+                model: ListModel {
+                    id: yearsModel
+                }
+
+                delegate: Rectangle {
+                    width: parent.width
+                    height: datepicker.cellSize * 1.5
+                    Text {
+                        anchors.centerIn: parent
+                        font.pointSize: root.fontPointSizeNormal
+                        text: name
+                        scale: index === (yearsList.currentYear - yearsList.startYear) ? 1.5 : 1
+                        color: palette.primary_dark
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            calendarModel.setYear(yearsList.startYear + index);
+                            yearsList.hide();
+                        }
+                    }
+                }
+
+                Component.onCompleted: {
+                    for (var year = startYear; year <= endYear; year ++)
+                        yearsModel.append({
+                        name: year
+                    });
+                }
+                function show() {
+                    visible = true
+                    calendar.visible = false
+                    currentYear = calendar.currentYear
+                    yearsList.positionViewAtIndex(currentYear - startYear, ListView.SnapToItem)
+                }
+                function hide() {
+                    visible = false;
+                    calendar.visible = true;
+                }
+            }
+
+            Rectangle {
+                height: datepicker.cellSize * 1.5
+                anchors {
+                    top: calendar.bottom
+                    right: parent.right
+                    rightMargin: datepicker.cellSize * 0.5
+                }
+                color: "black"
+            }
+        }
+    }
+}

--- a/app/qml/components/DateTimePicker.qml
+++ b/app/qml/components/DateTimePicker.qml
@@ -231,6 +231,8 @@ Item {
       Layout.fillWidth: root.hasDatePicker ? true : false
       Layout.fillHeight: root.hasDatePicker ? true : false
 
+      visible: root.hasDatePicker
+
       Item {
         id: calendar
 

--- a/app/qml/components/DateTimePicker.qml
+++ b/app/qml/components/DateTimePicker.qml
@@ -1,10 +1,19 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 import QtQuick 2.14
 import QtQuick.Layouts 1.14
 import QtQuick.Controls 2.14
 import Qt.labs.calendar 1.0
 import QtGraphicalEffects 1.14
 
-// Inspired by https://gist.github.com/ilnuribat/5cc6010aea7e35708ff90c65d7be5bcf
+import ".."
 
 Item {
   id: root
@@ -14,9 +23,9 @@ Item {
 
   property date dateToSelect: new Date()
 
-  property int fontPointSizeBig: 18
-  property int fontPointSizeNormal: 15
-  property int fontPointSizeSmall: 12
+  property int fontPointSizeBig: InputStyle.fontPointSizeBig
+  property int fontPointSizeNormal: InputStyle.fontPointSizeNormal
+  property int fontPointSizeSmall: InputStyle.fontPointSizeSmall
 
   signal selected(date selectedDate)
   signal canceled()
@@ -65,18 +74,6 @@ Item {
   height: 400
   width: 400
 
-  QtObject {
-    id: palette
-    property color primary: "#006146"
-    property color primary_dark: "#006146"
-    property color primary_light: "#B2EBF2"
-    property color accent: "#FF5722"
-    property color primary_text: "#212121"
-    property color secondary_text: "#757575"
-    property color icons: "#FFFFFF"
-    property color divider: "#BDBDBD"
-  }
-
   ColumnLayout {
     anchors.fill: parent
 
@@ -90,7 +87,7 @@ Item {
       Layout.preferredHeight: 50
       Layout.maximumHeight: 55
 
-      color: palette.primary_dark
+      color: InputStyle.clrPanelBackground
 
       Rectangle {
         id: cancelBtn
@@ -104,14 +101,14 @@ Item {
           verticalCenter: parent.verticalCenter
         }
 
-        color: palette.primary_dark
+        color: InputStyle.clrPanelBackground
         Text {
           id: cancelBtnText
           anchors.centerIn: parent
           font.pointSize: root.fontPointSizeBig
           font.bold: true
           color: "#FD9626"
-          text: "Cancel"
+          text: qsTr("Cancel")
         }
         MouseArea {
           anchors.fill: parent
@@ -137,7 +134,7 @@ Item {
           visible: root.hasDatePicker
           height: parent.height / 2
           width: parent.width
-          color: palette.primary_dark
+          color: InputStyle.clrPanelBackground
           Text {
             id: yearTitle
 
@@ -193,7 +190,7 @@ Item {
           verticalCenter: parent.verticalCenter
         }
 
-        color: palette.primary_dark
+        color: InputStyle.clrPanelBackground
 
         Text {
           id: okBtnText
@@ -203,8 +200,8 @@ Item {
           font.pointSize: root.fontPointSizeBig
           font.bold: true
 
-          color: "#FD9626"
-          text: "Ok"
+          color: InputStyle.activeButtonColorOrange
+          text: qsTr("OK")
         }
         MouseArea {
           anchors.fill: parent
@@ -389,7 +386,7 @@ Item {
               radius: height * 0.5
 
               enabled: model.month === monthGrid.month
-              color: enabled && highlighted ? palette.primary_dark : "white"
+              color: enabled && highlighted ? InputStyle.fontColor : "white"
 
               Text {
                 anchors.centerIn: parent
@@ -442,7 +439,7 @@ Item {
             font.pointSize: root.fontPointSizeNormal
             text: name
             scale: index === (yearsList.currentYear - yearsList.startYear) ? 1.5 : 1
-            color: palette.primary_dark
+            color: InputStyle.fontColor
           }
           MouseArea {
             anchors.fill: parent
@@ -477,7 +474,7 @@ Item {
     Rectangle {
       id: separator
 
-      color: palette.primary_dark
+      color: InputStyle.clrPanelBackground
 
       visible: root.hasDatePicker
 
@@ -544,7 +541,7 @@ Item {
           verticalAlignment: Text.AlignVCenter
           font.pointSize: root.fontPointSizeNormal
 
-          color: isActive ? "#006146" : "black"
+          color: isActive ? InputStyle.fontColor : "black"
         }
       }
 

--- a/app/qml/editor/inputdatetime.qml
+++ b/app/qml/editor/inputdatetime.qml
@@ -11,6 +11,7 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 import QtGraphicalEffects 1.14
+import QtQuick.Window 2.14
 
 import "../components" as Components
 
@@ -84,6 +85,7 @@ AbstractEditor {
       requestedDate = new Date()
 
     dateTimeDrawerLoader.active = true
+    dateTimeDrawerLoader.focus = true
     dateTimeDrawerLoader.item.dateToOpen = requestedDate
   }
 
@@ -108,9 +110,6 @@ AbstractEditor {
     id: dateText
 
     text: formatText(root.parentValue)
-
-    onTextChanged: console.log( "TIMEDATE:", labelAlias, text, root.parentField, root.fieldIsDate, root.typeFromFieldFormat, root.parentValue, __inputUtils.fieldType( field ), __inputUtils.dateTimeFieldFormat( config['field_format'] )
- )
 
     anchors.fill: parent
 
@@ -169,10 +168,18 @@ AbstractEditor {
       dragMargin: 0
       closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
-      height: root.includesDate ? parent.height * 2/3 : parent.height * 1/3
+      height: {
+        if (root.includesDate) {
+          if ( Screen.primaryOrientation === Qt.PortraitOrientation ) {
+            return parent.height * 2/3
+          }
+          return parent.height // for landscape mode
+        }
+
+        return parent.height * 1/3
+      }
       width: formView.width
 
-      onOpened: console.log( labelAlias, "W:", width, "H:", height )
       onClosed: dateTimeDrawerLoader.active = false
 
       Component.onCompleted: open()
@@ -194,290 +201,9 @@ AbstractEditor {
         }
 
         onCanceled: {
-          dateTimeDrawer.hide()
+          dateTimeDrawer.close()
         }
       }
     }
   }
 }
-
-//  Components.DatePicker {
-//    id: datePicker
-
-//  }
-
-//    ColumnLayout {
-//        id: main
-//        property var currentValue: value
-//        property bool fieldIsDate: __inputUtils.fieldType( field ) === 'QDate'
-//        property var typeFromFieldFormat: __inputUtils.dateTimeFieldFormat( config['field_format'] )
-//        property var rowHeight: customStyle.fields.height * 0.75
-
-//        anchors { right: parent.right; left: parent.left }
-
-//        Item {
-//            Layout.fillWidth: true
-//            Layout.minimumHeight: customStyle.fields.height
-
-//            TextField {
-//                id: label
-
-//                anchors.fill: parent
-//                verticalAlignment: Text.AlignVCenter
-//                font.pointSize: customStyle.fields.fontPointSize
-//                color: customStyle.fields.fontColor
-//                padding: 0
-//                topPadding: 10 * __dp
-//                bottomPadding: 10 * __dp
-//                leftPadding: customStyle.fields.sideMargin
-//                background: Rectangle {
-//                    radius: customStyle.fields.cornerRadius
-
-//                    border.color: popup.opened ? customStyle.fields.activeColor : customStyle.fields.normalColor
-//                    border.width: popup.opened ? 2 : 1
-//                    color: customStyle.fields.backgroundColor
-//                }
-
-//                text: if ( value === undefined )
-//                        {
-//                          qsTr('(no date)')
-//                        }
-//                        else
-//                        {
-//                          if ( field.isDateOrTime )
-//                          {
-//                            // if the field is a QDate, the automatic conversion to JS date [1]
-//                            // leads to the creation of date time object with the time zone.
-//                            // For instance shapefiles has support for dates but not date/time or time.
-//                            // So a date coming from a shapefile as 2001-01-01 will become 2000-12-31 19:00:00 -05 in QML/JS in UTC -05 zone.
-//                            // And when formatting this with the display format, this is shown as 2000-12-31.
-//                            // So we detect if the field is a date only and revert the time zone offset.
-//                            // [1] http://doc.qt.io/qt-5/qtqml-cppintegration-data.html#basic-qt-data-types
-//                            if (main.fieldIsDate) {
-//                              Qt.formatDateTime( new Date(value.getTime() + value.getTimezoneOffset() * 60000), config['display_format'])
-//                            } else {
-//                              Qt.formatDateTime(value, config['display_format'])
-//                            }
-//                          }
-//                          else
-//                          {
-//                            var date = Date.fromLocaleString(Qt.locale(), value, config['field_format'])
-//                            Qt.formatDateTime(date, config['display_format'])
-//                          }
-//                        }
-
-//                inputMethodHints: Qt.ImhDate
-
-//                MouseArea {
-//                  anchors.fill: parent
-//                  onClicked: {
-//                    var usedDate = new Date();
-//                    if (value !== undefined && value !== '') {
-//                      usedDate = field.isDateOrTime ? value : Date.fromLocaleString(Qt.locale(), value, config['field_format'])
-//                    }
-
-//                    calendar.selectedDate = usedDate
-//                    if (main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time") {
-//                      hoursSpinBox.value = usedDate.getHours()
-//                      minutesSpinBox.value = usedDate.getMinutes()
-//                      secondsSpinBox.value = usedDate.getSeconds()
-//                    }
-
-//                    popup.open()
-//                  }
-//                }
-//            }
-
-//            Image {
-//                id: todayBtn2
-//                height: fieldItem.iconSize
-//                sourceSize.height: fieldItem.iconSize
-//                autoTransform: true
-//                fillMode: Image.PreserveAspectFit
-//                source: customStyle.icons.today
-//                anchors.right: parent.right
-//                anchors.verticalCenter: parent.verticalCenter
-//                visible: fieldItem.enabled
-//                anchors.rightMargin: customStyle.fields.sideMargin
-
-//                MouseArea {
-//                    anchors.fill: parent
-//                    onClicked: {
-//                      var newDate = new Date()
-//                      var newValue = field.isDateOrTime ? newDate : Qt.formatDateTime(newDate, config['field_format'])
-//                      editorValueChanged(newValue, false)
-//                    }
-//                }
-//            }
-
-//            ColorOverlay {
-//                anchors.fill: todayBtn
-//                source: todayBtn
-//                color: customStyle.toolbutton.activeButtonColor
-//                visible: todayBtn.visible
-//            }
-//        }
-
-//        Popup {
-//          id: popup
-//          modal: true
-//          focus: true
-//          closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-//          parent: ApplicationWindow.overlay
-//          anchors.centerIn: parent
-
-//            ScrollView {
-//              clip: true
-//              width: parent.width
-//              height: parent.height
-
-//              ColumnLayout {
-//                Rectangle {
-//                  id: calendarOverlay
-//                  color: "transparent"
-//                  implicitWidth: Math.min(popup.parent.width, popup.parent.height) * 0.8
-//                  implicitHeight: implicitWidth
-//                  visible: main.typeFromFieldFormat === "Date" || main.typeFromFieldFormat === "Date Time"
-
-//                  MouseArea {
-//                      anchors.fill: parent
-//                      onClicked: mouse.accepted = true
-//                      onWheel: wheel.accepted = true
-//                  }
-
-//                  GridLayout {
-//                      id: calendarGrid
-//                      anchors.left: parent.left
-//                      anchors.right: parent.right
-//                      columns: 1
-//                      implicitWidth: calendarOverlay.width
-//                      implicitHeight: calendarOverlay.height
-
-//                        Controls1.Calendar {
-//                          id: calendar
-//                          selectedDate: {
-//                            var date = field.isDateOrTime ? main.currentValue : Date.fromLocaleString(Qt.locale(), value, config['field_format'])
-//                            date || new Date()
-//                          }
-//                          weekNumbersVisible: true
-//                          focus: false
-//                          implicitWidth: calendarOverlay.width
-//                          implicitHeight: calendarOverlay.height
-//                      }
-//                  }
-//              }
-
-//              RowLayout {
-//                visible: main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time"
-//                Layout.alignment: Qt.AlignHCenter
-
-//                  GridLayout {
-//                      id: timeGrid
-//                      Layout.alignment: Qt.AlignHCenter
-//                      Layout.leftMargin: 20
-//                      rows: 3
-//                      columns: 2
-
-//                      Label {
-//                          verticalAlignment: Text.AlignVCenter
-//                          Layout.preferredHeight: main.rowHeight
-//                          Layout.fillWidth: true
-//                          Layout.row: 0
-//                          Layout.column: 0
-//                          text: qsTr( "Hours" )
-
-//                      }
-//                      SpinBox {
-//                          id: hoursSpinBox
-//                          Layout.preferredHeight: main.rowHeight
-//                          Layout.minimumWidth: main.rowHeight * 3
-//                          Layout.fillWidth: true
-//                          Layout.row: 0
-//                          Layout.column: 1
-//                          editable: true
-//                          from: 0
-//                          to: 23
-//                          value: 12
-//                          inputMethodHints: Qt.ImhTime
-//                          down.indicator.width: main.rowHeight
-//                          up.indicator.width: main.rowHeight
-//                      }
-//                      Label {
-//                          verticalAlignment: Text.AlignVCenter
-//                          Layout.preferredHeight: main.rowHeight
-//                          Layout.fillWidth: true
-//                          Layout.row: 1
-//                          Layout.column: 0
-//                          text: qsTr( "Minutes" )
-//                      }
-//                      SpinBox {
-//                          id: minutesSpinBox
-//                          Layout.preferredHeight: main.rowHeight
-//                          Layout.minimumWidth: main.rowHeight * 3
-//                          Layout.fillWidth: true
-//                          Layout.row: 1
-//                          Layout.column: 1
-//                          editable: true
-//                          from: 0
-//                          to: 59
-//                          value: 30
-//                          inputMethodHints: Qt.ImhTime
-//                          down.indicator.width: main.rowHeight
-//                          up.indicator.width: main.rowHeight
-//                      }
-//                      Label {
-//                          verticalAlignment: Text.AlignVCenter
-//                          Layout.preferredHeight: main.rowHeight
-//                          Layout.fillWidth: true
-//                          Layout.row: 2
-//                          Layout.column: 0
-//                          text: qsTr( "Seconds" )
-//                      }
-//                      SpinBox {
-//                          id: secondsSpinBox
-//                          Layout.preferredHeight: main.rowHeight
-//                          Layout.minimumWidth: main.rowHeight * 3
-//                          Layout.fillWidth: true
-//                          Layout.row: 2
-//                          Layout.column: 1
-//                          editable: true
-//                          from: 0
-//                          to: 59
-//                          value: 30
-//                          inputMethodHints: Qt.ImhTime
-//                          down.indicator.width: main.rowHeight
-//                          up.indicator.width: main.rowHeight
-//                      }
-//                  }
-//              }
-
-//              RowLayout {
-//                  Button {
-//                      text: qsTr( "OK" )
-//                      Layout.fillWidth: true
-//                      Layout.preferredHeight: main.rowHeight
-
-//                      onClicked: {
-//                          var newDate = calendar.selectedDate
-
-//                          if (main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time") {
-//                            newDate.setHours(hoursSpinBox.value);
-//                            newDate.setMinutes(minutesSpinBox.value);
-//                            newDate.setSeconds(secondsSpinBox.value);
-//                          }
-
-//                          var newValue = field.isDateOrTime ? newDate : Qt.formatDateTime(newDate, config['field_format'])
-//                          editorValueChanged(newValue, newValue === undefined)
-//                          popup.close()
-//                      }
-//                  }
-//                }
-//             }
-//          }
-//        }
-
-//        onCurrentValueChanged: {
-//            label.text = field.isDateOrTime ? timeToString(main.currentValue) : main.currentValue
-//        }
-//    }
-

--- a/app/qml/editor/inputdatetime.qml
+++ b/app/qml/editor/inputdatetime.qml
@@ -1,10 +1,4 @@
 /***************************************************************************
- datetime.qml
-  --------------------------------------
-  Date                 : 2017
-  Copyright            : (C) 2017 by Matthias Kuhn
-  Email                : matthias@opengis.ch
- ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -13,315 +7,477 @@
  *                                                                         *
  ***************************************************************************/
 
-import QtQuick 2.9
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.1
-import QtQuick.Controls 1.4 as Controls1
-import QtGraphicalEffects 1.0
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+import QtGraphicalEffects 1.14
 
+import "../components" as Components
 
-/**
- * Calendar for QGIS Attribute Form
- * Requires various global properties set to function, see featureform Loader section
- * Do not use directly from Application QML
- */
-Item {
-    signal editorValueChanged(var newValue, bool isNull)
-    property real iconSize:  fieldItem.height * 0.75
+AbstractEditor {
+  id: root
 
-    id: fieldItem
-    enabled: !readOnly
-    height: childrenRect.height
-    anchors {
-      left: parent.left
-      right: parent.right
+  property var parentField: parent.field
+  property var parentValue: parent.value
+  property bool parentValueIsNull: parent.valueIsNull
+
+  property bool isReadOnly: parent.readOnly
+
+  property bool fieldIsDate: __inputUtils.fieldType( field ) === 'QDate'
+  property var typeFromFieldFormat: __inputUtils.dateTimeFieldFormat( config['field_format'] )
+
+  property bool includesTime: typeFromFieldFormat.includes("Time")
+  property bool includesDate: typeFromFieldFormat.includes("Date")
+
+  signal editorValueChanged(var newValue, bool isNull)
+
+  enabled: !isReadOnly
+
+  function timeToString(attrValue) {
+    if (attrValue === undefined)
+    {
+      return ''
     }
+    else
+    {
+      return Qt.formatDateTime(attrValue, config['display_format'])
+    }
+  }
 
-    property var timeToString: function timeToString(attrValue) {
-      if (attrValue === undefined)
+  function formatText(v) {
+    if ( v === undefined || root.parentValueIsNull )
+    {
+      return ''
+    }
+    else
+    {
+      if ( root.parentField.isDateOrTime )
       {
-          return qsTr('(no date)')
+        // if the field is a QDate, the automatic conversion to JS date [1]
+        // leads to the creation of date time object with the time zone.
+        // For instance shapefiles has support for dates but not date/time or time.
+        // So a date coming from a shapefile as 2001-01-01 will become 2000-12-31 19:00:00 -05 in QML/JS in UTC -05 zone.
+        // And when formatting this with the display format, this is shown as 2000-12-31.
+        // So we detect if the field is a date only and revert the time zone offset.
+        // [1] http://doc.qt.io/qt-5/qtqml-cppintegration-data.html#basic-qt-data-types
+        if (root.fieldIsDate)
+        {
+          return Qt.formatDateTime( new Date(v.getTime() + v.getTimezoneOffset() * 60000), config['display_format'])
+        }
+        else
+        {
+          return Qt.formatDateTime(v, config['display_format'])
+        }
       }
       else
       {
-        return Qt.formatDateTime(attrValue, config['display_format'])
+        let date = Date.fromLocaleString(Qt.locale(), v, config['field_format'])
+        return Qt.formatDateTime(date, config['display_format'])
       }
     }
+  }
 
-    ColumnLayout {
-        id: main
-        property var currentValue: value
-        property bool fieldIsDate: __inputUtils.fieldType( field ) === 'QDate'
-        property var typeFromFieldFormat: __inputUtils.dateTimeFieldFormat( config['field_format'] )
-        property var rowHeight: customStyle.fields.height * 0.75
+  function openPicker(requestedDate)
+  {
+    // open calendar for today when no date is set
+    if (!requestedDate)
+      requestedDate = new Date()
 
-        anchors { right: parent.right; left: parent.left }
+    dateTimeDrawerLoader.active = true
+    dateTimeDrawerLoader.item.dateToOpen = requestedDate
+  }
 
-        Item {
-            Layout.fillWidth: true
-            Layout.minimumHeight: customStyle.fields.height
+  onContentClicked: {
+    if (root.parentValueIsNull)
+    {
+      root.openPicker()
+    }
+    else
+    {
+      root.openPicker(root.parentValue)
+    }
+  }
 
-            TextField {
-                id: label
+  onRightActionClicked: {
+    let newDate = new Date()
+    let newValue = field.isDateOrTime ? newDate : Qt.formatDateTime(newDate, config['field_format'])
+    editorValueChanged(newValue, false)
+  }
 
-                anchors.fill: parent
-                verticalAlignment: Text.AlignVCenter
-                font.pointSize: customStyle.fields.fontPointSize
-                color: customStyle.fields.fontColor
-                padding: 0
-                topPadding: 10 * __dp
-                bottomPadding: 10 * __dp
-                leftPadding: customStyle.fields.sideMargin
-                background: Rectangle {
-                    radius: customStyle.fields.cornerRadius
+  content: Text {
+    id: dateText
 
-                    border.color: popup.opened ? customStyle.fields.activeColor : customStyle.fields.normalColor
-                    border.width: popup.opened ? 2 : 1
-                    color: customStyle.fields.backgroundColor
-                }
+    text: formatText(root.parentValue)
 
-                text: if ( value === undefined )
-                        {
-                          qsTr('(no date)')
-                        }
-                        else
-                        {
-                          if ( field.isDateOrTime )
-                          {
-                            // if the field is a QDate, the automatic conversion to JS date [1]
-                            // leads to the creation of date time object with the time zone.
-                            // For instance shapefiles has support for dates but not date/time or time.
-                            // So a date coming from a shapefile as 2001-01-01 will become 2000-12-31 19:00:00 -05 in QML/JS in UTC -05 zone.
-                            // And when formatting this with the display format, this is shown as 2000-12-31.
-                            // So we detect if the field is a date only and revert the time zone offset.
-                            // [1] http://doc.qt.io/qt-5/qtqml-cppintegration-data.html#basic-qt-data-types
-                            if (main.fieldIsDate) {
-                              Qt.formatDateTime( new Date(value.getTime() + value.getTimezoneOffset() * 60000), config['display_format'])
-                            } else {
-                              Qt.formatDateTime(value, config['display_format'])
-                            }
-                          }
-                          else
-                          {
-                            var date = Date.fromLocaleString(Qt.locale(), value, config['field_format'])
-                            Qt.formatDateTime(date, config['display_format'])
-                          }
-                        }
+    onTextChanged: console.log( "TIMEDATE:", labelAlias, text, root.parentField, root.fieldIsDate, root.typeFromFieldFormat, root.parentValue, __inputUtils.fieldType( field ), __inputUtils.dateTimeFieldFormat( config['field_format'] )
+ )
 
-                inputMethodHints: Qt.ImhDate
+    anchors.fill: parent
 
-                MouseArea {
-                  anchors.fill: parent
-                  onClicked: {
-                    var usedDate = new Date();
-                    if (value !== undefined && value !== '') {
-                      usedDate = field.isDateOrTime ? value : Date.fromLocaleString(Qt.locale(), value, config['field_format'])
-                    }
+    verticalAlignment: Text.AlignVCenter
 
-                    calendar.selectedDate = usedDate
-                    if (main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time") {
-                      hoursSpinBox.value = usedDate.getHours()
-                      minutesSpinBox.value = usedDate.getMinutes()
-                      secondsSpinBox.value = usedDate.getSeconds()
-                    }
+    topPadding: customStyle.fields.height * 0.25
+    bottomPadding: customStyle.fields.height * 0.25
+    leftPadding: customStyle.fields.sideMargin
+    rightPadding: customStyle.fields.sideMargin
 
-                    popup.open()
-                  }
-                }
-            }
+    color: customStyle.fields.fontColor
+    font.pointSize: customStyle.fields.fontPointSize
+  }
 
-            Image {
-                id: todayBtn
-                height: fieldItem.iconSize
-                sourceSize.height: fieldItem.iconSize
-                autoTransform: true
-                fillMode: Image.PreserveAspectFit
-                source: customStyle.icons.today
-                anchors.right: parent.right
-                anchors.verticalCenter: parent.verticalCenter
-                visible: fieldItem.enabled
-                anchors.rightMargin: customStyle.fields.sideMargin
+  rightAction: Item {
+    id: todayBtnContainer
 
-                MouseArea {
-                    anchors.fill: parent
-                    onClicked: {
-                      var newDate = new Date()
-                      var newValue = field.isDateOrTime ? newDate : Qt.formatDateTime(newDate, config['field_format'])
-                      editorValueChanged(newValue, false)
-                    }
-                }
-            }
+    anchors.fill: parent
 
-            ColorOverlay {
-                anchors.fill: todayBtn
-                source: todayBtn
-                color: customStyle.toolbutton.activeButtonColor
-                visible: todayBtn.visible
-            }
-        }
+    Image {
+      id: todayBtn
 
-        Popup {
-          id: popup
-          modal: true
-          focus: true
-          closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-          parent: ApplicationWindow.overlay
-          anchors.centerIn: parent
+      anchors.centerIn: parent
+      width: parent.width / 2
+      sourceSize.width: parent.width / 2
 
-            ScrollView {
-              clip: true
-              width: parent.width
-              height: parent.height
-
-              ColumnLayout {
-                Rectangle {
-                  id: calendarOverlay
-                  color: "transparent"
-                  implicitWidth: Math.min(popup.parent.width, popup.parent.height) * 0.8
-                  implicitHeight: implicitWidth
-                  visible: main.typeFromFieldFormat === "Date" || main.typeFromFieldFormat === "Date Time"
-
-                  MouseArea {
-                      anchors.fill: parent
-                      onClicked: mouse.accepted = true
-                      onWheel: wheel.accepted = true
-                  }
-
-                  GridLayout {
-                      id: calendarGrid
-                      anchors.left: parent.left
-                      anchors.right: parent.right
-                      columns: 1
-                      implicitWidth: calendarOverlay.width
-                      implicitHeight: calendarOverlay.height
-
-                        Controls1.Calendar {
-                          id: calendar
-                          selectedDate: {
-                            var date = field.isDateOrTime ? main.currentValue : Date.fromLocaleString(Qt.locale(), value, config['field_format'])
-                            date || new Date()
-                          }
-                          weekNumbersVisible: true
-                          focus: false
-                          implicitWidth: calendarOverlay.width
-                          implicitHeight: calendarOverlay.height
-                      }
-                  }
-              }
-
-              RowLayout {
-                visible: main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time"
-                Layout.alignment: Qt.AlignHCenter
-
-                  GridLayout {
-                      id: timeGrid
-                      Layout.alignment: Qt.AlignHCenter
-                      Layout.leftMargin: 20
-                      rows: 3
-                      columns: 2
-
-                      Label {
-                          verticalAlignment: Text.AlignVCenter
-                          Layout.preferredHeight: main.rowHeight
-                          Layout.fillWidth: true
-                          Layout.row: 0
-                          Layout.column: 0
-                          text: qsTr( "Hours" )
-
-                      }
-                      SpinBox {
-                          id: hoursSpinBox
-                          Layout.preferredHeight: main.rowHeight
-                          Layout.minimumWidth: main.rowHeight * 3
-                          Layout.fillWidth: true
-                          Layout.row: 0
-                          Layout.column: 1
-                          editable: true
-                          from: 0
-                          to: 23
-                          value: 12
-                          inputMethodHints: Qt.ImhTime
-                          down.indicator.width: main.rowHeight
-                          up.indicator.width: main.rowHeight
-                      }
-                      Label {
-                          verticalAlignment: Text.AlignVCenter
-                          Layout.preferredHeight: main.rowHeight
-                          Layout.fillWidth: true
-                          Layout.row: 1
-                          Layout.column: 0
-                          text: qsTr( "Minutes" )
-                      }
-                      SpinBox {
-                          id: minutesSpinBox
-                          Layout.preferredHeight: main.rowHeight
-                          Layout.minimumWidth: main.rowHeight * 3
-                          Layout.fillWidth: true
-                          Layout.row: 1
-                          Layout.column: 1
-                          editable: true
-                          from: 0
-                          to: 59
-                          value: 30
-                          inputMethodHints: Qt.ImhTime
-                          down.indicator.width: main.rowHeight
-                          up.indicator.width: main.rowHeight
-                      }
-                      Label {
-                          verticalAlignment: Text.AlignVCenter
-                          Layout.preferredHeight: main.rowHeight
-                          Layout.fillWidth: true
-                          Layout.row: 2
-                          Layout.column: 0
-                          text: qsTr( "Seconds" )
-                      }
-                      SpinBox {
-                          id: secondsSpinBox
-                          Layout.preferredHeight: main.rowHeight
-                          Layout.minimumWidth: main.rowHeight * 3
-                          Layout.fillWidth: true
-                          Layout.row: 2
-                          Layout.column: 1
-                          editable: true
-                          from: 0
-                          to: 59
-                          value: 30
-                          inputMethodHints: Qt.ImhTime
-                          down.indicator.width: main.rowHeight
-                          up.indicator.width: main.rowHeight
-                      }
-                  }
-              }
-
-              RowLayout {
-                  Button {
-                      text: qsTr( "OK" )
-                      Layout.fillWidth: true
-                      Layout.preferredHeight: main.rowHeight
-
-                      onClicked: {
-                          var newDate = calendar.selectedDate
-
-                          if (main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time") {
-                            newDate.setHours(hoursSpinBox.value);
-                            newDate.setMinutes(minutesSpinBox.value);
-                            newDate.setSeconds(secondsSpinBox.value);
-                          }
-
-                          var newValue = field.isDateOrTime ? newDate : Qt.formatDateTime(newDate, config['field_format'])
-                          editorValueChanged(newValue, newValue === undefined)
-                          popup.close()
-                      }
-                  }
-                }
-             }
-          }
-        }
-
-        onCurrentValueChanged: {
-            label.text = field.isDateOrTime ? timeToString(main.currentValue) : main.currentValue
-        }
+      source: customStyle.icons.today
     }
 
+    ColorOverlay {
+      anchors.fill: todayBtn
+      source: todayBtn
+      color: todayBtn.enabled ? customStyle.toolbutton.activeButtonColor : customStyle.toolbutton.backgroundColorInvalid
+    }
+  }
+
+  Loader {
+    id: dateTimeDrawerLoader
+
+    asynchronous: true
+    active: false
+    sourceComponent: dateTimeDrawerBlueprint
+  }
+
+  Component {
+    id: dateTimeDrawerBlueprint
+
+    Drawer {
+      id: dateTimeDrawer
+
+      property alias dateToOpen: picker.dateToSelect
+
+      dim: true
+      edge: Qt.BottomEdge
+      interactive: false
+      dragMargin: 0
+      closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+      height: root.includesDate ? parent.height * 2/3 : parent.height * 1/3
+      width: formView.width
+
+      onOpened: console.log( labelAlias, "W:", width, "H:", height )
+      onClosed: dateTimeDrawerLoader.active = false
+
+      Component.onCompleted: open()
+
+      Components.DateTimePicker {
+        id: picker
+
+        width: parent.width
+        height: parent.height
+
+        hasDatePicker: root.includesDate
+        hasTimePicker: root.includesTime
+
+        onSelected: {
+          if ( selectedDate )
+            root.editorValueChanged(selectedDate, false)
+
+          dateTimeDrawer.close()
+        }
+
+        onCanceled: {
+          dateTimeDrawer.hide()
+        }
+      }
+    }
+  }
 }
+
+//  Components.DatePicker {
+//    id: datePicker
+
+//  }
+
+//    ColumnLayout {
+//        id: main
+//        property var currentValue: value
+//        property bool fieldIsDate: __inputUtils.fieldType( field ) === 'QDate'
+//        property var typeFromFieldFormat: __inputUtils.dateTimeFieldFormat( config['field_format'] )
+//        property var rowHeight: customStyle.fields.height * 0.75
+
+//        anchors { right: parent.right; left: parent.left }
+
+//        Item {
+//            Layout.fillWidth: true
+//            Layout.minimumHeight: customStyle.fields.height
+
+//            TextField {
+//                id: label
+
+//                anchors.fill: parent
+//                verticalAlignment: Text.AlignVCenter
+//                font.pointSize: customStyle.fields.fontPointSize
+//                color: customStyle.fields.fontColor
+//                padding: 0
+//                topPadding: 10 * __dp
+//                bottomPadding: 10 * __dp
+//                leftPadding: customStyle.fields.sideMargin
+//                background: Rectangle {
+//                    radius: customStyle.fields.cornerRadius
+
+//                    border.color: popup.opened ? customStyle.fields.activeColor : customStyle.fields.normalColor
+//                    border.width: popup.opened ? 2 : 1
+//                    color: customStyle.fields.backgroundColor
+//                }
+
+//                text: if ( value === undefined )
+//                        {
+//                          qsTr('(no date)')
+//                        }
+//                        else
+//                        {
+//                          if ( field.isDateOrTime )
+//                          {
+//                            // if the field is a QDate, the automatic conversion to JS date [1]
+//                            // leads to the creation of date time object with the time zone.
+//                            // For instance shapefiles has support for dates but not date/time or time.
+//                            // So a date coming from a shapefile as 2001-01-01 will become 2000-12-31 19:00:00 -05 in QML/JS in UTC -05 zone.
+//                            // And when formatting this with the display format, this is shown as 2000-12-31.
+//                            // So we detect if the field is a date only and revert the time zone offset.
+//                            // [1] http://doc.qt.io/qt-5/qtqml-cppintegration-data.html#basic-qt-data-types
+//                            if (main.fieldIsDate) {
+//                              Qt.formatDateTime( new Date(value.getTime() + value.getTimezoneOffset() * 60000), config['display_format'])
+//                            } else {
+//                              Qt.formatDateTime(value, config['display_format'])
+//                            }
+//                          }
+//                          else
+//                          {
+//                            var date = Date.fromLocaleString(Qt.locale(), value, config['field_format'])
+//                            Qt.formatDateTime(date, config['display_format'])
+//                          }
+//                        }
+
+//                inputMethodHints: Qt.ImhDate
+
+//                MouseArea {
+//                  anchors.fill: parent
+//                  onClicked: {
+//                    var usedDate = new Date();
+//                    if (value !== undefined && value !== '') {
+//                      usedDate = field.isDateOrTime ? value : Date.fromLocaleString(Qt.locale(), value, config['field_format'])
+//                    }
+
+//                    calendar.selectedDate = usedDate
+//                    if (main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time") {
+//                      hoursSpinBox.value = usedDate.getHours()
+//                      minutesSpinBox.value = usedDate.getMinutes()
+//                      secondsSpinBox.value = usedDate.getSeconds()
+//                    }
+
+//                    popup.open()
+//                  }
+//                }
+//            }
+
+//            Image {
+//                id: todayBtn2
+//                height: fieldItem.iconSize
+//                sourceSize.height: fieldItem.iconSize
+//                autoTransform: true
+//                fillMode: Image.PreserveAspectFit
+//                source: customStyle.icons.today
+//                anchors.right: parent.right
+//                anchors.verticalCenter: parent.verticalCenter
+//                visible: fieldItem.enabled
+//                anchors.rightMargin: customStyle.fields.sideMargin
+
+//                MouseArea {
+//                    anchors.fill: parent
+//                    onClicked: {
+//                      var newDate = new Date()
+//                      var newValue = field.isDateOrTime ? newDate : Qt.formatDateTime(newDate, config['field_format'])
+//                      editorValueChanged(newValue, false)
+//                    }
+//                }
+//            }
+
+//            ColorOverlay {
+//                anchors.fill: todayBtn
+//                source: todayBtn
+//                color: customStyle.toolbutton.activeButtonColor
+//                visible: todayBtn.visible
+//            }
+//        }
+
+//        Popup {
+//          id: popup
+//          modal: true
+//          focus: true
+//          closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+//          parent: ApplicationWindow.overlay
+//          anchors.centerIn: parent
+
+//            ScrollView {
+//              clip: true
+//              width: parent.width
+//              height: parent.height
+
+//              ColumnLayout {
+//                Rectangle {
+//                  id: calendarOverlay
+//                  color: "transparent"
+//                  implicitWidth: Math.min(popup.parent.width, popup.parent.height) * 0.8
+//                  implicitHeight: implicitWidth
+//                  visible: main.typeFromFieldFormat === "Date" || main.typeFromFieldFormat === "Date Time"
+
+//                  MouseArea {
+//                      anchors.fill: parent
+//                      onClicked: mouse.accepted = true
+//                      onWheel: wheel.accepted = true
+//                  }
+
+//                  GridLayout {
+//                      id: calendarGrid
+//                      anchors.left: parent.left
+//                      anchors.right: parent.right
+//                      columns: 1
+//                      implicitWidth: calendarOverlay.width
+//                      implicitHeight: calendarOverlay.height
+
+//                        Controls1.Calendar {
+//                          id: calendar
+//                          selectedDate: {
+//                            var date = field.isDateOrTime ? main.currentValue : Date.fromLocaleString(Qt.locale(), value, config['field_format'])
+//                            date || new Date()
+//                          }
+//                          weekNumbersVisible: true
+//                          focus: false
+//                          implicitWidth: calendarOverlay.width
+//                          implicitHeight: calendarOverlay.height
+//                      }
+//                  }
+//              }
+
+//              RowLayout {
+//                visible: main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time"
+//                Layout.alignment: Qt.AlignHCenter
+
+//                  GridLayout {
+//                      id: timeGrid
+//                      Layout.alignment: Qt.AlignHCenter
+//                      Layout.leftMargin: 20
+//                      rows: 3
+//                      columns: 2
+
+//                      Label {
+//                          verticalAlignment: Text.AlignVCenter
+//                          Layout.preferredHeight: main.rowHeight
+//                          Layout.fillWidth: true
+//                          Layout.row: 0
+//                          Layout.column: 0
+//                          text: qsTr( "Hours" )
+
+//                      }
+//                      SpinBox {
+//                          id: hoursSpinBox
+//                          Layout.preferredHeight: main.rowHeight
+//                          Layout.minimumWidth: main.rowHeight * 3
+//                          Layout.fillWidth: true
+//                          Layout.row: 0
+//                          Layout.column: 1
+//                          editable: true
+//                          from: 0
+//                          to: 23
+//                          value: 12
+//                          inputMethodHints: Qt.ImhTime
+//                          down.indicator.width: main.rowHeight
+//                          up.indicator.width: main.rowHeight
+//                      }
+//                      Label {
+//                          verticalAlignment: Text.AlignVCenter
+//                          Layout.preferredHeight: main.rowHeight
+//                          Layout.fillWidth: true
+//                          Layout.row: 1
+//                          Layout.column: 0
+//                          text: qsTr( "Minutes" )
+//                      }
+//                      SpinBox {
+//                          id: minutesSpinBox
+//                          Layout.preferredHeight: main.rowHeight
+//                          Layout.minimumWidth: main.rowHeight * 3
+//                          Layout.fillWidth: true
+//                          Layout.row: 1
+//                          Layout.column: 1
+//                          editable: true
+//                          from: 0
+//                          to: 59
+//                          value: 30
+//                          inputMethodHints: Qt.ImhTime
+//                          down.indicator.width: main.rowHeight
+//                          up.indicator.width: main.rowHeight
+//                      }
+//                      Label {
+//                          verticalAlignment: Text.AlignVCenter
+//                          Layout.preferredHeight: main.rowHeight
+//                          Layout.fillWidth: true
+//                          Layout.row: 2
+//                          Layout.column: 0
+//                          text: qsTr( "Seconds" )
+//                      }
+//                      SpinBox {
+//                          id: secondsSpinBox
+//                          Layout.preferredHeight: main.rowHeight
+//                          Layout.minimumWidth: main.rowHeight * 3
+//                          Layout.fillWidth: true
+//                          Layout.row: 2
+//                          Layout.column: 1
+//                          editable: true
+//                          from: 0
+//                          to: 59
+//                          value: 30
+//                          inputMethodHints: Qt.ImhTime
+//                          down.indicator.width: main.rowHeight
+//                          up.indicator.width: main.rowHeight
+//                      }
+//                  }
+//              }
+
+//              RowLayout {
+//                  Button {
+//                      text: qsTr( "OK" )
+//                      Layout.fillWidth: true
+//                      Layout.preferredHeight: main.rowHeight
+
+//                      onClicked: {
+//                          var newDate = calendar.selectedDate
+
+//                          if (main.typeFromFieldFormat === "Time" || main.typeFromFieldFormat === "Date Time") {
+//                            newDate.setHours(hoursSpinBox.value);
+//                            newDate.setMinutes(minutesSpinBox.value);
+//                            newDate.setSeconds(secondsSpinBox.value);
+//                          }
+
+//                          var newValue = field.isDateOrTime ? newDate : Qt.formatDateTime(newDate, config['field_format'])
+//                          editorValueChanged(newValue, newValue === undefined)
+//                          popup.close()
+//                      }
+//                  }
+//                }
+//             }
+//          }
+//        }
+
+//        onCurrentValueChanged: {
+//            label.text = field.isDateOrTime ? timeToString(main.currentValue) : main.currentValue
+//        }
+//    }
 

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -100,5 +100,6 @@
         <file>misc/GpsDataPage.qml</file>
         <file>components/TextRowWithTitle.qml</file>
         <file>components/NumberInputField.qml</file>
+        <file>components/DateTimePicker.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Previous calendar used `quick controls 1`. We thus needed to replace it with new one.

New calendar look:

https://user-images.githubusercontent.com/22449698/145367793-37b15f82-a3ca-475e-b850-4fa6be31fd76.mp4



@jozef-budac if you want, I created project `tomas/test_datetime`(dev) that contains all different combinations of datetime widgets. 