### PR TITLE
Attention banner padding

### DIFF
--- a/app/qml/components/TextWithIcon.qml
+++ b/app/qml/components/TextWithIcon.qml
@@ -65,5 +65,6 @@ Row {
           + "; text-decoration: underline; }</style>" + root.text
     textFormat: Text.RichText
     wrapMode: Text.WordWrap
+    rightPadding: fieldHeight / 4
   }
 }


### PR DESCRIPTION
PR adds right padding to component that is used in attention banner ~ the same padding is applied on left (before icon).

<img src="https://user-images.githubusercontent.com/22449698/145542514-73b1b52c-6175-41a1-8d25-aa2b01c6d04f.jpg" width=300>

Resolves #1802 