### PR TITLE
Invalidate position fix

### DIFF
--- a/app/position/bluetoothpositionprovider.cpp
+++ b/app/position/bluetoothpositionprovider.cpp
@@ -18,7 +18,6 @@ NmeaParser::NmeaParser() : QgsNmeaConnection( new QBluetoothSocket() )
 
 QgsGpsInformation NmeaParser::parseNmeaString( const QString &nmeastring )
 {
-  mLastGPSInformation = QgsGpsInformation();
   mStringBuffer = nmeastring;
   processStringBuffer();
   return mLastGPSInformation;
@@ -135,6 +134,9 @@ void BluetoothPositionProvider::handleLostConnection()
       mReconnectDelay = BluetoothPositionProvider::LongDelay;
     }
   }
+
+  // let's also invalidate current position since we no longer have connection
+  emit positionChanged( GeoPosition() );
 }
 
 void BluetoothPositionProvider::socketStateChanged( QBluetoothSocket::SocketState state )


### PR DESCRIPTION
We need to invalidate position when user looses connection to its GPS. Previous fix did not work, we now invalidate it when he/she really loses the connection (in error handler).