### PR TITLE
Position providers cpp fixes

### DIFF
--- a/app/bluetoothdiscoverymodel.cpp
+++ b/app/bluetoothdiscoverymodel.cpp
@@ -21,7 +21,7 @@ BluetoothDiscoveryModel::BluetoothDiscoveryModel( QObject *parent ) : QAbstractL
   connect( mDiscoveryAgent.get(), &QBluetoothDeviceDiscoveryAgent::canceled, this, &BluetoothDiscoveryModel::finishedDiscovery );
   connect( mDiscoveryAgent.get(), &QBluetoothDeviceDiscoveryAgent::finished, this, &BluetoothDiscoveryModel::finishedDiscovery );
 
-  connect( mDiscoveryAgent.get(), QOverload<QBluetoothDeviceDiscoveryAgent::Error>::of( &QBluetoothDeviceDiscoveryAgent::error ),
+  connect( mDiscoveryAgent.get(), QOverload<QBluetoothDeviceDiscoveryAgent::Error>::of( &QBluetoothDeviceDiscoveryAgent::error ), this,
            [ = ]( QBluetoothDeviceDiscoveryAgent::Error error )
   {
     qDebug() << error << "occured during discovery, ending.."; // TODO: remove

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -440,7 +440,7 @@ int main( int argc, char *argv[] )
   PositionKit pk;
   pk.setPositionProvider( pk.constructActiveProvider( &as ) );
   // when provider changes, save it to QSettings
-  QObject::connect( &pk, &PositionKit::positionProviderChanged, [&as]( AbstractPositionProvider * provider )
+  QObject::connect( &pk, &PositionKit::positionProviderChanged, &as, [&as]( AbstractPositionProvider * provider )
   {
     as.setActivePositionProviderId( provider->providerId() );
   } );

--- a/app/position/bluetoothpositionprovider.cpp
+++ b/app/position/bluetoothpositionprovider.cpp
@@ -28,7 +28,7 @@ BluetoothPositionProvider::BluetoothPositionProvider( const QString &addr, QObje
   mSocket = std::unique_ptr<QBluetoothSocket>( new QBluetoothSocket( QBluetoothServiceInfo::RfcommProtocol ) );
 
   connect( mSocket.get(), &QBluetoothSocket::stateChanged, this, &BluetoothPositionProvider::socketStateChanged );
-  connect( mSocket.get(), QOverload<QBluetoothSocket::SocketError>::of( &QBluetoothSocket::error ),
+  connect( mSocket.get(), QOverload<QBluetoothSocket::SocketError>::of( &QBluetoothSocket::error ), this,
            [ = ]( QBluetoothSocket::SocketError error )
   {
     CoreUtils::log( QStringLiteral( "BluetoothPositionProvider" ), QStringLiteral( "Occured error code: %1" ).arg( error ) );

--- a/app/position/bluetoothpositionprovider.cpp
+++ b/app/position/bluetoothpositionprovider.cpp
@@ -36,7 +36,7 @@ BluetoothPositionProvider::BluetoothPositionProvider( const QString &addr, QObje
   } );
 
   connect( mSocket.get(), &QBluetoothSocket::readyRead, this, &BluetoothPositionProvider::positionUpdateReceived );
-  startUpdates();
+  BluetoothPositionProvider::startUpdates();
 }
 
 BluetoothPositionProvider::~BluetoothPositionProvider()

--- a/app/position/internalpositionprovider.cpp
+++ b/app/position/internalpositionprovider.cpp
@@ -75,7 +75,7 @@ InternalPositionProvider::InternalPositionProvider( QObject *parent )
     } );
   }
 
-  startUpdates();
+  InternalPositionProvider::startUpdates();
 }
 
 InternalPositionProvider::~InternalPositionProvider() = default;

--- a/app/position/internalpositionprovider.cpp
+++ b/app/position/internalpositionprovider.cpp
@@ -44,14 +44,14 @@ InternalPositionProvider::InternalPositionProvider( QObject *parent )
     //TODO: maybe set a minimal timeout (e.g. 500 ms)?
 
     connect( mGpsPositionSource.get(), &QGeoPositionInfoSource::positionUpdated, this, &InternalPositionProvider::parsePositionUpdate );
-    connect( mGpsPositionSource.get(), QOverload<QGeoPositionInfoSource::Error>::of( &QGeoPositionInfoSource::error ),
+    connect( mGpsPositionSource.get(), QOverload<QGeoPositionInfoSource::Error>::of( &QGeoPositionInfoSource::error ), this,
              [ = ]( QGeoPositionInfoSource::Error positioningError )
     {
       CoreUtils::log( QStringLiteral( "Internal GPS provider" ), QStringLiteral( "Error occured (position source), code: %1" ).arg( positioningError ) );
       qDebug() << positioningError << " <- has occured during initialization of internal GPS position provider!"; // TODO: remove
       emit lostConnection();
     } );
-    connect( mGpsPositionSource.get(), &QGeoPositionInfoSource::updateTimeout, [ = ]()
+    connect( mGpsPositionSource.get(), &QGeoPositionInfoSource::updateTimeout, this, [ = ]()
     {
       CoreUtils::log( QStringLiteral( "Internal GPS provider" ), QStringLiteral( "Stopped receiving position data" ) );
       qDebug() << " Internal GPS (position) stopped receiving data!"; // TODO: remove
@@ -60,14 +60,14 @@ InternalPositionProvider::InternalPositionProvider( QObject *parent )
 
     connect( mGpsSatellitesSource.get(), &QGeoSatelliteInfoSource::satellitesInViewUpdated, this, &InternalPositionProvider::parseVisibleSatellitesUpdate );
     connect( mGpsSatellitesSource.get(), &QGeoSatelliteInfoSource::satellitesInUseUpdated, this, &InternalPositionProvider::parseUsedSatellitesUpdate );
-    connect( mGpsSatellitesSource.get(), QOverload<QGeoSatelliteInfoSource::Error>::of( &QGeoSatelliteInfoSource::error ),
+    connect( mGpsSatellitesSource.get(), QOverload<QGeoSatelliteInfoSource::Error>::of( &QGeoSatelliteInfoSource::error ), this,
              [ = ]( QGeoSatelliteInfoSource::Error satelliteError )
     {
       CoreUtils::log( QStringLiteral( "Internal GPS provider" ), QStringLiteral( "Error occured (satellites source), code: %1" ).arg( satelliteError ) );
       qDebug() << satelliteError << " <- has occured during initialization of internal GPS satellites provider!"; // TODO: remove
       emit lostConnection();
     } );
-    connect( mGpsSatellitesSource.get(), &QGeoSatelliteInfoSource::requestTimeout, [ = ]()
+    connect( mGpsSatellitesSource.get(), &QGeoSatelliteInfoSource::requestTimeout, this, [ = ]()
     {
       CoreUtils::log( QStringLiteral( "Internal GPS provider" ), QStringLiteral( "Stopped receiving satellites data" ) );
       qDebug() << " Internal GPS (satellite) stopped receiving data!"; // TODO: remove

--- a/app/position/simulatedpositionprovider.cpp
+++ b/app/position/simulatedpositionprovider.cpp
@@ -22,7 +22,7 @@ SimulatedPositionProvider::SimulatedPositionProvider( double longitude, double l
 
   connect( mTimer.get(), &QTimer::timeout, this, &SimulatedPositionProvider::generateNextPosition );
 
-  startUpdates();
+  SimulatedPositionProvider::startUpdates();
 }
 
 SimulatedPositionProvider::~SimulatedPositionProvider() = default;


### PR DESCRIPTION
There were two cpp issues with providers:
 1. lambda functions did not have context so after a provider was deleted, lambda became dangling pointer and crashed
 2. constructor called on overridden virtual method without explicitly noting which version to take (I found out that it is a _no no_ in cpp https://wiki.sei.cmu.edu/confluence/display/cplusplus/OOP50-CPP.+Do+not+invoke+virtual+functions+from+constructors+or+destructors)