### PR TITLE
Update connection dialog after reconnect 

### DIFF
--- a/app/position/bluetoothpositionprovider.cpp
+++ b/app/position/bluetoothpositionprovider.cpp
@@ -109,7 +109,7 @@ void BluetoothPositionProvider::reconnectTimeout()
   else
   {
     mSecondsLeftToReconnect--;
-    setState( tr( "Lost connection, reconnecting in (%1)" ).arg( mSecondsLeftToReconnect ), State::WaitingToReconnect );
+    setState( tr( "No connection, reconnecting in (%1)" ).arg( mSecondsLeftToReconnect ), State::WaitingToReconnect );
     mReconnectTimer.start();
   }
 }
@@ -125,7 +125,7 @@ void BluetoothPositionProvider::handleLostConnection()
   else if ( mState != WaitingToReconnect && mState != Connecting )
   {
     mSecondsLeftToReconnect = mReconnectDelay / 1000;
-    setState( tr( "Lost connection, reconnecting in (%1)" ).arg( mSecondsLeftToReconnect ), State::WaitingToReconnect );
+    setState( tr( "No connection, reconnecting in (%1)" ).arg( mSecondsLeftToReconnect ), State::WaitingToReconnect );
 
     mReconnectTimer.start();
 
@@ -161,7 +161,7 @@ void BluetoothPositionProvider::positionUpdateReceived()
 {
   if ( mSocket->state() != QBluetoothSocket::UnconnectedState )
   {
-    // if by any chance we showed wrong message in the status like "lost connection", fix it here
+    // if by any chance we showed wrong message in the status like "no connection", fix it here
     // we know the connection is working because we just received data from the device
     setState( tr( "Connected" ), State::Connected );
 


### PR DESCRIPTION
As we added auto-reconnect  for bluetooth position provider, connection dialog window was jumping between states of "connecting" and "failed" and was very misleading.

I added another state "waitingToReconnect". It will be visible when you are connecting to **unreachable, but paired** device.

https://user-images.githubusercontent.com/22449698/151543470-0e1c25d0-4130-4dd6-abf3-45f4cfa50957.mp4


