### PR TITLE
Fix building with qgis built on proj 8

### DIFF
--- a/app/inputprojutils.cpp
+++ b/app/inputprojutils.cpp
@@ -13,9 +13,9 @@
 #include <QDir>
 #include <QFileInfo>
 
+#include "proj.h"
 #include "inpututils.h"
 #include "coreutils.h"
-#include "proj.h"
 #include "qgsprojutils.h"
 #include "inputhelp.h"
 


### PR DESCRIPTION
This is still a workaround, just a subtle one.
I think the real issue is in qgis, where `PROJ_VERSION_MAJOR` is used in https://github.com/qgis/QGIS/blob/31ac4082f849c14e0aa6c6c16ca93e63c59756c0/src/core/proj/qgsprojutils.h#L215 and https://github.com/qgis/QGIS/blob/31ac4082f849c14e0aa6c6c16ca93e63c59756c0/src/core/proj/qgscoordinatereferencesystem.h#L51 without importing `proj.h` that defines it.