### PR TITLE
Add new permission for Android sensors

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,7 +26,7 @@ jobs:
       ANDROIDAPI: 24
       ANDROID_NDK_PLATFORM: android-24
       NDK_VERSION: r21
-      SDK_PLATFORM: android-30
+      SDK_PLATFORM: android-31
       SDK_BUILD_TOOLS: 28.0.3
       INPUT_SDK_VERSION: android-macOS-20211210-41
       CCACHE_DIR: /Users/runner/work/ccache

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -114,14 +114,14 @@ jobs:
         uses: pat-s/always-upload-cache@v2.1.5
         with:
           path: ${{ github.workspace }}/input-sdk
-          key: ${{ runner.os }}-input-sdk-v1-${{ env.INPUT_SDK_VERSION }}-${{ env.CACHE_VERSION }}
+          key: ${{ runner.os }}-input-sdk-v1-${{ env.INPUT_SDK_VERSION }}-${{ env.CACHE_VERSION }}-android-12
 
       - name: Install Input-SDK
         if: steps.cache-input-sdk.outputs.cache-hit != 'true'
         run: |
           wget -O \
             input-sdk.tar.gz \
-            https://github.com/lutraconsulting/input-sdk/releases/download/${{ env.INPUT_SDK_VERSION }}/input-sdk-qt-${{ env.QT_VERSION }}-${{ env.INPUT_SDK_VERSION }}.tar.gz
+            https://github.com/lutraconsulting/input-sdk/suites/5150833911/artifacts/155692535
           mkdir -p ${{ github.workspace }}/input-sdk
           cd ${{ github.workspace }}/input-sdk
           tar -xvzf ${{ github.workspace }}/input-sdk.tar.gz

--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -81,7 +81,7 @@
         </provider>
 
     </application>
-    <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="30"/>
+    <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="31"/>
     <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.

--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -110,6 +110,9 @@
     <!-- Camera permissions -->
     <uses-permission android:name="android.permission.CAMERA"/>
 
+    <!-- We are reading sensors that from API 31 needs additional permission -->
+    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
+
     <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
          Remove the comment if you do not require these default features. -->
     <!-- %%INSERT_FEATURES -->


### PR DESCRIPTION
Android introduced new permission for sensors that we use during camera capture. Since we did not declare them, camera activity failed with white screen.

Should fix #1904 - @saberraz can you please confirm that?