### PR TITLE
PositionKit as QML singleton

### DIFF
--- a/app/loader.cpp
+++ b/app/loader.cpp
@@ -62,12 +62,6 @@ QgsProject *Loader::project()
   return mProject;
 }
 
-void Loader::setPositionKit( PositionKit *kit )
-{
-  mPositionKit = kit;
-  emit positionKitChanged();
-}
-
 void Loader::setRecording( bool isRecordingOn )
 {
   if ( mRecording != isRecordingOn )
@@ -308,18 +302,6 @@ void Loader::appStateChanged( Qt::ApplicationState state )
 
   logHelper << "Application changed state to: " << state;
   CoreUtils::log( "Input", msg );
-
-  if ( !mRecording && mPositionKit )
-  {
-    if ( state == Qt::ApplicationActive )
-    {
-      mPositionKit->startUpdates();
-    }
-    else
-    {
-      mPositionKit->stopUpdates();
-    }
-  }
 }
 
 void Loader::appAboutToQuit()

--- a/app/loader.h
+++ b/app/loader.h
@@ -20,7 +20,6 @@
 #include <QObject>
 #include "qgsproject.h"
 #include "inpututils.h"
-#include "position/positionkit.h"
 #include "mapthemesmodel.h"
 #include "appsettings.h"
 #include "activelayer.h"
@@ -32,7 +31,6 @@ class Loader: public QObject
 {
     Q_OBJECT
     Q_PROPERTY( QgsProject *project READ project NOTIFY projectChanged ) // never changes
-    Q_PROPERTY( PositionKit *positionKit READ positionKit WRITE setPositionKit NOTIFY positionKitChanged )
     Q_PROPERTY( bool recording READ isRecording WRITE setRecording NOTIFY recordingChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
 
@@ -45,9 +43,6 @@ class Loader: public QObject
       , QObject *parent = nullptr );
 
     QgsProject *project();
-
-    PositionKit *positionKit() const { return mPositionKit; }
-    void setPositionKit( PositionKit *kit );
 
     bool isRecording() const { return mRecording; }
     void setRecording( bool isRecording );
@@ -107,7 +102,6 @@ class Loader: public QObject
     void projectReloaded( QgsProject *project );
     void projectWillBeReloaded( const QString &projectFile );
 
-    void positionKitChanged();
     void recordingChanged();
 
     void loadingStarted();
@@ -131,7 +125,6 @@ class Loader: public QObject
 
 
     QgsProject *mProject = nullptr;
-    PositionKit *mPositionKit = nullptr;
     bool mRecording = false;
 
     MapThemesModel &mMapThemeModel;

--- a/app/position/positionkit.cpp
+++ b/app/position/positionkit.cpp
@@ -241,6 +241,18 @@ void PositionKit::parsePositionUpdate( const GeoPosition &newPosition )
   }
 }
 
+void PositionKit::appStateChanged( Qt::ApplicationState state )
+{
+  if ( state == Qt::ApplicationActive )
+  {
+    startUpdates();
+  }
+  else
+  {
+    stopUpdates();
+  }
+}
+
 double PositionKit::latitude() const
 {
   return mPosition.latitude;

--- a/app/position/positionkit.h
+++ b/app/position/positionkit.h
@@ -137,6 +137,9 @@ class PositionKit : public QObject
   public slots:
     void parsePositionUpdate( const GeoPosition &newPosition );
 
+    // stop updates when application is minimized
+    void appStateChanged( Qt::ApplicationState state );
+
   private:
     GeoPosition mPosition;
     bool mHasPosition = false;

--- a/app/qml/NavigationPanel.qml
+++ b/app/qml/NavigationPanel.qml
@@ -58,15 +58,15 @@ Item {
         return;
 
       _map.navigationHighlightFeature = navigationTargetFeature
-      _map.navigationHighlightGpsPosition = _map.positionKit.position
+      _map.navigationHighlightGpsPosition = __positionKit.positionCoordinate
 
       var previewPanelHeightRatio = previewPanelHeight / _map.height;
-      calculatedNavigationExtent =  __inputUtils.navigationFeatureExtent( _map.navigationHighlightFeature, _map.positionKit.position, _map.mapSettings, previewPanelHeightRatio );
+      calculatedNavigationExtent =  __inputUtils.navigationFeatureExtent( _map.navigationHighlightFeature, __positionKit.positionCoordinate, _map.mapSettings, previewPanelHeightRatio );
 
       if ( autoFollow )
         _map.mapSettings.extent = calculatedNavigationExtent;
 
-      navigationPanel.featureToGpsDistance = __inputUtils.distanceToFeature( _map.positionKit.position, navigationTargetFeature, _map.mapSettings );
+      navigationPanel.featureToGpsDistance = __inputUtils.distanceToFeature( __positionKit.positionCoordinate, navigationTargetFeature, _map.mapSettings );
     }
 
     onAutoFollowChanged: {
@@ -89,7 +89,7 @@ Item {
     }
 
     Connections {
-        target: _map.positionKit
+        target: __positionKit
         onPositionChanged: {
           if ( _map.state === "navigation" && navigationTargetFeature )
             updateNavigation();

--- a/app/qml/SettingsPanel.qml
+++ b/app/qml/SettingsPanel.qml
@@ -24,8 +24,6 @@ Item {
   property string defaultLayer: __appSettings.defaultLayer
   property color gpsIndicatorColor: InputStyle.softRed
 
-  property PositionKit positionKit
-
   Keys.onReleased: {
     if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
       event.accepted = true
@@ -350,7 +348,6 @@ Item {
     id: positionProviderComponent
     PositionProviderPage {
       onClose: stackview.pop(null)
-      positionKit: root.positionKit
       stackView: stackview
       Component.onCompleted: forceActiveFocus()
     }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -164,13 +164,12 @@ ApplicationWindow {
       }
 
       Component.onCompleted: {
-        __loader.positionKit = map.positionKit
         __loader.recording = map.digitizingController.recording
         __loader.mapSettings = map.mapSettings
-        __iosUtils.positionKit = map.positionKit
+        __iosUtils.positionKit = __positionKit
         __iosUtils.compass = map.compass
         __variablesManager.compass = map.compass
-        __variablesManager.positionKit = map.positionKit
+        __variablesManager.positionKit = __positionKit
       }
     }
 
@@ -229,8 +228,6 @@ ApplicationWindow {
       height: window.height
       width: window.width
       rowHeight: InputStyle.rowHeight
-
-      positionKit: map.positionKit
 
       onVisibleChanged: {
         if (settingsPanel.visible)
@@ -294,8 +291,7 @@ ApplicationWindow {
 
         onBack: gpsDataPageLoader.active = false
 
-        mapPositioning: map.mapPositioning
-        positionKit: map.positionKit
+        mapSettings: map.mapSettings
 
         height: window.height
         width: window.width
@@ -431,7 +427,7 @@ ApplicationWindow {
       onNavigateToFeature: {
         if ( !__inputUtils.isPointLayerFeature( feature ) )
           return;
-        if ( !map.positionKit.hasPosition )
+        if ( !__positionKit.hasPosition )
         {
           showMessage( "Navigation mode is disabled because location is unavailable!" );
           return;

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -322,7 +322,6 @@ Item {
   PositionMarker {
     id: _positionMarker
 
-    positionKit: __positionKit
     mapPosition: _mapPosition
     compass: _compass
   }

--- a/app/qml/map/PositionMarker.qml
+++ b/app/qml/map/PositionMarker.qml
@@ -18,7 +18,6 @@ import lc 1.0
 Item {
     id: positionMarker
 
-    property PositionKit positionKit
     /*required*/ property MapPosition mapPosition
     property Compass compass
 
@@ -26,19 +25,20 @@ Item {
     property color baseColor: InputStyle.highlightColor
     property bool withAccuracy: true
 
-    onPositionKitChanged: positionDirection.positionKit = positionMarker.positionKit
     onCompassChanged: positionDirection.compass = positionMarker.compass
 
     PositionDirection {
       id: positionDirection
+
+      positionKit: __positionKit
     }
 
     Rectangle {
         id: accuracyIndicator
 
         visible: withAccuracy &&
-                 positionKit.hasPosition &&
-                 (positionKit.horizontalAccuracy > 0) &&
+                 __positionKit.hasPosition &&
+                 (__positionKit.horizontalAccuracy > 0) &&
                  (accuracyIndicator.width > positionMarker.size / 2.0)
         x: mapPosition.screenPosition.x - width/2
         y: mapPosition.screenPosition.y - height/2
@@ -59,7 +59,7 @@ Item {
         width: positionMarker.size * 2
         height: width
         smooth: true
-        visible: positionKit.hasPosition && positionDirection.hasDirection
+        visible: __positionKit.hasPosition && positionDirection.hasDirection
         x: mapPosition.screenPosition.x - width/2
         y: mapPosition.screenPosition.y - (height * 1)
 
@@ -69,8 +69,8 @@ Item {
     Image {
         id: navigation
 
-        source: positionKit.hasPosition ? InputStyle.gpsMarkerPositionIcon : InputStyle.gpsMarkerNoPositionIcon
-        visible: positionKit.hasPosition
+        source: __positionKit.hasPosition ? InputStyle.gpsMarkerPositionIcon : InputStyle.gpsMarkerNoPositionIcon
+        visible: __positionKit.hasPosition
         fillMode: Image.PreserveAspectFit
         width: positionMarker.size
         height: width

--- a/app/qml/misc/AddPositionProviderPage.qml
+++ b/app/qml/misc/AddPositionProviderPage.qml
@@ -19,8 +19,6 @@ import "../components" as Components
 Page {
   id: root
 
-  property PositionKit positionKit;
-
   signal close
   signal initiatedConnectionTo( string deviceAddress, string deviceName )
 
@@ -135,7 +133,7 @@ Page {
         anchors.fill: parent
         onClicked: {
           btModel.discovering = false
-          root.positionKit.positionProvider = root.positionKit.constructProvider( "external", model.DeviceAddress )
+          __positionKit.positionProvider = __positionKit.constructProvider( "external", model.DeviceAddress )
           initiatedConnectionTo( model.DeviceAddress, model.DeviceName )
           close()
         }

--- a/app/qml/misc/GpsDataPage.qml
+++ b/app/qml/misc/GpsDataPage.qml
@@ -18,9 +18,8 @@ import lc 1.0
 Page {
   id: root
 
-  property var positionKit
-  property var mapPositioning
-  property string coordinatesInDegrees: __inputUtils.degreesString( root.positionKit.positionCoordinate )
+  property var mapSettings
+  property string coordinatesInDegrees: __inputUtils.degreesString( __positionKit.positionCoordinate )
 
   property real cellWidth: root.width * 0.4
 
@@ -33,6 +32,13 @@ Page {
       event.accepted = true
       root.back()
     }
+  }
+
+  MapPosition {
+    id: mapPositioning
+
+    positionKit: __positionKit
+    mapSettings: root.mapSettings
   }
 
   header: PanelHeader {
@@ -80,7 +86,7 @@ Page {
 
         titleText: qsTr( "Longitude" )
         text: {
-          if ( !root.positionKit.hasPosition ) {
+          if ( !__positionKit.hasPosition ) {
             return qsTr( "Loading data from GPS" ) // if you do not have position yet
           }
           root.coordinatesInDegrees.split(", ")[0]
@@ -94,7 +100,7 @@ Page {
 
         titleText: qsTr( "Latitude" )
         text: {
-          if ( !root.positionKit.hasPosition ) {
+          if ( !__positionKit.hasPosition ) {
             return qsTr( "Loading data from GPS" ) // if you do not have position yet
           }
           root.coordinatesInDegrees.split(", ")[1]
@@ -108,10 +114,10 @@ Page {
 
         titleText: qsTr( "X" )
         text: {
-          if ( !root.positionKit.hasPosition ) {
+          if ( !__positionKit.hasPosition ) {
             return qsTr( "Loading data from GPS" ) // if you do not have projected position yet
           }
-          __inputUtils.formatNumber( root.mapPositioning.mapPosition.x, 2 )
+          __inputUtils.formatNumber( mapPositioning.mapPosition.x, 2 )
         }
       }
 
@@ -122,10 +128,10 @@ Page {
 
         titleText: qsTr( "Y" )
         text: {
-          if ( !root.positionKit.hasPosition ) {
+          if ( !__positionKit.hasPosition ) {
             return qsTr( "Loading data from GPS" ) // if you do not have projected position yet
           }
-          __inputUtils.formatNumber( root.mapPositioning.mapPosition.y, 2 )
+          __inputUtils.formatNumber( mapPositioning.mapPosition.y, 2 )
         }
       }
 
@@ -136,11 +142,11 @@ Page {
 
         titleText: qsTr( "Horizontal accuracy" )
         text: {
-          if ( !root.positionKit.hasPosition ) {
+          if ( !__positionKit.hasPosition ) {
             return qsTr( "Loading data from GPS" ) // if you do not have position yet
           }
 
-          root.positionKit.horizontalAccuracy < 0 ? qsTr( "N/A" ) : ( __inputUtils.formatNumber( root.positionKit.horizontalAccuracy, 2 ) + " m" )
+          __positionKit.horizontalAccuracy < 0 ? qsTr( "N/A" ) : ( __inputUtils.formatNumber( __positionKit.horizontalAccuracy, 2 ) + " m" )
         }
       }
 
@@ -151,11 +157,11 @@ Page {
 
         titleText: qsTr( "Vertical accuracy" )
         text: {
-          if ( !root.positionKit.hasPosition ) {
+          if ( !__positionKit.hasPosition ) {
             return qsTr( "Loading data from GPS" ) // if you do not have position yet
           }
 
-          root.positionKit.verticalAccuracy < 0 ? qsTr( "N/A" ) : __inputUtils.formatNumber( root.positionKit.verticalAccuracy, 2 ) + " m"
+          __positionKit.verticalAccuracy < 0 ? qsTr( "N/A" ) : __inputUtils.formatNumber( __positionKit.verticalAccuracy, 2 ) + " m"
         }
       }
 
@@ -168,10 +174,10 @@ Page {
 
         titleText: qsTr( "Altitude" )
         text: {
-          if ( !root.positionKit.hasPosition ) {
+          if ( !__positionKit.hasPosition ) {
             return qsTr( "Loading data from GPS" ) // if you do not have position yet
           }
-          __inputUtils.formatNumber( root.positionKit.altitude, 2 ) + " m"
+          __inputUtils.formatNumber( __positionKit.altitude, 2 ) + " m"
         }
       }
 
@@ -184,12 +190,12 @@ Page {
 
         titleText: qsTr( "Satellites (in use/view)" )
         text: {
-          if ( root.positionKit.satellitesUsed < 0 || root.positionKit.satellitesVisible < 0 )
+          if ( __positionKit.satellitesUsed < 0 || __positionKit.satellitesVisible < 0 )
           {
             return qsTr( "Loading data from GPS" )
           }
 
-          root.positionKit.satellitesUsed + "/" + root.positionKit.satellitesVisible
+          __positionKit.satellitesUsed + "/" + __positionKit.satellitesVisible
         }
       }
 
@@ -201,7 +207,7 @@ Page {
         Layout.column: 0
 
         titleText: qsTr( "Speed" )
-        text: root.positionKit.speed < 0 ? qsTr( "Loading data from GPS" ) : __inputUtils.formatNumber( root.positionKit.speed, 2 ) + " km/h"
+        text: __positionKit.speed < 0 ? qsTr( "Loading data from GPS" ) : __inputUtils.formatNumber( __positionKit.speed, 2 ) + " km/h"
       }
 
       TextRowWithTitle {
@@ -212,7 +218,7 @@ Page {
         Layout.column: 0
 
         titleText: qsTr( "Last fix" )
-        text: root.positionKit.lastRead ? root.positionKit.lastRead.toLocaleTimeString( Qt.locale() ) : qsTr( "Date not available" )
+        text: __positionKit.lastRead ? __positionKit.lastRead.toLocaleTimeString( Qt.locale() ) : qsTr( "Date not available" )
       }
     }
   }

--- a/app/qml/misc/PositionProviderPage.qml
+++ b/app/qml/misc/PositionProviderPage.qml
@@ -20,7 +20,6 @@ import "../components" as Components
 Page {
   id: root
 
-  property var positionKit
   property var stackView
 
   signal close
@@ -78,7 +77,7 @@ Page {
       MouseArea {
         anchors.fill: parent
         onClicked: {
-            root.positionKit.positionProvider = root.positionKit.constructProvider( model.ProviderType, model.ProviderId )
+            __positionKit.positionProvider = __positionKit.constructProvider( model.ProviderType, model.ProviderId )
         }
       }
 
@@ -127,7 +126,7 @@ Page {
           MouseArea {
             anchors.fill: parent
             onClicked: {
-                root.positionKit.positionProvider = root.positionKit.constructProvider( model.ProviderType, model.ProviderId )
+                __positionKit.positionProvider = __positionKit.constructProvider( model.ProviderType, model.ProviderId )
             }
           }
         }
@@ -245,8 +244,6 @@ Page {
     id: bluetoothDiscoveryComponent
 
     AddPositionProviderPage {
-      positionKit: root.positionKit
-
       height: root.height + header.height
       width: root.width
 
@@ -280,7 +277,7 @@ Page {
         if ( __appSettings.activePositionProviderId == relatedProviderId )
         {
           // we are removing an active provider, replace it with internal provider
-          root.positionKit.positionProvider = root.positionKit.constructProvider( "internal", "devicegps" )
+          __positionKit.positionProvider = __positionKit.constructProvider( "internal", "devicegps" )
         }
 
         providersModel.removeProvider( relatedProviderId )


### PR DESCRIPTION
Changed position kit to be a singleton in QML. Previously we needed to pass `PositionKit` qml instance all over the place. It is handy to be able to access device position from any part of the app.