### PR TITLE
Set up concurrency between workflow runs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,6 +13,10 @@ on:
     types:
       - published
 
+concurrency:
+  group: ci-${{github.ref}}-android
+  cancel-in-progress: true
+
 jobs:
   android_build:
     if: ( github.repository == 'lutraconsulting/input' ) && (!contains(github.event.head_commit.message, 'Translate '))

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -22,6 +22,10 @@ env:
   IOS_MIN_SDK_VERSION: ${{ '12.0' }}
   CCACHE_DIR: /Users/runner/work/ccache
 
+concurrency:
+  group: ci-${{github.ref}}-ios
+  cancel-in-progress: true
+
 jobs:
   ios_build:
     if: ( github.repository == 'lutraconsulting/input' ) && (!contains(github.event.head_commit.message, 'Translate '))

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,6 +18,10 @@ env:
   INPUT_SDK_VERSION: ubuntu-2004-20211201-34
   QT_VERSION: '5.14.2'
 
+concurrency:
+  group: ci-${{github.ref}}-linux
+  cancel-in-progress: true
+
 jobs:
   linux_build:
     if: ( github.repository == 'lutraconsulting/input' ) && (!contains(github.event.head_commit.message, 'Translate '))

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ env:
   CCACHE_DIR: /Users/runner/work/ccache
 
 concurrency:
-  group: ci-${{github.ref}}-linux
+  group: ci-${{github.ref}}-macos
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,10 +22,23 @@ env:
   INPUT_SDK_VERSION: mac-20211201-46
   CCACHE_DIR: /Users/runner/work/ccache
 
+concurrency:
+  group: ci-${{github.ref}}-linux
+  cancel-in-progress: true
+
 jobs:
   macos_build:
     if: ( github.repository == 'lutraconsulting/input' ) && (!contains(github.event.head_commit.message, 'Translate '))
     runs-on: macos-10.15
+    # Set concurrency to this job so that there will be only one workflow instance
+    # running throughout all branches. This limitation can be removed once we
+    # solve https://github.com/lutraconsulting/input/issues/902 - have unique
+    # user for each run of tests. Until then we can run only one instance of tests
+    # at a time - concurrent runs could (and often does) harm each others state,
+    # resulting in failed autotests. There will be a maximum of two runs
+    # accepted - one will run and the other will be set as pending (wait until
+    # the first one finishes). Other runs are automatically canceled if there are two runs already.
+    concurrency: ci-autotests
     steps:
       - name: Checkout Input
         uses: actions/checkout@v2

--- a/app/compass.h
+++ b/app/compass.h
@@ -17,7 +17,6 @@
 
 class Compass: public QObject
 {
-
     Q_OBJECT
   public:
     explicit Compass( QObject *parent = nullptr );


### PR DESCRIPTION
PR adds `concurrency` to workflow files for ios/mac/linux/android. When you push new changes to a branch, already running workflows **on the same branch** are going to be stopped automatically.

Moreover, to make autotests a little bit more stable, I added concurrency also for autotests file. It does not have the `cancel-in-progress` option set, so already runnning tests **on different branch** are not going to be canceled. However, if there would be some workflows waiting to start autotests, this queue will be cleared. See more here: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idconcurrency

Resolves #1843 