### PR TITLE
Fix path to proj database (proj.db) on desktop builds

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -386,6 +386,9 @@ int main( int argc, char *argv[] )
 #ifdef Q_OS_LINUX
   appBundleDir = dataDir;
 #endif
+#ifdef Q_OS_MACOS
+  appBundleDir = dataDir;
+#endif
   InputProjUtils inputProjUtils;
   inputProjUtils.initProjLib( appBundleDir, dataDir, projectDir );
   init_qgis( appBundleDir );

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -383,6 +383,9 @@ int main( int argc, char *argv[] )
   appBundleDir = QCoreApplication::applicationDirPath() + "\\qgis-data";
   //TODO win32 package demo projects
 #endif
+#ifdef Q_OS_LINUX
+  appBundleDir = dataDir;
+#endif
   InputProjUtils inputProjUtils;
   inputProjUtils.initProjLib( appBundleDir, dataDir, projectDir );
   init_qgis( appBundleDir );


### PR DESCRIPTION
Without this, Input would fail to do _some_ transforms (where the database access is needed). For example, GPS info window would show project X/Y coordinates with the same values as lat/lon even when using a projected CRS (such as web mercator) - it's possible to test e.g. with `lutraconsulting/test_digitizing` project.

Output error messages such as
```
PROJ6 error: The Input has failed to load PROJ6 database./proj/proj.db\n"
InputPROJ: Input Search Paths ("/proj")
InputPROJ: Custom Search Path "/proj_custom"
InputPROJ: found 0 projects with custom projections
...
proj_create_from_wkt: Cannot find proj.db
proj_create_from_database: Cannot find proj.db
proj_identify: Cannot find proj.db
proj_create: Error -38: failed to load datum shift file
...
pj_obj_create: Cannot find proj.db
...
```