### PR TITLE
Update compared qgis version with latest changes to mapcanvas

### DIFF
--- a/.github/workflows/qgsquick.yml
+++ b/.github/workflows/qgsquick.yml
@@ -12,7 +12,7 @@ on:
       - published
 
 env:
-  QGIS_COMMIT_HASH: e524574d0e25995fb0c9a543dd96aeb4e2ade727
+  QGIS_COMMIT_HASH: e46de3c3de5a3631e79bd1898315744f2cccf350
 
 jobs:
   qgsquick_up_to_date:

--- a/qgsquick/qgsquickmapsettings.h
+++ b/qgsquick/qgsquickmapsettings.h
@@ -282,6 +282,7 @@ class QUICK_EXPORT QgsQuickMapSettings : public QObject
     //! \copydoc QgsQuickMapSettings::layers
     void layersChanged();
 
+    //! \copydoc QgsQuickMapSettings::devicePixelRatio
     void devicePixelRatioChanged();
 
   private slots:


### PR DESCRIPTION
PR updates used version of QGIS for comparison of `up-to-date` qgsquick sources. It is still 3.22 QGIS but contains backported changes to qgsquickmapcanvas.qml and other quick files. These files are already released in the latest (1.2.0) Input version  

> Note: QGIS version has **not yet** been updated in Input-SDK!