### PR TITLE
Make satellite source optional (fixes Apple)

### DIFF
--- a/app/position/internalpositionprovider.h
+++ b/app/position/internalpositionprovider.h
@@ -40,7 +40,9 @@ class InternalPositionProvider : public AbstractPositionProvider
     void parseUsedSatellitesUpdate( const QList<QGeoSatelliteInfo> &satellites );
 
   private:
-    bool mIsValid = true; // determines if both position sources were successfully created
+    // determines if sources were successfully created
+    bool mPositionSourceValid = false;
+    bool mSatelliteSourceValid = false;
 
     // There are two sources of GPS data, one informs us about position and the other about satellites.
     // Both of them are handled in separate slots and in order to be able to emit merged information


### PR DESCRIPTION
`InternalPositionProvider` previously had to have both geo sources (position and satellite) valid in order to start receiving updates. This is wrong on few devices including Apple, where `QGeoSatelliteInfoSource` does not work.

Provider now works in a separates validity of each of the two sources and acts based on that (turns them on/off).

Position can now be read also on mac! :) 
