### PR TITLE
Do not use bluetooth qt API on iOS platform

### DIFF
--- a/app/android.pri
+++ b/app/android.pri
@@ -77,6 +77,8 @@ android {
     QT += multimedia
     QT += printsupport
     QT += androidextras
+    QT += bluetooth
+    DEFINES += "HAVE_BLUETOOTH"
 
     QMAKE_CXXFLAGS += -std=c++11
 

--- a/app/bluetoothdiscoverymodel.h
+++ b/app/bluetoothdiscoverymodel.h
@@ -13,8 +13,12 @@
 #include <QAbstractListModel>
 #include <QObject>
 #include <qglobal.h>
-#include <QtBluetooth>
 #include <memory>
+
+#ifdef HAVE_BLUETOOTH
+#include <QBluetoothDeviceInfo>
+#include <QBluetoothDeviceDiscoveryAgent>
+#endif
 
 class BluetoothDiscoveryModel : public QAbstractListModel
 {
@@ -43,8 +47,11 @@ class BluetoothDiscoveryModel : public QAbstractListModel
     void setDiscovering( bool discovering );
 
   public slots:
+
+#ifdef HAVE_BLUETOOTH
     void deviceDiscovered( const QBluetoothDeviceInfo &info );
     void deviceUpdated( const QBluetoothDeviceInfo &info, QBluetoothDeviceInfo::Fields updatedFields );
+#endif
     void finishedDiscovery();
 
   signals:
@@ -53,8 +60,10 @@ class BluetoothDiscoveryModel : public QAbstractListModel
   private:
     bool mDiscovering = false;
 
+#ifdef HAVE_BLUETOOTH
     QList<QBluetoothDeviceInfo> mFoundDevices;
-    std::unique_ptr<QBluetoothDeviceDiscoveryAgent> mDiscoveryAgent; // owned
+    std::unique_ptr<QBluetoothDeviceDiscoveryAgent> mDiscoveryAgent;
+#endif
 };
 
 #endif // BLUETOOTHDISCOVERYMODEL_H

--- a/app/input.pro
+++ b/app/input.pro
@@ -10,7 +10,7 @@ isEmpty(QGIS_QUICK_DATA_PATH) {
 }
 
 QT += quick qml xml concurrent positioning sensors quickcontrols2
-QT += network svg sql bluetooth
+QT += network svg sql
 QT += opengl
 QT += core
 

--- a/app/ios/Info.plist
+++ b/app/ios/Info.plist
@@ -38,9 +38,9 @@
 	<string>Program requires access to gallery to attach pictures to features on map</string>
 	<key>NSPhotoLibraryUsageDescription</key>
     <string>Program requires access to gallery to attach pictures to features on map</string>
-    <key>NSBluetoothAlwaysUsageDescription</key>
+    <key>NSBluetoothAlwaysUsageDescription-macos</key>
     <string>Program requires access to bluetooth to connect to external GPS receivers</string>
-    <key>NSBluetoothPeripheralUsageDescription</key>
+    <key>NSBluetoothPeripheralUsageDescription-macos</key>
 	<string>Program requires access to bluetooth to connect to external GPS receivers</string>
 	<key>CFBundleLocalizations</key>
 	<array>

--- a/app/linux.pri
+++ b/app/linux.pri
@@ -74,6 +74,8 @@
     QT += printsupport
     QT += widgets
     QT += multimedia
+    QT += bluetooth
+    DEFINES += "HAVE_BLUETOOTH"
     DEFINES += "HAVE_WIDGETS"
 
     QMAKE_CXXFLAGS += -std=c++11

--- a/app/macx.pri
+++ b/app/macx.pri
@@ -78,6 +78,8 @@ macx:!android {
     QT += printsupport
     QT += widgets
     QT += multimedia
+    QT += bluetooth
+    DEFINES += "HAVE_BLUETOOTH"
     DEFINES += "HAVE_WIDGETS"
 
     QMAKE_CXXFLAGS += -std=c++11 -fvisibility-inlines-hidden -fvisibility=hidden

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -519,6 +519,12 @@ int main( int argc, char *argv[] )
   engine.rootContext()->setContextProperty( "__variablesManager", vm.get() );
   engine.rootContext()->setContextProperty( "__positionKit", &pk );
 
+#ifdef HAVE_BLUETOOTH
+  engine.rootContext()->setContextProperty( "__haveBluetooth", true );
+#else
+  engine.rootContext()->setContextProperty( "__haveBluetooth", false );
+#endif
+
 #ifdef MOBILE_OS
   engine.rootContext()->setContextProperty( "__appwindowvisibility", QWindow::Maximized );
   engine.rootContext()->setContextProperty( "__appwindowwidth", QVariant( 0 ) );

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -93,9 +93,9 @@
 #include "project.h"
 #include "qgsproject.h"
 #include "bluetoothdiscoverymodel.h"
-#include "position/bluetoothpositionprovider.h"
 #include "position/mapposition.h"
 #include "position/positionprovidersmodel.h"
+#include "position/abstractpositionprovider.h"
 
 
 #ifndef NDEBUG

--- a/app/position/internalpositionprovider.cpp
+++ b/app/position/internalpositionprovider.cpp
@@ -28,10 +28,6 @@ InternalPositionProvider::InternalPositionProvider( QObject *parent )
     {
       CoreUtils::log( QStringLiteral( "Internal GPS provider" ), QStringLiteral( "Error occured (position source), code: %1" ).arg( positioningError ) );
     } );
-    connect( mGpsPositionSource.get(), &QGeoPositionInfoSource::updateTimeout, this, [ = ]()
-    {
-      CoreUtils::log( QStringLiteral( "Internal GPS provider" ), QStringLiteral( "Stopped receiving position data" ) );
-    } );
 
     mPositionSourceValid = true;
     setState( tr( "Connected" ), State::Connected );

--- a/app/position/positionkit.cpp
+++ b/app/position/positionkit.cpp
@@ -12,7 +12,10 @@
 
 #include "qgis.h"
 
+#ifndef Q_OS_IOS
 #include "bluetoothpositionprovider.h"
+#endif
+
 #include "internalpositionprovider.h"
 #include "simulatedpositionprovider.h"
 
@@ -78,11 +81,21 @@ void PositionKit::setPositionProvider( AbstractPositionProvider *provider )
 
 AbstractPositionProvider *PositionKit::constructProvider( const QString &type, const QString &id, const QString &name )
 {
+  QString providerType( type );
+
+  // currently the only external provider is bluetooth, so manually set internal provider for platforms that
+  // do not support reading bluetooth serial
+#ifndef HAVE_BLUETOOTH
+  providerType = QStringLiteral( "internal" );
+#endif
+
   if ( type == QStringLiteral( "external" ) )
   {
+#ifdef HAVE_BLUETOOTH
     AbstractPositionProvider *provider = new BluetoothPositionProvider( id, name );
     QQmlEngine::setObjectOwnership( provider, QQmlEngine::CppOwnership );
     return provider;
+#endif
   }
   else // type == internal
   {

--- a/app/qml/misc/PositionProviderPage.qml
+++ b/app/qml/misc/PositionProviderPage.qml
@@ -239,6 +239,9 @@ Page {
       height: InputStyle.rowHeightHeader
       width: ListView.view.width
 
+      // Apple does not support reading Bluetooth serial
+      visible: !__iosUtils.isIos
+
       Components.TextWithIcon {
         width: parent.width
         height: parent.height

--- a/app/qml/misc/PositionProviderPage.qml
+++ b/app/qml/misc/PositionProviderPage.qml
@@ -235,12 +235,25 @@ Page {
       }
     }
 
-    footer: Rectangle {
+    Component.onCompleted: {
+      // select appropriate footer, on iOS say that you can not connect via BT
+      if ( __haveBluetooth )
+      {
+        view.footer = connectNewReceiverButtonComponent
+      }
+      else
+      {
+        view.footer = btNotSupportedComponent
+      }
+    }
+  }
+
+  Component {
+    id: connectNewReceiverButtonComponent
+
+    Rectangle {
       height: InputStyle.rowHeightHeader
       width: ListView.view.width
-
-      // Apple does not support reading Bluetooth serial
-      visible: !__iosUtils.isIos
 
       Components.TextWithIcon {
         width: parent.width
@@ -261,6 +274,42 @@ Page {
           let page = root.stackView.push( bluetoothDiscoveryComponent )
           page.focus = true
         }
+      }
+    }
+  }
+
+  Component {
+    id: btNotSupportedComponent
+
+    Rectangle {
+      height: InputStyle.rowHeightHeader * 5
+      width: ListView.view.width
+
+
+      Text {
+        id: textItem
+
+        anchors.fill: parent
+        anchors.topMargin: InputStyle.panelMargin
+
+        verticalAlignment: Text.AlignTop
+        font.pixelSize: InputStyle.fontPixelSizeNormal
+
+        color: InputStyle.fontColor
+        text: qsTr( "Connecting to receivers via Bluetooth directly in Input is not possible on iOS." +
+                   " Your hardware vendor may provide a custom app that connects to the receiver and sets position." +
+                   " Input will still think it is the internal GPS of your phone/tablet." +
+                   "%1%2Click here to learn more.%3" )
+        .arg( "<br><br>" )
+        .arg( "<a style=\"text-decoration: underline; color:" + InputStyle.fontColor + ";\" href='" + __inputHelp.howToConnectGPSLink + "'>" )
+        .arg( "</a>" )
+
+        wrapMode: Text.Wrap
+        textFormat: Text.RichText
+        leftPadding: InputStyle.panelMargin
+        rightPadding: InputStyle.panelMargin
+
+        onLinkActivated: Qt.openUrlExternally( link )
       }
     }
   }

--- a/app/sources.pri
+++ b/app/sources.pri
@@ -9,7 +9,6 @@ attributes/attributetabproxymodel.cpp \
 attributes/rememberattributescontroller.cpp \
 attributes/fieldvalidator.cpp \
 position/abstractpositionprovider.cpp \
-position/bluetoothpositionprovider.cpp \
 position/internalpositionprovider.cpp \
 position/mapposition.cpp \
 position/positiondirection.cpp \
@@ -60,7 +59,6 @@ attributes/attributetabproxymodel.h \
 attributes/rememberattributescontroller.h \
 attributes/fieldvalidator.h \
 position/abstractpositionprovider.h \
-position/bluetoothpositionprovider.h \
 position/internalpositionprovider.h \
 position/mapposition.h \
 position/positiondirection.h \
@@ -98,6 +96,13 @@ featuresmodel.h \
 relationfeaturesmodel.h \
 relationreferencefeaturesmodel.h \
 valuerelationfeaturesmodel.h
+
+contains(DEFINES, HAVE_BLUETOOTH) {
+  message("Building with bluetooth position provider")
+
+  SOURCES += position/bluetoothpositionprovider.cpp
+  HEADERS += position/bluetoothpositionprovider.h
+}
 
 contains(DEFINES, INPUT_TEST) {
 


### PR DESCRIPTION
As iOS does not allow us to read serial from bluetooth device, this PR removes all connections to bluetooth API for ios build.

There is a new define "HAVE_BLUETOOTH" that is used on max/android/linux.