### PR TITLE
Selection of position providers

### DIFF
--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -253,56 +253,15 @@ QVariantList AppSettings::savedPositionProviders() const
   return providers;
 }
 
-void AppSettings::savePositionProvider( const QString &name, const QString &address )
+void AppSettings::savePositionProviders( const QVariantList &providers )
 {
   QSettings settings;
-  QVariantList providers = savedPositionProviders();
 
-  if ( !providers.isEmpty() )
+  if ( settings.contains( mPositionProvidersArrayGroupName ) )
   {
     settings.remove( mPositionProvidersArrayGroupName );
   }
 
-  // ignore if we already have such address saved
-  for ( int i = 0; i < providers.count(); i++ )
-  {
-    if ( providers[i].toList()[1] == address )
-      return;
-  }
-
-  providers.append( { name, address } );
-
-  writePositionProvidersArray( providers );
-  emit savedPositionProvidersChanged( providers );
-}
-
-void AppSettings::removePositionProvider( const QString &address )
-{
-  QSettings settings;
-  QVariantList providers = savedPositionProviders();
-
-  if ( !providers.isEmpty() )
-  {
-    settings.remove( mPositionProvidersArrayGroupName );
-  }
-
-  // do we already have such address saved?
-  for ( int i = 0; i < providers.count(); i++ )
-  {
-    if ( providers[i].toList()[1] == address )
-    {
-      providers.removeAt( i );
-      break;
-    }
-  }
-
-  writePositionProvidersArray( providers );
-  emit savedPositionProvidersChanged( providers );
-}
-
-void AppSettings::writePositionProvidersArray( QVariantList providers )
-{
-  QSettings settings;
   settings.beginWriteArray( mPositionProvidersArrayGroupName );
 
   for ( int i = 0; i < providers.count(); i++ )

--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -243,9 +243,10 @@ QVariantList AppSettings::savedPositionProviders() const
   for ( int i = 0; i < size; i++ )
   {
     settings.setArrayIndex( i );
-    QString name = settings.value( "providerName" ).toString();
-    QString address = settings.value( "providerAddress" ).toString();
-    providers.append( { name, address } );
+    QStringList provider;
+    provider << settings.value( "providerName" ).toString();
+    provider << settings.value( "providerAddress" ).toString();
+    providers.push_back( provider );
   }
 
   settings.endArray();

--- a/app/appsettings.h
+++ b/app/appsettings.h
@@ -29,7 +29,6 @@ class AppSettings: public QObject
     Q_PROPERTY( QString appVersion READ appVersion WRITE setAppVersion NOTIFY appVersionChanged )
     Q_PROPERTY( bool legacyFolderMigrated READ legacyFolderMigrated WRITE setLegacyFolderMigrated NOTIFY legacyFolderMigratedChanged )
     Q_PROPERTY( QString activePositionProviderId READ activePositionProviderId WRITE setActivePositionProviderId NOTIFY activePositionProviderIdChanged )
-    Q_PROPERTY( QVariantList savedPositionProviders READ savedPositionProviders NOTIFY savedPositionProvidersChanged )
 
   public:
     explicit AppSettings( QObject *parent = nullptr );
@@ -71,8 +70,7 @@ class AppSettings: public QObject
     // SavedPositionProviders property is read only when needed ~ not at startup time.
     // It returns list of all external position providers (does not include internal/simulated position providers)
     QVariantList savedPositionProviders() const;
-    Q_INVOKABLE void savePositionProvider( const QString &name, const QString &address );
-    Q_INVOKABLE void removePositionProvider( const QString &address );
+    void savePositionProviders( const QVariantList &providers );
 
     const QString &activePositionProviderId() const;
     void setActivePositionProviderId( const QString &id );
@@ -96,8 +94,6 @@ class AppSettings: public QObject
     void activePositionProviderIdChanged( const QString & );
 
   private:
-    void writePositionProvidersArray( QVariantList positionProviders );
-
     // Projects path
     QString mDefaultProject;
     // Path to active project

--- a/app/bluetoothdiscoverymodel.cpp
+++ b/app/bluetoothdiscoverymodel.cpp
@@ -134,9 +134,10 @@ void BluetoothDiscoveryModel::deviceDiscovered( const QBluetoothDeviceInfo &devi
   if ( device.address().isNull() )
     return;
 
-  beginInsertRows( QModelIndex(), 0, 0 );
+  int insertIndex = mFoundDevices.count();
+  beginInsertRows( QModelIndex(), insertIndex, insertIndex );
 
-  mFoundDevices.push_front( device );
+  mFoundDevices << device;
 
   endInsertRows();
 }

--- a/app/bluetoothdiscoverymodel.cpp
+++ b/app/bluetoothdiscoverymodel.cpp
@@ -134,10 +134,9 @@ void BluetoothDiscoveryModel::deviceDiscovered( const QBluetoothDeviceInfo &devi
   if ( device.address().isNull() )
     return;
 
-  int insertIndex = mFoundDevices.count();
-  beginInsertRows( QModelIndex(), insertIndex, insertIndex );
+  beginInsertRows( QModelIndex(), 0, 0 );
 
-  mFoundDevices << device;
+  mFoundDevices.push_front( device );
 
   endInsertRows();
 }

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -95,6 +95,7 @@
 #include "bluetoothdiscoverymodel.h"
 #include "position/bluetoothpositionprovider.h"
 #include "position/mapposition.h"
+#include "position/positionprovidersmodel.h"
 
 
 #ifndef NDEBUG
@@ -283,6 +284,7 @@ void initDeclarative()
   qmlRegisterType< ValueRelationFeaturesModel >( "lc", 1, 0, "ValueRelationFeaturesModel" );
   qmlRegisterType< RelationReferenceFeaturesModel >( "lc", 1, 0, "RelationReferenceFeaturesModel" );
   qmlRegisterType< BluetoothDiscoveryModel >( "lc", 1, 0, "BluetoothDiscoveryModel" );
+  qmlRegisterType< PositionProvidersModel >( "lc", 1, 0, "PositionProvidersModel" );
 
   qmlRegisterUncreatableType< QgsUnitTypes >( "QgsQuick", 0, 1, "QgsUnitTypes", "Only enums from QgsUnitTypes can be used" );
   qmlRegisterType< QgsVectorLayer >( "QgsQuick", 0, 1, "VectorLayer" );

--- a/app/position/bluetoothpositionprovider.cpp
+++ b/app/position/bluetoothpositionprovider.cpp
@@ -63,6 +63,8 @@ void BluetoothPositionProvider::closeProvider()
 
 void BluetoothPositionProvider::socketStateChanged( QBluetoothSocket::SocketState state )
 {
+  // TODO: emit messages when BT devices is connected / error occured!
+
   if ( state == QBluetoothSocket::ConnectingState )
     emit providerConnecting();
   else if ( state == QBluetoothSocket::ConnectedState )

--- a/app/position/bluetoothpositionprovider.cpp
+++ b/app/position/bluetoothpositionprovider.cpp
@@ -72,7 +72,7 @@ void BluetoothPositionProvider::socketStateChanged( QBluetoothSocket::SocketStat
   else if ( state == QBluetoothSocket::UnconnectedState )
     emit lostConnection();
 
-  CoreUtils::log( QStringLiteral( "BluetoothPositionProvider" ), QStringLiteral( "Socket changed state, code: " ).arg( state ) );
+  CoreUtils::log( QStringLiteral( "BluetoothPositionProvider" ), QStringLiteral( "Socket changed state, code: %1" ).arg( state ) );
 }
 
 void BluetoothPositionProvider::positionUpdateReceived()

--- a/app/position/internalpositionprovider.cpp
+++ b/app/position/internalpositionprovider.cpp
@@ -15,7 +15,7 @@
 #include "qdebug.h" //TODO: remove
 
 InternalPositionProvider::InternalPositionProvider( QObject *parent )
-  : AbstractPositionProvider( QStringLiteral( "internal" ), parent )
+  : AbstractPositionProvider( QStringLiteral( "devicegps" ), parent )
 {
   mGpsPositionSource = std::unique_ptr<QGeoPositionInfoSource>( QGeoPositionInfoSource::createDefaultSource( nullptr ) );
   if ( !mGpsPositionSource.get() || mGpsPositionSource->error() != QGeoPositionInfoSource::NoError )

--- a/app/position/positionprovidersmodel.cpp
+++ b/app/position/positionprovidersmodel.cpp
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -28,6 +28,8 @@ PositionProvidersModel::PositionProvidersModel( QObject *parent ) : QAbstractLis
 
   mProviders.push_front( internal );
 }
+
+PositionProvidersModel::~PositionProvidersModel() = default;
 
 QHash<int, QByteArray> PositionProvidersModel::roleNames() const
 {
@@ -109,7 +111,7 @@ void PositionProvidersModel::addProvider( const QString &name, const QString &pr
   PositionProvider toAdd;
   toAdd.name = name;
   toAdd.providerId = providerId;
-  toAdd.description = tr( "Bluetooth GPS receiver" );
+  toAdd.description = providerId + " " + tr( " Bluetooth device" );
   toAdd.providerType = "external";
 
   if ( mProviders.contains( toAdd ) )
@@ -157,7 +159,7 @@ void PositionProvidersModel::setAppSettings( AppSettings *as )
         PositionProvider provider;
         provider.name = providers[i].toList()[0].toString();
         provider.providerId = providers[i].toList()[1].toString();
-        provider.description = tr( "Bluetooth GPS receiver" );
+        provider.description = provider.providerId + " " + tr( "Bluetooth device" );
         provider.providerType = "external";
 
         mProviders.append( provider );

--- a/app/position/positionprovidersmodel.cpp
+++ b/app/position/positionprovidersmodel.cpp
@@ -1,0 +1,181 @@
+﻿/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "positionprovidersmodel.h"
+#include "inpututils.h"
+#include "appsettings.h"
+
+PositionProvidersModel::PositionProvidersModel( QObject *parent ) : QAbstractListModel( parent )
+{
+  if ( !InputUtils::isMobilePlatform() )
+  {
+    PositionProvider simulated( "Simulated provider", "Simulated position around point", "simulated" );
+
+    mProviders.push_front( simulated );
+  }
+
+  PositionProvider internal;
+  internal.name = tr( "Internal GPS receiver" );
+  internal.description = tr( "GPS receiver of this device" );
+  internal.providerId = "internal";
+
+  mProviders.push_front( internal );
+}
+
+QHash<int, QByteArray> PositionProvidersModel::roleNames() const
+{
+  QHash<int, QByteArray> roles;
+  roles.insert( DataRoles::ProviderName, QByteArray( "ProviderName" ) );
+  roles.insert( DataRoles::ProviderDescription, QByteArray( "ProviderDescription" ) );
+  roles.insert( DataRoles::ProviderId, QByteArray( "ProviderId" ) );
+  roles.insert( DataRoles::CanBeDeleted, QByteArray( "CanBeDeleted" ) );
+  return roles;
+}
+
+int PositionProvidersModel::rowCount( const QModelIndex & ) const
+{
+  return mProviders.count();
+}
+
+QVariant PositionProvidersModel::data( const QModelIndex &index, int role ) const
+{
+  if ( !index.isValid() )
+    return QVariant();
+
+  int row = index.row();
+
+  PositionProvider provider = mProviders.at( row );
+
+  if ( row < 0 || row > mProviders.count() )
+    return QVariant();
+
+  switch ( role )
+  {
+    case DataRoles::ProviderName:
+      return provider.name;
+
+    case DataRoles::ProviderDescription:
+      return provider.description;
+
+    case DataRoles::ProviderId:
+      return provider.providerId;
+
+    case DataRoles::CanBeDeleted:
+      return !provider.isPermanent();
+
+    default:
+      return QVariant();
+  }
+}
+
+void PositionProvidersModel::removeProvider( const QString &providerId )
+{
+  if ( providerId.isEmpty() )
+    return;
+
+  PositionProvider toRemove;
+  toRemove.providerId = providerId;
+
+  if ( !mProviders.contains( toRemove ) )
+    return;
+
+  int removeIndex = mProviders.indexOf( toRemove );
+
+  beginRemoveRows( QModelIndex(), removeIndex, removeIndex );
+
+  mProviders.removeAt( removeIndex );
+
+  endRemoveRows();
+
+  // save the new list to persistent QSettings
+  if ( mAppSettings )
+  {
+    mAppSettings->savePositionProviders( toVariantList() );
+  }
+}
+
+void PositionProvidersModel::addProvider( const QString &name, const QString &providerId )
+{
+  if ( providerId.isEmpty() )
+    return;
+
+  PositionProvider toAdd;
+  toAdd.name = name;
+  toAdd.providerId = providerId;
+  toAdd.description = tr( "Bluetooth GPS receiver" );
+
+  if ( mProviders.contains( toAdd ) )
+    return;
+
+  int addIndex = mProviders.count();
+
+  beginInsertRows( QModelIndex(), addIndex, addIndex );
+
+  mProviders.push_back( toAdd );
+
+  endInsertRows();
+
+  // save the new list to persistent QSettings
+  if ( mAppSettings )
+  {
+    mAppSettings->savePositionProviders( toVariantList() );
+  }
+}
+
+AppSettings *PositionProvidersModel::appSettings() const
+{
+  return mAppSettings;
+}
+
+void PositionProvidersModel::setAppSettings( AppSettings *as )
+{
+  if ( mAppSettings == as )
+    return;
+
+  mAppSettings = as;
+  emit appSettingsChanged( mAppSettings );
+
+  // read providers from QSettings
+  if ( mAppSettings )
+  {
+    QVariantList providers = mAppSettings->savedPositionProviders();
+
+    beginResetModel();
+
+    for ( int i = 0; i < providers.count(); ++i )
+    {
+      if ( providers[i].type() == QVariant::List || providers[i].type() == QVariant::StringList )
+      {
+        PositionProvider provider;
+        provider.name = providers[i].toList()[0].toString();
+        provider.providerId = providers[i].toList()[1].toString();
+        provider.description = tr( "Bluetooth GPS receiver" );
+
+        mProviders.append( provider );
+      }
+    }
+
+    endResetModel();
+  }
+}
+
+QVariantList PositionProvidersModel::toVariantList() const
+{
+  QVariantList out;
+
+  for ( int i = 0; i < mProviders.count(); ++i )
+  {
+    if ( mProviders[i].isPermanent() )
+      continue;
+
+    out.append( { mProviders[i].name, mProviders[i].providerId } );
+  }
+
+  return out;
+}

--- a/app/position/positionprovidersmodel.h
+++ b/app/position/positionprovidersmodel.h
@@ -20,7 +20,8 @@ struct PositionProvider
 {
   QString name;
   QString description;
-  QString providerId; // simulated/internal/BT address
+  QString providerType; // either internal or external
+  QString providerId; // holds BT address for external provider and simulated/internal for internal provider
 
   bool operator==( const PositionProvider &other ) const
   {
@@ -32,16 +33,11 @@ struct PositionProvider
     return !( *this == other );
   }
 
-  PositionProvider( const QString &name, const QString &desc, const QString &id )
-    : name( name ), description( desc ), providerId( id )
+  PositionProvider( const QString &name, const QString &desc, const QString &type, const QString &id )
+    : name( name ), description( desc ), providerType( type ), providerId( id )
   {}
 
   PositionProvider() {}
-
-  bool isPermanent() const
-  {
-    return ( providerId == QStringLiteral( "internal" ) || providerId == QStringLiteral( "simulated" ) );
-  }
 };
 
 class PositionProvidersModel : public QAbstractListModel
@@ -60,7 +56,7 @@ class PositionProvidersModel : public QAbstractListModel
       ProviderName = Qt::UserRole + 1, //! physical address of BT device
       ProviderDescription,
       ProviderId,
-      CanBeDeleted
+      ProviderType // external (connected) / internal (device)
     };
     Q_ENUM( DataRoles )
 

--- a/app/position/positionprovidersmodel.h
+++ b/app/position/positionprovidersmodel.h
@@ -49,7 +49,7 @@ class PositionProvidersModel : public QAbstractListModel
   public:
 
     explicit PositionProvidersModel( QObject *parent = nullptr );
-    virtual ~PositionProvidersModel() = default;
+    virtual ~PositionProvidersModel();
 
     enum DataRoles
     {
@@ -77,7 +77,7 @@ class PositionProvidersModel : public QAbstractListModel
   private:
     QVariantList toVariantList() const;
 
-    AppSettings *mAppSettings; // not owned
+    AppSettings *mAppSettings = nullptr; // not owned
     QList<PositionProvider> mProviders;
 };
 

--- a/app/position/positionprovidersmodel.h
+++ b/app/position/positionprovidersmodel.h
@@ -1,0 +1,88 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef POSITIONPROVIDERSMODEL_H
+#define POSITIONPROVIDERSMODEL_H
+
+#include <QObject>
+#include <qglobal.h>
+#include <QAbstractListModel>
+
+class AppSettings;
+
+struct PositionProvider
+{
+  QString name;
+  QString description;
+  QString providerId; // simulated/internal/BT address
+
+  bool operator==( const PositionProvider &other ) const
+  {
+    return ( this->providerId == other.providerId );
+  }
+
+  bool operator!=( const PositionProvider &other ) const
+  {
+    return !( *this == other );
+  }
+
+  PositionProvider( const QString &name, const QString &desc, const QString &id )
+    : name( name ), description( desc ), providerId( id )
+  {}
+
+  PositionProvider() {}
+
+  bool isPermanent() const
+  {
+    return ( providerId == QStringLiteral( "internal" ) || providerId == QStringLiteral( "simulated" ) );
+  }
+};
+
+class PositionProvidersModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY( AppSettings *appSettings READ appSettings WRITE setAppSettings NOTIFY appSettingsChanged )
+
+  public:
+
+    explicit PositionProvidersModel( QObject *parent = nullptr );
+    virtual ~PositionProvidersModel() = default;
+
+    enum DataRoles
+    {
+      ProviderName = Qt::UserRole + 1, //! physical address of BT device
+      ProviderDescription,
+      ProviderId,
+      CanBeDeleted
+    };
+    Q_ENUM( DataRoles )
+
+    QHash<int, QByteArray> roleNames() const override;
+
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
+    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
+
+    Q_INVOKABLE void removeProvider( const QString &providerId );
+    Q_INVOKABLE void addProvider( const QString &providerName, const QString &providerId );
+
+    AppSettings *appSettings() const;
+    void setAppSettings( AppSettings * );
+
+  signals:
+    void appSettingsChanged( AppSettings * );
+
+  private:
+    QVariantList toVariantList() const;
+
+    AppSettings *mAppSettings; // not owned
+    QList<PositionProvider> mProviders;
+};
+
+#endif // POSITIONPROVIDERSMODEL_H

--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -28,6 +28,7 @@ QtObject {
     property color panelBackgroundDarker: "#575757"
     property color panelBackgroundLight: "#E6E6E6"
     property color labelColor: "#999999"
+    property color secondaryFontColor: "#B3B3B3"
 
     property color highlightColor: "#FD9626"
     property color panelItemHighlight: "#9ABFA0"
@@ -67,6 +68,8 @@ QtObject {
     property real innerFieldMargin: 10 * __dp  // TODO rename fieldMargin
     property real outerFieldMargin: 20 * __dp  // TODO change for PanelMargin
     property real formSpacing: 10 * __dp
+
+    property real circleRadius: 100
 
     // icons
     property string cameraIcon: "qrc:/add_photo.svg"

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -24,6 +24,8 @@ Item {
   property string defaultLayer: __appSettings.defaultLayer
   property color gpsIndicatorColor: InputStyle.softRed
 
+  property PositionKit positionKit
+
   Keys.onReleased: {
     if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
       event.accepted = true
@@ -348,6 +350,7 @@ Item {
     id: positionProviderComponent
     PositionProviderPage {
       onClose: stackview.pop(null)
+      positionKit: root.positionKit
       Component.onCompleted: forceActiveFocus()
     }
   }

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -351,6 +351,7 @@ Item {
     PositionProviderPage {
       onClose: stackview.pop(null)
       positionKit: root.positionKit
+      stackView: stackview
       Component.onCompleted: forceActiveFocus()
     }
   }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -230,6 +230,8 @@ ApplicationWindow {
       width: window.width
       rowHeight: InputStyle.rowHeight
 
+      positionKit: map.positionKit
+
       onVisibleChanged: {
         if (settingsPanel.visible)
           settingsPanel.focus = true; // get focus

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -304,7 +304,7 @@ Item {
     }
 
     onPositionProviderChanged: {
-      __appSettings.activePositionProviderId = _positionKit.positionProviderId( provider.providerId() )
+      __appSettings.activePositionProviderId = provider.providerId() ? provider.providerId() : ""
     }
   }
 

--- a/app/qml/misc/AddPositionProviderPage.qml
+++ b/app/qml/misc/AddPositionProviderPage.qml
@@ -1,0 +1,105 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+
+import lc 1.0
+
+import "../" // import InputStyle singleton
+import "../components" as Components
+
+Page {
+  id: root
+
+  property PositionKit positionKit;
+
+  signal close
+
+  header: Components.PanelHeader {
+    id: header
+
+    height: InputStyle.rowHeightHeader
+    width: parent.width
+    color: InputStyle.clrPanelBackground
+    rowHeight: InputStyle.rowHeightHeader
+    titleText: "Find bluetooth device"
+
+    onBack: {
+      btModel.discovering = false
+      root.close()
+    }
+
+    withBackButton: true
+  }
+
+  ListView {
+    id: view
+
+    anchors.fill: parent
+
+    model: BluetoothDiscoveryModel {
+      id: btModel
+      discovering: true
+    }
+
+    delegate: Rectangle {
+
+      width: ListView.view.width
+      height: InputStyle.rowHeight
+
+      border.color: "black"
+      border.width: 2 * __dp
+
+      Column {
+        anchors.fill: parent
+        anchors.leftMargin: 5
+        anchors.topMargin: 5
+
+        Text {
+          id: deviceName
+
+          width: parent.width
+          height: parent.height * 0.5
+
+          text: model.DeviceName
+        }
+
+        Text {
+          id: deviceAddress
+          width: parent.width
+          height: parent.height * 0.5
+
+          text: model.DeviceAddress + ", signal strength: " + model.SignalStrength
+        }
+      }
+
+      MouseArea {
+        anchors.fill: parent
+        onClicked: {
+          root.positionKit.positionProvider = root.positionKit.constructProvider( "external", model.DeviceAddress )
+        }
+      }
+    }
+
+    footer: Text {
+      id: discoveryInProgress
+
+      width: ListView.view.width
+      height: InputStyle.rowHeight
+
+      leftPadding: 5
+      topPadding: 5
+
+      visible: btModel.discovering
+      text: ListView.view.count > 2 ? qsTr("Looking for more devices ...") : qsTr("Looking for devices ...")
+    }
+  }
+}
+

--- a/app/qml/misc/AddPositionProviderPage.qml
+++ b/app/qml/misc/AddPositionProviderPage.qml
@@ -85,7 +85,7 @@ Page {
             width: parent.width
             height: parent.height * 0.5
 
-            text: model.DeviceName
+            text: model.DeviceName ? model.DeviceName : qsTr( "Unknown device" )
 
             elide: Text.ElideRight
             color: InputStyle.fontColor

--- a/app/qml/misc/PositionProviderPage.qml
+++ b/app/qml/misc/PositionProviderPage.qml
@@ -155,8 +155,7 @@ Page {
             width: parent.width
             height: parent.height * 0.5
 
-            // add BT address to text if it is external receiver
-            text: model.ProviderDescription + ( model.ProviderType === "external" ? " (" + model.ProviderId + ")": "" )
+            text: model.ProviderDescription
 
             elide: Text.ElideRight
             color: InputStyle.secondaryFontColor

--- a/app/qml/misc/PositionProviderPage.qml
+++ b/app/qml/misc/PositionProviderPage.qml
@@ -78,7 +78,7 @@ Page {
       MouseArea {
         anchors.fill: parent
         onClicked: {
-          root.positionKit.positionProvider = root.positionKit.constructProvider( model.ProviderType, model.ProviderId )
+            root.positionKit.positionProvider = root.positionKit.constructProvider( model.ProviderType, model.ProviderId )
         }
       }
 
@@ -97,6 +97,7 @@ Page {
           width: parent.height
           height: parent.height
 
+          checkable: false
           checked: __appSettings.activePositionProviderId === model.ProviderId
 
           indicator: Rectangle {
@@ -118,7 +119,15 @@ Page {
 
               radius: InputStyle.circleRadius
               color: InputStyle.darkGreen
-              visible: isActiveButton.checked
+              visible: __appSettings.activePositionProviderId === model.ProviderId
+            }
+          }
+
+          // We need to duplicate mouse area here in order to handle clicks from RadioButton
+          MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                root.positionKit.positionProvider = root.positionKit.constructProvider( model.ProviderType, model.ProviderId )
             }
           }
         }
@@ -133,7 +142,7 @@ Page {
             width: parent.width
             height: parent.height * 0.5
 
-            text: model.ProviderName
+            text: model.ProviderName ? model.ProviderName : qsTr( "Unknown device" )
 
             elide: Text.ElideRight
             color: InputStyle.fontColor
@@ -191,8 +200,8 @@ Page {
 
       Rectangle {
         property bool separatorVisible: {
-          // items that have separator: first item in internal providers and all other in external but the last one
-          if ( model.ProviderType === "internal" ) return index === 0
+          // items that have separator: all items in external but the last one
+          if ( model.ProviderType === "internal" ) return false
           else return index < providerDelegate.ListView.view.count - 1
         }
 

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -105,5 +105,6 @@
         <file>NavigationPanel.qml</file>
         <file>map/NavigationHighlight.qml</file>
         <file>misc/PositionProviderPage.qml</file>
+        <file>misc/AddPositionProviderPage.qml</file>
     </qresource>
 </RCC>

--- a/app/sources.pri
+++ b/app/sources.pri
@@ -14,6 +14,7 @@ position/internalpositionprovider.cpp \
 position/mapposition.cpp \
 position/positiondirection.cpp \
 position/positionkit.cpp \
+position/positionprovidersmodel.cpp \
 position/simulatedpositionprovider.cpp \
 bluetoothdiscoverymodel.cpp \
 featurelayerpair.cpp \
@@ -64,6 +65,7 @@ position/internalpositionprovider.h \
 position/mapposition.h \
 position/positiondirection.h \
 position/positionkit.h \
+position/positionprovidersmodel.h \
 position/simulatedpositionprovider.h \
 bluetoothdiscoverymodel.h \
 featurelayerpair.h \

--- a/app/test/testpositionkit.cpp
+++ b/app/test/testpositionkit.cpp
@@ -53,7 +53,9 @@ void TestPositionKit::simulated_position()
 
   SimulatedPositionProvider *simulatedProvider2 = new SimulatedPositionProvider( 90.36, 33.93, 0 );
 
-  positionKit.setPositionProvider( simulatedProvider2 ); // deletes the first provider
+  // position kit ignores new provider if it is the same type and id, so delete the previous one first
+  positionKit.setPositionProvider( nullptr ); // deletes the first provider
+  positionKit.setPositionProvider( simulatedProvider2 );
   simulatedProvider2 = nullptr;
 
   hasPositionChanged = positionKitSpy.wait( 2000 );


### PR DESCRIPTION
PR adds UI for position providers page and adding new GPS receiver page based on design doc. To change position provider navigate to settings -> `Select GPS receiver`.

Internal GPS provider is the default device GPS receiver. Desktop platforms have there also additional simulated provider.

Showcase video:

https://user-images.githubusercontent.com/22449698/150008161-c6e2c8c4-296a-4007-ba29-f86bdb91482d.mp4

**Note: connection to BT device still needs a little love, we need to show somehow that mobile is trying to connect to a device.**

Note2: that `eeee` device is just test, it is thus duplicated on video. With normal devices it does not happen.

@PeterPetrik I have not removed all TODOs from previous PR. There will be another one :) 