### PR TITLE
Disable building the same provider twice

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -21,6 +21,7 @@ env:
   XC_VERSION: ${{ '12.0.1' }}
   IOS_MIN_SDK_VERSION: ${{ '12.0' }}
   CCACHE_DIR: /Users/runner/work/ccache
+  CACHE_VERSION: 0
 
 concurrency:
   group: ci-${{github.ref}}-ios
@@ -115,7 +116,7 @@ jobs:
         uses: pat-s/always-upload-cache@v2.1.5
         with:
           path: ${{ github.workspace }}/input-sdk
-          key: ${{ runner.os }}-input-sdk-v1-${{ env.INPUT_SDK_VERSION }}
+          key: ${{ runner.os }}-input-sdk-v1-${{ env.INPUT_SDK_VERSION }}-${{ env.CACHE_VERSION }}
 
       - name: Install Input-SDK
         if: steps.cache-input-sdk.outputs.cache-hit != 'true'
@@ -133,7 +134,7 @@ jobs:
         uses: pat-s/always-upload-cache@v2.1.5
         with:
           path: ${{ github.workspace }}/Qt
-          key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}-ios
+          key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}-ios-${{ env.CACHE_VERSION }}
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   TEST_MERGIN_URL: https://test.dev.cloudmergin.com/
-  TEST_API_USERNAME: test_inputapp
+  TEST_API_USERNAME: test_inputapp2
   TEST_API_PASSWORD: ${{ secrets.MERGINTEST_API_PASSWORD }}
   QT_VERSION: 5.14.2
   QMAKE_MACOSX_DEPLOYMENT_TARGET: 10.13.0

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -436,14 +436,13 @@ int main( int argc, char *argv[] )
   std::unique_ptr<VariablesManager> vm( new VariablesManager( ma.get() ) );
   vm->registerInputExpressionFunctions();
 
-  // build position kit and load previously active provider
+  // build position kit, save active provider to QSettings and load previously active provider
   PositionKit pk;
-  pk.setPositionProvider( pk.constructActiveProvider( &as ) );
-  // when provider changes, save it to QSettings
   QObject::connect( &pk, &PositionKit::positionProviderChanged, &as, [&as]( AbstractPositionProvider * provider )
   {
     as.setActivePositionProviderId( provider->providerId() );
   } );
+  pk.setPositionProvider( pk.constructActiveProvider( &as ) );
 
   // Connections
   QObject::connect( &app, &QGuiApplication::applicationStateChanged, &loader, &Loader::appStateChanged );

--- a/app/qml/misc/PositionProviderPage.qml
+++ b/app/qml/misc/PositionProviderPage.qml
@@ -24,6 +24,14 @@ Page {
 
   signal close
 
+  function constructProvider( type, id )
+  {
+    if ( __appSettings.activePositionProviderId === id )
+      return // do not construct the same provider again
+
+    __positionKit.positionProvider = __positionKit.constructProvider( type, id )
+  }
+
   header: Components.PanelHeader {
     id: header
 
@@ -76,9 +84,7 @@ Page {
 
       MouseArea {
         anchors.fill: parent
-        onClicked: {
-            __positionKit.positionProvider = __positionKit.constructProvider( model.ProviderType, model.ProviderId )
-        }
+        onClicked: root.constructProvider( model.ProviderType, model.ProviderId )
       }
 
       Row {
@@ -125,9 +131,7 @@ Page {
           // We need to duplicate mouse area here in order to handle clicks from RadioButton
           MouseArea {
             anchors.fill: parent
-            onClicked: {
-                __positionKit.positionProvider = __positionKit.constructProvider( model.ProviderType, model.ProviderId )
-            }
+            onClicked: root.constructProvider( model.ProviderType, model.ProviderId )
           }
         }
 
@@ -277,7 +281,7 @@ Page {
         if ( __appSettings.activePositionProviderId == relatedProviderId )
         {
           // we are removing an active provider, replace it with internal provider
-          __positionKit.positionProvider = __positionKit.constructProvider( "internal", "devicegps" )
+          root.constructProvider( "internal", "devicegps" )
         }
 
         providersModel.removeProvider( relatedProviderId )


### PR DESCRIPTION
From position providers list user could click on the same item multiple times which resulted in instantiation of x providers (of that type).
Even though position kit do not accept the same provider, this was dangerous for bluetooth providers as they rely on Android sockets and instantiation of them multiple times (~ > 8) led to a crash. 