### PR TITLE
Autoreconnect for BT GPS receivers

### DIFF
--- a/app/bluetoothdiscoverymodel.cpp
+++ b/app/bluetoothdiscoverymodel.cpp
@@ -24,7 +24,6 @@ BluetoothDiscoveryModel::BluetoothDiscoveryModel( QObject *parent ) : QAbstractL
   connect( mDiscoveryAgent.get(), QOverload<QBluetoothDeviceDiscoveryAgent::Error>::of( &QBluetoothDeviceDiscoveryAgent::error ), this,
            [ = ]( QBluetoothDeviceDiscoveryAgent::Error error )
   {
-    qDebug() << error << "occured during discovery, ending.."; // TODO: remove
     CoreUtils::log( "Bluetooth discovery", QString( "Error occured during device discovery, error code #" ).arg( error ) );
     finishedDiscovery();
   } );
@@ -102,22 +101,6 @@ void BluetoothDiscoveryModel::setDiscovering( bool discovering )
 
   mDiscovering = discovering;
   emit discoveringChanged( mDiscovering );
-}
-
-// TODO: this is a helper class to print the device, let's keep it there for a while
-void _printDeviceInfo( const QBluetoothDeviceInfo &device )
-{
-  qDebug() << "Device" << device.name() << "Address:" << device.address();
-  qDebug() << "  uuid:" << device.deviceUuid();
-  qDebug() << "  rssi (signal strength):" << device.rssi();
-  qDebug() << "  core config:" << device.coreConfigurations();
-  qDebug() << "  service classes:" << device.serviceClasses();
-  qDebug() << "  service uuids:" << device.serviceUuids();
-  qDebug() << "  valid:" << device.isValid();
-  qDebug() << "  cached: " << device.isCached();
-  qDebug() << "  major class:" << device.majorDeviceClass();
-  qDebug() << "  minor class:" << device.minorDeviceClass();
-  qDebug() << " --- ";
 }
 
 void BluetoothDiscoveryModel::deviceDiscovered( const QBluetoothDeviceInfo &device )

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -294,7 +294,7 @@ void initDeclarative()
   qmlRegisterType< QgsQuickMapTransform >( "QgsQuick", 0, 1, "MapTransform" );
   qmlRegisterType< QgsQuickCoordinateTransformer >( "QgsQuick", 0, 1, "CoordinateTransformer" );
 
-  qmlRegisterUncreatableType< AbstractPositionProvider >( "lc", 1, 0, "AbstractPositionProvider", "Must be instantiated via its construct method" );
+  qmlRegisterUncreatableType< AbstractPositionProvider >( "lc", 1, 0, "PositionProvider", "Must be instantiated via its construct method" );
 
   qmlRegisterType( QUrl( "qrc:/qgsquickmapcanvas.qml" ), "QgsQuick", 0, 1, "MapCanvas" );
 }

--- a/app/position/abstractpositionprovider.cpp
+++ b/app/position/abstractpositionprovider.cpp
@@ -18,13 +18,6 @@ AbstractPositionProvider::AbstractPositionProvider( const QString &id, const QSt
 {
 }
 
-void AbstractPositionProvider::reconnect()
-{
-  CoreUtils::log( QStringLiteral( "PositionProvider" ), QStringLiteral( "Reconnecting provider " ) + mProviderId );
-  stopUpdates();
-  startUpdates();
-}
-
 AbstractPositionProvider::~AbstractPositionProvider() = default;
 
 QString AbstractPositionProvider::name() const
@@ -32,14 +25,14 @@ QString AbstractPositionProvider::name() const
   return mProviderName;
 }
 
-QString AbstractPositionProvider::statusMessage() const
+QString AbstractPositionProvider::stateMessage() const
 {
-  return mStatusMessage;
+  return mStateMessage;
 }
 
-AbstractPositionProvider::StatusLevel AbstractPositionProvider::statusLevel() const
+AbstractPositionProvider::State AbstractPositionProvider::state() const
 {
-  return mStatusLevel;
+  return mState;
 }
 
 QString AbstractPositionProvider::id() const
@@ -52,18 +45,23 @@ QString AbstractPositionProvider::type() const
   return mProviderType;
 }
 
-void AbstractPositionProvider::setStatus( const QString &message, StatusLevel level )
+void AbstractPositionProvider::setState( const QString &message )
 {
-  if ( mStatusMessage != message )
+  setState( message, mState );
+}
+
+void AbstractPositionProvider::setState( const QString &message, AbstractPositionProvider::State state )
+{
+  if ( mStateMessage != message )
   {
-    mStatusMessage = message;
-    emit statusMessageChanged( mStatusMessage );
+    mStateMessage = message;
+    emit stateMessageChanged( mStateMessage );
   }
 
-  if ( mStatusLevel != level )
+  if ( mState != state )
   {
-    mStatusLevel = level;
-    emit statusLevelChanged( mStatusLevel );
+    mState = state;
+    emit stateChanged( mState );
   }
 }
 

--- a/app/position/abstractpositionprovider.h
+++ b/app/position/abstractpositionprovider.h
@@ -43,7 +43,7 @@ class AbstractPositionProvider : public QObject
 
     enum State
     {
-      Unconnected = 0,
+      Disconnected = 0,
       WaitingToReconnect,
       Connecting,
       Connected
@@ -88,7 +88,7 @@ class AbstractPositionProvider : public QObject
 
     // State of this provider, see State enum. Message bears human readable explanation of the state
     QString mStateMessage;
-    State mState = State::Unconnected;
+    State mState = State::Disconnected;
 };
 
 #endif // ABSTRACTPOSITIONPROVIDER_H

--- a/app/position/abstractpositionprovider.h
+++ b/app/position/abstractpositionprovider.h
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -36,17 +36,19 @@ class AbstractPositionProvider : public QObject
 {
     Q_OBJECT
 
-    Q_PROPERTY( QString statusMessage READ statusMessage NOTIFY statusMessageChanged )
-    Q_PROPERTY( StatusLevel statusLevel READ statusLevel NOTIFY statusLevelChanged )
+    Q_PROPERTY( QString stateMessage READ stateMessage NOTIFY stateMessageChanged )
+    Q_PROPERTY( State state READ state NOTIFY stateChanged )
 
   public:
 
-    enum StatusLevel
+    enum State
     {
-      Info = 0, //!< nothing serious, status like "connected"
-      Error     //!< there is a serious error in provider like "lost connection"
+      Unconnected = 0,
+      WaitingToReconnect,
+      Connecting,
+      Connected
     };
-    Q_ENUMS( StatusLevel )
+    Q_ENUMS( State )
 
     AbstractPositionProvider( const QString &id, const QString &type, const QString &name, QObject *object = nullptr );
     virtual ~AbstractPositionProvider();
@@ -54,25 +56,22 @@ class AbstractPositionProvider : public QObject
     virtual void startUpdates() = 0;
     virtual void stopUpdates() = 0;
     virtual void closeProvider() = 0;
-    Q_INVOKABLE virtual void reconnect();
 
-    QString statusMessage() const;
-    StatusLevel statusLevel() const;
+    QString stateMessage() const;
+    State state() const;
     Q_INVOKABLE QString id() const;
     Q_INVOKABLE QString name() const;
     Q_INVOKABLE QString type() const;
 
   signals:
     void positionChanged( const GeoPosition &position );
-    void providerConnecting();
-    void providerConnected();
-    void lostConnection();
 
-    void statusMessageChanged( const QString &status );
-    void statusLevelChanged( StatusLevel level );
+    void stateMessageChanged( const QString &message );
+    void stateChanged( State state );
 
   protected:
-    void setStatus( const QString &message, StatusLevel level = StatusLevel::Info );
+    void setState( const QString &message ); // keeps state enum the same and only changes the message
+    void setState( const QString &message, State state );
 
     // ProviderId - unique id of this provider.
     // For external receiver it holds mac address of a bluetooth device.
@@ -87,10 +86,9 @@ class AbstractPositionProvider : public QObject
     // Internal providers has constant values of "Internal GPS receiver" and "Simulated provider"
     QString mProviderName;
 
-    // Status of this provider, "connected", "failure",..
-    QString mStatusMessage;
-    StatusLevel mStatusLevel;
+    // State of this provider, see State enum. Message bears human readable explanation of the state
+    QString mStateMessage;
+    State mState = State::Unconnected;
 };
-
 
 #endif // ABSTRACTPOSITIONPROVIDER_H

--- a/app/position/bluetoothpositionprovider.cpp
+++ b/app/position/bluetoothpositionprovider.cpp
@@ -9,6 +9,8 @@
 
 #include "bluetoothpositionprovider.h"
 #include "coreutils.h"
+#include "androidutils.h"
+#include "inpututils.h"
 
 NmeaParser::NmeaParser() : QgsNmeaConnection( new QBluetoothSocket() )
 {
@@ -82,6 +84,16 @@ void BluetoothPositionProvider::reconnect()
   setState( tr( "Reconnecting" ), State::Connecting );
 
   CoreUtils::log( QStringLiteral( "BluetoothPositionProvider" ), QStringLiteral( "Reconnecting to %1" ).arg( mProviderName ) );
+
+  if ( mReceiverDevice->hostMode() == QBluetoothLocalDevice::HostPoweredOff )
+  {
+    // bluetooth is powered off.. ask user once to turn it on
+    if ( InputUtils::appPlatform() == QStringLiteral( "android" ) )
+    {
+      AndroidUtils android;
+      android.turnBluetoothOn();
+    }
+  }
 
   stopUpdates();
   startUpdates();

--- a/app/position/bluetoothpositionprovider.cpp
+++ b/app/position/bluetoothpositionprovider.cpp
@@ -40,7 +40,7 @@ BluetoothPositionProvider::BluetoothPositionProvider( const QString &addr, const
       QStringLiteral( "Occured connection error: %1, text: %2" ).arg( errorToString ).arg( mSocket->errorString() )
     );
 
-    setState( tr( "Unconnected" ), State::Unconnected );
+    setState( tr( "Disconnected" ), State::Disconnected );
     handleLostConnection();
   } );
 
@@ -119,7 +119,7 @@ void BluetoothPositionProvider::handleLostConnection()
 
   if ( mReceiverDevice->pairingStatus( mTargetAddress ) == QBluetoothLocalDevice::Unpaired )
   {
-    setState( tr( "Could not connect to device, not paired" ), State::Unconnected );
+    setState( tr( "Could not connect to device, not paired" ), State::Disconnected );
   }
   else if ( mState != WaitingToReconnect && mState != Connecting )
   {
@@ -148,7 +148,7 @@ void BluetoothPositionProvider::socketStateChanged( QBluetoothSocket::SocketStat
   }
   else if ( state == QBluetoothSocket::UnconnectedState )
   {
-    setState( tr( "Unconnected" ), State::Unconnected );
+    setState( tr( "Disconnected" ), State::Disconnected );
     handleLostConnection();
   }
 

--- a/app/position/internalpositionprovider.cpp
+++ b/app/position/internalpositionprovider.cpp
@@ -34,7 +34,7 @@ InternalPositionProvider::InternalPositionProvider( QObject *parent )
     } );
 
     mPositionSourceValid = true;
-    emit providerConnected();
+    setState( tr( "Connected" ), State::Connected );
   }
   else
   {
@@ -111,7 +111,7 @@ void InternalPositionProvider::parsePositionUpdate( const QGeoPositionInfo &posi
 {
   // if by any chance we are in wrong state (QML thinking that provider is not connected)
   // emit connected signal here to know that the connection is OK
-  emit providerConnected();
+  setState( tr( "Connected" ), State::Connected );
 
   bool hasPosition = position.coordinate().isValid();
   if ( !hasPosition )

--- a/app/position/positionkit.cpp
+++ b/app/position/positionkit.cpp
@@ -62,7 +62,6 @@ void PositionKit::setPositionProvider( AbstractPositionProvider *provider )
   if ( mPositionProvider )
   {
     connect( mPositionProvider.get(), &AbstractPositionProvider::positionChanged, this, &PositionKit::parsePositionUpdate );
-    connect( mPositionProvider.get(), &AbstractPositionProvider::lostConnection, this, &PositionKit::lostConnection );
 
     CoreUtils::log( QStringLiteral( "PositionKit" ), QStringLiteral( "Changed position provider to: %1" ).arg( provider->id() ) );
   }

--- a/app/position/positionkit.h
+++ b/app/position/positionkit.h
@@ -107,8 +107,6 @@ class PositionKit : public QObject
     Q_INVOKABLE static AbstractPositionProvider *constructActiveProvider( AppSettings *appsettings );
 
   signals:
-    void lostConnection();
-
     void latitudeChanged( double );
     void longitudeChanged( double );
     void altitudeChanged( double );

--- a/app/position/simulatedpositionprovider.cpp
+++ b/app/position/simulatedpositionprovider.cpp
@@ -45,7 +45,7 @@ void SimulatedPositionProvider::closeProvider()
 
 void SimulatedPositionProvider::generateNextPosition()
 {
-  emit providerConnected();
+  setState( tr( "Connected" ), State::Connected );
 
   if ( mFlightRadius <= 0 )
     generateConstantPosition();

--- a/app/qml/NotificationBanner.qml
+++ b/app/qml/NotificationBanner.qml
@@ -28,16 +28,28 @@ Rectangle {
   signal notificationClosed()
   signal detailsClicked()
 
-  function pushNotification( message ) {
+  function pushNotification( message )
+  {
     showNotification = true;
-    text = message;
   }
 
-  function reset() {
-    state = "fade";
+  function pushNotificationMessage( message )
+  {
+    text = message;
+    pushNotification()
+  }
+
+  function close()
+  {
+    state = "fade"
     notificationBanner.visible = false;
     showNotification = false;
+  }
+
+  function reset()
+  {
     text = "";
+    close()
   }
 
   color: notificationBanner.bgColor

--- a/app/qml/components/BluetoothConnectionDialog.qml
+++ b/app/qml/components/BluetoothConnectionDialog.qml
@@ -10,7 +10,9 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
+
 import ".."
+import lc 1.0
 
 Dialog {
   id: root
@@ -52,25 +54,6 @@ Dialog {
   signal success()
   signal failure()
 
-  Connections {
-    target: __positionKit.positionProvider
-
-    function onLostConnection()
-    {
-      rootstate.state = "fail"
-    }
-
-    function onProviderConnecting()
-    {
-      rootstate.state = "working"
-    }
-
-    function onProviderConnected()
-    {
-      rootstate.state = "success"
-    }
-  }
-
   focus: true
 
   // just close the popup, keep the connection running
@@ -106,17 +89,20 @@ Dialog {
     states: [
       State {
         name: "working"
+        when: __positionKit.positionProvider && __positionKit.positionProvider.state === PositionProvider.Connecting
         PropertyChanges { target: loadingSpinner; opacity: 1.0 }
         PropertyChanges { target: resultIcon; opacity: 0.0 }
       },
       State {
         name: "success"
+        when: __positionKit.positionProvider && __positionKit.positionProvider.state === PositionProvider.Connected
         PropertyChanges { target: resultIcon; source: InputStyle.yesIcon }
         PropertyChanges { target: loadingSpinner; opacity: 0.0 }
         PropertyChanges { target: resultIcon; opacity: 1.0 }
       },
       State {
         name: "fail"
+        when: !__positionKit.positionProvider || __positionKit.positionProvider.state === PositionProvider.Unconnected
         PropertyChanges { target: resultIcon; source: InputStyle.noIcon }
         PropertyChanges { target: loadingSpinner; opacity: 0.0 }
         PropertyChanges { target: resultIcon; opacity: 1.0 }

--- a/app/qml/components/BluetoothConnectionDialog.qml
+++ b/app/qml/components/BluetoothConnectionDialog.qml
@@ -102,7 +102,7 @@ Dialog {
       },
       State {
         name: "fail"
-        when: !__positionKit.positionProvider || __positionKit.positionProvider.state === PositionProvider.Unconnected
+        when: !__positionKit.positionProvider || __positionKit.positionProvider.state === PositionProvider.Disconnected
         PropertyChanges { target: resultIcon; source: InputStyle.noIcon }
         PropertyChanges { target: loadingSpinner; opacity: 0.0 }
         PropertyChanges { target: resultIcon; opacity: 1.0 }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -211,9 +211,9 @@ ApplicationWindow {
     }
 
     NotificationBanner {
-      id: notificationBanner
+      id: failedToLoadProjectBanner
 
-      width: parent.width - notificationBanner.anchors.margins * 2
+      width: parent.width - failedToLoadProjectBanner.anchors.margins * 2
       height: InputStyle.rowHeight * 2
 
       onDetailsClicked: {
@@ -227,6 +227,10 @@ ApplicationWindow {
 
       width: parent.width - gpsNotificationBanner.anchors.margins * 2
       height: InputStyle.rowHeight * 2
+
+      text: __positionKit.positionProvider ? __positionKit.positionProvider.stateMessage : ""
+
+      showNotification: __positionKit.positionProvider ? ( __positionKit.positionProvider.state === PositionProvider.WaitingToReconnect ) : false
 
       onDetailsClicked: {
         settingsPanel.open( "gps" )
@@ -500,12 +504,12 @@ ApplicationWindow {
       target: __loader
       onLoadingStarted: {
         projectLoadingScreen.visible = true;
-        notificationBanner.reset();
+        failedToLoadProjectBanner.reset();
         projectIssuesPanel.clear();
       }
       onLoadingFinished: projectLoadingScreen.visible = false
       onLoadingErrorFound: {
-        notificationBanner.pushNotification( "There were issues loading the project." )
+        failedToLoadProjectBanner.pushNotificationMessage( qsTr( "There were issues loading the project." ) )
       }
 
       onReportIssue: projectIssuesPanel.reportIssue( layerName, message )
@@ -514,22 +518,6 @@ ApplicationWindow {
       onProjectReloaded: map.clear()
       onProjectWillBeReloaded: {
         formsStackManager.reload()
-      }
-    }
-
-    Connections {
-      target: __positionKit.positionProvider
-
-      function onLostConnection() {
-        gpsNotificationBanner.pushNotification( qsTr( "Lost connection to GPS receiver." ) )
-      }
-
-      function onProviderConnected() {
-        gpsNotificationBanner.reset()
-      }
-
-      function onProviderConnecting() {
-        gpsNotificationBanner.reset()
       }
     }
 

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -524,9 +524,29 @@ Item {
         id: acctext
 
         text: {
-          if ( Number.isNaN( __positionKit.horizontalAccuracy ) || __positionKit.horizontalAccuracy < 0 )
+          if ( !__positionKit.positionProvider )
           {
-            return qsTr( "unknown accuracy" ) // Replace by "no position" when GPS do not provide position
+            return ""
+          }
+          else if ( __positionKit.positionProvider.type() === "external" )
+          {
+            if ( __positionKit.positionProvider.state === PositionProvider.Connecting )
+            {
+              return qsTr( "connecting to %1" ).arg( __positionKit.positionProvider.name() )
+            }
+            else if ( __positionKit.positionProvider.state === PositionProvider.WaitingToReconnect )
+            {
+              return qsTr( "no position" )
+            }
+          }
+
+          if ( !__positionKit.hasPosition )
+          {
+            return qsTr( "no position" )
+          }
+          else if ( Number.isNaN( __positionKit.horizontalAccuracy ) || __positionKit.horizontalAccuracy < 0 )
+          {
+            return qsTr( "unknown accuracy" )
           }
           return __inputUtils.formatNumber( __positionKit.horizontalAccuracy, _accuracyButton.accuracyPrecision ) + " m"
         }

--- a/app/qml/misc/PositionProviderPage.qml
+++ b/app/qml/misc/PositionProviderPage.qml
@@ -38,14 +38,6 @@ Page {
 
     if ( __appSettings.activePositionProviderId === id )
     {
-      // if provider has error, try to reconnect on click
-      if ( __positionKit.positionProvider.statusLevel === AbstractPositionProvider.Error )
-      {
-        __positionKit.positionProvider.reconnect()
-        dialogLoader.active = true
-        dialogLoader.focus = true
-      }
-
       return // do not construct the same provider again
     }
 
@@ -200,7 +192,7 @@ Page {
             height: parent.height * 0.3
 
             visible: providerDelegate.isActiveProvider
-            text: __positionKit.positionProvider ? __positionKit.positionProvider.statusMessage : ""
+            text: __positionKit.positionProvider ? __positionKit.positionProvider.stateMessage : ""
 
             elide: Text.ElideRight
             color: InputStyle.secondaryFontColor


### PR DESCRIPTION
PR adds option for bluetooth receivers to autoconnect after lost connection.
BT Provider tries to connect to receiver each 10 seconds after connection was lost. 

BT Provider now contains countdown system to keep user informed about next reconnect try.
Accuracy button now shows when app is connecting to GPS.

I have also replaced position provider's status and signals with unified `State`.

https://user-images.githubusercontent.com/22449698/151196887-46cf0aa6-7fa4-45f3-8d03-8b9d31d87dd1.mp4
