### PR TITLE
Opt to enable bluetooth when it is disabled

### DIFF
--- a/app/androidutils.h
+++ b/app/androidutils.h
@@ -14,6 +14,7 @@
 #ifdef ANDROID
 #include <QAndroidActivityResultReceiver>
 #include <QAndroidJniObject>
+#include <QBluetoothLocalDevice>
 #endif
 #include <QObject>
 
@@ -55,6 +56,9 @@ class AndroidUtils: public QObject
     bool findLegacyFolder( QString &legacyFolderPath );
     void migrateLegacyProjects( const QString &from, const QString &to );
 
+    void turnBluetoothOn();
+    bool isBluetoothTurnedOn();
+
     /**
       * Starts ACTION_PICK activity which opens a gallery. If an image is selected,
       * handler of the activity emits imageSelected signal.
@@ -64,6 +68,7 @@ class AndroidUtils: public QObject
 #ifdef ANDROID
     const static int MEDIA_CODE = 101;
     const static int CAMERA_CODE = 102;
+    const static int BLUETOOTH_CODE = 103;
 
     void handleActivityResult( int receiverRequestCode, int resultCode, const QAndroidJniObject &data ) override;
 #endif
@@ -76,12 +81,17 @@ class AndroidUtils: public QObject
     void migrationStarted( int numOfProjectsToCopy );
     void notEnoughSpaceLeftToMigrate( QString neededSpace );
 
+    void bluetoothEnabled( bool state );
+
   public slots:
     void showToast( QString message );
 
   private:
-
     bool mIsAndroid;
+
+#ifdef ANDROID
+    QBluetoothLocalDevice mBluetooth;
+#endif
 };
 
 #endif // ANDROIDUTILS_H

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -51,9 +51,15 @@
 static const QString DATE_TIME_FORMAT = QStringLiteral( "yyMMdd-hhmmss" );
 static const QString INVALID_DATETIME_STR = QStringLiteral( "Invalid datetime" );
 
-InputUtils::InputUtils( QObject *parent ): QObject( parent )
+InputUtils::InputUtils( QObject *parent )
+  : QObject( parent )
 {
-  mAndroidUtils = std::unique_ptr<AndroidUtils>( new AndroidUtils() );
+}
+
+InputUtils::InputUtils( AndroidUtils *au, QObject *parent )
+  : QObject( parent )
+  , mAndroidUtils( au )
+{
 }
 
 bool InputUtils::removeFile( const QString &filePath )
@@ -430,11 +436,28 @@ QString InputUtils::bytesToHumanSize( double bytes )
 
 bool InputUtils::acquireCameraPermission()
 {
-  if ( appPlatform() == QStringLiteral( "android" ) )
+  if ( appPlatform() == QStringLiteral( "android" ) && mAndroidUtils )
   {
     return mAndroidUtils->requestCameraPermission();
   }
   return true;
+}
+
+bool InputUtils::isBluetoothTurnedOn()
+{
+  if ( appPlatform() == QStringLiteral( "android" ) && mAndroidUtils )
+  {
+    return mAndroidUtils->isBluetoothTurnedOn();
+  }
+  return true;
+}
+
+void InputUtils::turnBluetoothOn()
+{
+  if ( appPlatform() == QStringLiteral( "android" ) && mAndroidUtils )
+  {
+    mAndroidUtils->turnBluetoothOn();
+  }
 }
 
 void InputUtils::quitApp()

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -48,6 +48,7 @@ class InputUtils: public QObject
     Q_OBJECT
   public:
     explicit InputUtils( QObject *parent = nullptr );
+    explicit InputUtils( AndroidUtils *au, QObject *parent = nullptr );
     ~InputUtils() override = default;
 
     Q_INVOKABLE static bool copyFile( const QString &srcPath, const QString &dstPath );
@@ -102,6 +103,10 @@ class InputUtils: public QObject
     Q_INVOKABLE static QString bytesToHumanSize( double bytes );
 
     Q_INVOKABLE bool acquireCameraPermission();
+
+    Q_INVOKABLE bool isBluetoothTurnedOn();
+
+    Q_INVOKABLE void turnBluetoothOn();
 
     Q_INVOKABLE void quitApp();
 
@@ -443,7 +448,8 @@ class InputUtils: public QObject
     static QString sanitizeName( const QString &path );
 
     static double ratherZeroThanNaN( double d );
-    std::unique_ptr<AndroidUtils> mAndroidUtils;
+
+    AndroidUtils *mAndroidUtils = nullptr; // not owned
 };
 
 #endif // INPUTUTILS_H

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -420,7 +420,7 @@ int main( int argc, char *argv[] )
   LocalProjectsManager localProjectsManager( projectDir );
   MapThemesModel mtm;
   std::unique_ptr<MerginApi> ma =  std::unique_ptr<MerginApi>( new MerginApi( localProjectsManager ) );
-  InputUtils iu;
+  InputUtils iu( &au );
   MerginProjectStatusModel mpsm( localProjectsManager );
   InputHelp help( ma.get(), &iu );
   ProjectWizard pw( projectDir );

--- a/app/qml/misc/AddPositionProviderPage.qml
+++ b/app/qml/misc/AddPositionProviderPage.qml
@@ -44,6 +44,7 @@ Page {
   Keys.onReleased: {
     if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
       event.accepted = true
+      btModel.discovering = false
       close()
     }
   }
@@ -55,7 +56,38 @@ Page {
 
     model: BluetoothDiscoveryModel {
       id: btModel
-      discovering: true
+      discovering: false
+    }
+
+    Component.onCompleted: {
+      // Is bluetooth turned on?
+      // For iOS this is working out of the box, but for Android we need to
+      // opt to enable Bluetooth and listen on response in the connections component.
+      if ( __inputUtils.isBluetoothTurnedOn() )
+      {
+        btModel.discovering = true
+      }
+      else
+      {
+        __inputUtils.turnBluetoothOn()
+      }
+    }
+
+    Connections {
+      target: __androidUtils
+
+      function onBluetoothEnabled( state )
+      {
+        if ( state )
+        {
+          btModel.discovering = true
+        }
+        else
+        {
+          __inputUtils.showNotification( qsTr( "You need to enable Bluetooth in order to connect new GPS receiver" ) )
+          root.close()
+        }
+      }
     }
 
     delegate: Rectangle {


### PR DESCRIPTION
Added check if bluetooth is turned on before starting discovery process. 
If:
 - bluetooth is turned on, discovery process starts automatically
 - bluetooth is turned off, show system dialog to enable bluetooth, if:
    - user enables bluetooth in the dialog, discovery process starts
    - user do not enable it, app goes back to list of existing providers and toast message pops up with text "You need to enable Bluetooth in order to connect new GPS receiver"

<img src="https://user-images.githubusercontent.com/22449698/150303855-714ab68e-178c-4a61-be04-5ebe86837724.jpg" width=300>
