### PR TITLE
Stake out - short mode

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ env:
   CCACHE_DIR: ~/.ccache
   INPUT_SDK_VERSION: ubuntu-2004-20211201-34
   QT_VERSION: '5.14.2'
-  CACHE_VERSION: 0
+  CACHE_VERSION: 1
 
 concurrency:
   group: ci-${{github.ref}}-linux

--- a/app/compass.cpp
+++ b/app/compass.cpp
@@ -23,7 +23,7 @@ Compass::Compass( QObject *parent ) : QObject( parent )
 qreal Compass::direction() const
 {
   qreal newDirection = MIN_INVALID_DIRECTION;
-  if ( mCompass->reading() )
+  if ( mCompass && mCompass->reading() )
   {
     newDirection = mCompass->reading()->azimuth() + mCompass->userOrientation();
   }
@@ -33,7 +33,11 @@ qreal Compass::direction() const
 
 QCompassReading *Compass::reading()
 {
-  return mCompass->reading();
+  if ( mCompass )
+  {
+    return mCompass->reading();
+  }
+  return nullptr;
 }
 
 void Compass::setUserOrientation()

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1390,8 +1390,9 @@ qreal InputUtils::distanceToFeature( QgsPoint gpsPosition, const FeatureLayerPai
 
   QgsDistanceArea distanceArea;
   distanceArea.setSourceCrs( mapSettings->destinationCrs(), mapSettings->transformContext() );
-
-  return distanceArea.measureLine( gpsPosition, targetPoint );
+  qreal distance = distanceArea.measureLine( gpsPosition, targetPoint );
+  distance = distanceArea.convertLengthMeasurement( distance, QgsUnitTypes::DistanceMeters );
+  return distance;
 }
 
 qreal InputUtils::bearingToFeature( QgsPoint gpsPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings )
@@ -1440,7 +1441,6 @@ qreal InputUtils::bearingToFeature( QgsPoint gpsPosition, const FeatureLayerPair
   QgsDistanceArea distanceArea;
   distanceArea.setSourceCrs( mapSettings->destinationCrs(), mapSettings->transformContext() );
 
-//  return distanceArea.measureLine( gpsPosition, targetPoint );
   return distanceArea.bearing( gpsPosition, targetPoint );
 }
 

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -674,6 +674,36 @@ double InputUtils::screenUnitsToMeters( QgsQuickMapSettings *mapSettings, int ba
   return mDistanceArea.measureLine( p1, p2 );
 }
 
+QgsPoint InputUtils::mapPointToGps( QPointF mapPosition, QgsQuickMapSettings *mapSettings )
+{
+  if ( !mapSettings )
+    return QgsPoint();
+
+  if ( mapPosition.isNull() )
+    return QgsPoint();
+
+  QgsPoint positionMapCrs = mapSettings->screenToCoordinate( mapPosition );
+
+  // convert it to GPS crs (EPSG:4326)
+  QgsCoordinateReferenceSystem c4326 = coordinateReferenceSystemFromEpsgId( 4326 );
+
+  try
+  {
+    QgsCoordinateTransform ct( mapSettings->destinationCrs(), c4326, QgsCoordinateTransformContext() );
+    if ( ct.isValid() )
+    {
+      const QgsPointXY pt = ct.transform( positionMapCrs );
+      return QgsPoint( pt.x(), pt.y() );
+    }
+  }
+  catch ( QgsCsException &cse )
+  {
+    Q_UNUSED( cse )
+  }
+
+  return QgsPoint();
+}
+
 bool InputUtils::fileExists( const QString &path )
 {
   QFileInfo check_file( path );

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -178,7 +178,8 @@ class InputUtils: public QObject
     Q_INVOKABLE static QgsPoint coordinateToPoint( const QGeoCoordinate &coor );
 
     /**
-      * Transforms point between different crs from QML
+      * Transforms point between different crs
+      * Return empty QgsPointXY if the transformation could not be applied or srcPoint is empty
       */
     Q_INVOKABLE static QgsPointXY transformPoint( const QgsCoordinateReferenceSystem &srcCrs,
         const QgsCoordinateReferenceSystem &destCrs,

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -189,6 +189,8 @@ class InputUtils: public QObject
       * Calculates the distance in meter representing baseLengthPixels pixels on the screen based on the current map settings.
       */
     Q_INVOKABLE static double screenUnitsToMeters( QgsQuickMapSettings *mapSettings, int baseLengthPixels );
+
+    Q_INVOKABLE static QgsPoint mapPointToGps( QPointF mapPosition, QgsQuickMapSettings *mapSettings );
 
     /**
       * Returns whether file on path exists

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -190,6 +190,7 @@ class InputUtils: public QObject
       */
     Q_INVOKABLE static double screenUnitsToMeters( QgsQuickMapSettings *mapSettings, int baseLengthPixels );
 
+    // Converts map coordinate in map's X/Y to GPS coordinate
     Q_INVOKABLE static QgsPoint mapPointToGps( QPointF mapPosition, QgsQuickMapSettings *mapSettings );
 
     /**
@@ -413,10 +414,10 @@ class InputUtils: public QObject
     Q_INVOKABLE QgsRectangle navigationFeatureExtent( const FeatureLayerPair &pair, QgsPoint gpsPosition, QgsQuickMapSettings *mapSettings, double panelOffsetRatio );
 
     // Returns the distance from \a gpsPos to the feature \a pair
-    Q_INVOKABLE qreal distanceToFeature( QgsPoint gpsPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings );
+    Q_INVOKABLE qreal distanceBetweenGpsAndFeature( QgsPoint gpsPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings );
 
-    // Returns a bearing between point a and b
-    Q_INVOKABLE qreal bearingToFeature( QgsPoint a, const FeatureLayerPair &b, QgsQuickMapSettings *mapSettings );
+    // Returns an angle between current gps position and feature
+    Q_INVOKABLE qreal angleBetweenGpsAndFeature( QgsPoint gpsPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings );
 
     // Returns the title of the feature
     Q_INVOKABLE static QString featureTitle( const FeatureLayerPair &pair, QgsProject *project );

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -413,7 +413,10 @@ class InputUtils: public QObject
     Q_INVOKABLE QgsRectangle navigationFeatureExtent( const FeatureLayerPair &pair, QgsPoint gpsPosition, QgsQuickMapSettings *mapSettings, double panelOffsetRatio );
 
     // Returns the distance from \a gpsPos to the feature \a pair
-    Q_INVOKABLE QString distanceToFeature( QgsPoint gpsPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings );
+    Q_INVOKABLE qreal distanceToFeature( QgsPoint gpsPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings );
+
+    // Returns a bearing between point a and b
+    Q_INVOKABLE qreal bearingToFeature( QgsPoint a, const FeatureLayerPair &b, QgsQuickMapSettings *mapSettings );
 
     // Returns the title of the feature
     Q_INVOKABLE static QString featureTitle( const FeatureLayerPair &pair, QgsProject *project );

--- a/app/position/abstractpositionprovider.cpp
+++ b/app/position/abstractpositionprovider.cpp
@@ -20,6 +20,10 @@ AbstractPositionProvider::AbstractPositionProvider( const QString &id, const QSt
 
 AbstractPositionProvider::~AbstractPositionProvider() = default;
 
+void AbstractPositionProvider::setPosition( QgsPoint )
+{
+}
+
 QString AbstractPositionProvider::name() const
 {
   return mProviderName;

--- a/app/position/abstractpositionprovider.h
+++ b/app/position/abstractpositionprovider.h
@@ -11,6 +11,7 @@
 #define ABSTRACTPOSITIONPROVIDER_H
 
 #include "qgsgpsconnection.h"
+#include "qgspoint.h"
 
 #include "qobject.h"
 
@@ -60,6 +61,8 @@ class AbstractPositionProvider : public QObject
     virtual void startUpdates() = 0;
     virtual void stopUpdates() = 0;
     virtual void closeProvider() = 0;
+
+    virtual void setPosition( QgsPoint position );
 
     QString stateMessage() const;
     State state() const;

--- a/app/position/mapposition.cpp
+++ b/app/position/mapposition.cpp
@@ -110,9 +110,11 @@ void MapPosition::recalculateMapPosition()
                                    mMapSettings->transformContext(),
                                    srcPoint
                                  );
-
-      newMapPosition = QgsPoint( mapPositionXY );
-      newMapPosition.addZValue( geoposition.z() );
+      if ( !mapPositionXY.isEmpty() )
+      {
+        newMapPosition = QgsPoint( mapPositionXY );
+        newMapPosition.addZValue( geoposition.z() );
+      }
     }
   }
 

--- a/app/position/positiondirection.cpp
+++ b/app/position/positiondirection.cpp
@@ -35,7 +35,7 @@ void PositionDirection::updateDirection()
   {
     newDirection = mPositionKit->direction();
   }
-  else if ( mCompass->reading() )
+  else if ( mCompass && mCompass->reading() )
   {
     newDirection = mCompass->direction();
   }

--- a/app/position/simulatedpositionprovider.cpp
+++ b/app/position/simulatedpositionprovider.cpp
@@ -8,6 +8,7 @@
  ***************************************************************************/
 
 #include "simulatedpositionprovider.h"
+#include "qgspoint.h"
 
 SimulatedPositionProvider::SimulatedPositionProvider( double longitude, double latitude, double flightRadius, double timerTimeout, QObject *parent )
   : AbstractPositionProvider( QStringLiteral( "simulated" ), QStringLiteral( "internal" ), QStringLiteral( "Simulated provider" ), parent )
@@ -41,6 +42,17 @@ void SimulatedPositionProvider::stopUpdates()
 void SimulatedPositionProvider::closeProvider()
 {
   mTimer->stop();
+}
+
+void SimulatedPositionProvider::setPosition( QgsPoint position )
+{
+  if ( position.isEmpty() )
+    return;
+
+  stopUpdates();
+  mLatitude = position.y();
+  mLongitude = position.x();
+  generateConstantPosition();
 }
 
 void SimulatedPositionProvider::generateNextPosition()
@@ -99,7 +111,7 @@ void SimulatedPositionProvider::generateConstantPosition()
   position.elevation = 20;
   position.utcDateTime = QDateTime::currentDateTime();
   position.direction = 0;
-  position.hacc = 20;
+  position.hacc = ( *mGenerator )() % 20;
   position.satellitesUsed = ( *mGenerator )() % 30;
   position.satellitesVisible = ( *mGenerator )() % 30;
   position.speed = 0;

--- a/app/position/simulatedpositionprovider.cpp
+++ b/app/position/simulatedpositionprovider.cpp
@@ -110,7 +110,7 @@ void SimulatedPositionProvider::generateConstantPosition()
   position.longitude = mLongitude;
   position.elevation = 20;
   position.utcDateTime = QDateTime::currentDateTime();
-  position.direction = 360 - int( mAngle ) % 360;;
+  position.direction = 360 - int( mAngle ) % 360;
   position.hacc = ( *mGenerator )() % 20;
   position.satellitesUsed = ( *mGenerator )() % 30;
   position.satellitesVisible = ( *mGenerator )() % 30;

--- a/app/position/simulatedpositionprovider.cpp
+++ b/app/position/simulatedpositionprovider.cpp
@@ -110,11 +110,11 @@ void SimulatedPositionProvider::generateConstantPosition()
   position.longitude = mLongitude;
   position.elevation = 20;
   position.utcDateTime = QDateTime::currentDateTime();
-  position.direction = 0;
+  position.direction = 360 - int( mAngle ) % 360;;
   position.hacc = ( *mGenerator )() % 20;
   position.satellitesUsed = ( *mGenerator )() % 30;
   position.satellitesVisible = ( *mGenerator )() % 30;
-  position.speed = 0;
+  position.speed = ( *mGenerator )() % 50 - ( ( ( *mGenerator )() % 10 ) / 10. );
 
   emit positionChanged( position );
 }

--- a/app/position/simulatedpositionprovider.h
+++ b/app/position/simulatedpositionprovider.h
@@ -46,6 +46,8 @@ class SimulatedPositionProvider : public AbstractPositionProvider
     virtual void stopUpdates() override;
     virtual void closeProvider() override;
 
+    virtual void setPosition( QgsPoint position ) override;
+
     void generateNextPosition();
 
   private:

--- a/app/position/simulatedpositionprovider.h
+++ b/app/position/simulatedpositionprovider.h
@@ -33,9 +33,9 @@ class SimulatedPositionProvider : public AbstractPositionProvider
      *  Set flightRadius to 0 in order to get constant position (no movement)
      */
     explicit SimulatedPositionProvider(
-      double longitude = 17.130,
-      double latitude = 48.130,
-      double flightRadius = 0.1,
+      double longitude = 17.107137342092614,
+      double latitude = 48.10301740375036,
+      double flightRadius = 0,
       double updateTimeout = 1000,
       QObject *parent = nullptr
     );

--- a/app/qml/NavigationPanel.qml
+++ b/app/qml/NavigationPanel.qml
@@ -171,7 +171,7 @@ Item {
 
         Text {
           Layout.preferredHeight: parent.height
-          Layout.preferredWidth: parent.width - closebtn.width
+          Layout.fillWidth: true
 
           text: qsTr( "Stake out" )
 
@@ -184,7 +184,25 @@ Item {
           verticalAlignment: Text.AlignVCenter
         }
 
-        // TODO: add center to extent icon! onClicked: autoFollow = true;
+        Item {
+          id: recenterbtn
+
+          Layout.preferredHeight: parent.height
+          Layout.preferredWidth: parent.height
+
+          visible: root.autoFollow === false
+
+          Components.Symbol {
+            source: InputStyle.zoomToProjectIcon
+            iconSize: parent.height / 2
+            anchors.centerIn: parent
+          }
+
+          MouseArea {
+            anchors.fill: parent
+            onClicked: root.autoFollow = true
+          }
+        }
 
         Item {
           id: closebtn

--- a/app/qml/NavigationPanel.qml
+++ b/app/qml/NavigationPanel.qml
@@ -35,6 +35,7 @@ Item {
 
     property string mapStateBeforeNavigation
 
+    signal navigationEnded()
 
     function startNavigation() {
       mapStateBeforeNavigation = _map.state
@@ -51,6 +52,7 @@ Item {
       autoFollow = false
       _map.state = mapStateBeforeNavigation;
       drawer.close()
+      navigationEnded()
     }
 
     function updateNavigation() {

--- a/app/qml/NavigationPanel.qml
+++ b/app/qml/NavigationPanel.qml
@@ -75,15 +75,6 @@ Item {
       mapCanvas.mapSettings.extent = calculatedNavigationExtent;
 
     root.featureToGpsDistance = __inputUtils.distanceToFeature( __positionKit.positionCoordinate, root.navigationTargetFeature, root.mapCanvas.mapSettings );
-
-    if ( root.featureToGpsDistance < root.distanceThresholdToFinishNavigation )
-    {
-      navigationComponent.state = "atTarget"
-    }
-    else
-    {
-      navigationComponent.state = "notAtTarget"
-    }
   }
 
   onAutoFollowChanged: updateNavigation()
@@ -263,17 +254,17 @@ Item {
           states: [
             State {
               name: "atTarget"
+              when: root.featureToGpsDistance < root.distanceThresholdToFinishNavigation
             },
             State {
               name: "notAtTarget"
+              when: state != "atTarget"
             }
           ]
 
           state: "notAtTarget"
 
           visible: root.state === "short"
-
-          onStateChanged: console.log( "state:", state )
 
           // enable antialiasing
           layer.enabled: true
@@ -291,6 +282,8 @@ Item {
               strokeColor: navigationComponent.state === "notAtTarget" ? InputStyle.panelBackgroundDarker : InputStyle.fontColorBright
               fillColor: navigationComponent.state === "notAtTarget" ? "transparent" : InputStyle.fontColorBright
 
+              strokeWidth: 5 * __dp
+
               PathAngleArc {
                 id: innerArc
 
@@ -306,8 +299,10 @@ Item {
             }
 
             ShapePath {
-              strokeColor: InputStyle.panelBackgroundDarker
-              fillColor: navigationComponent.state === "notAtTarget" ? "transparent" : InputStyle.fontColorBright
+              strokeColor: navigationComponent.state === "notAtTarget" ? InputStyle.panelBackgroundDarker : InputStyle.fontColorBright
+              fillColor: "transparent"
+
+              strokeWidth: 3 * __dp
 
               PathAngleArc {
                 id: outerArc
@@ -324,6 +319,35 @@ Item {
             }
           }
 
+          // Target X icon
+          Components.Symbol {
+            source: InputStyle.noIcon
+            iconColor: navigationComponent.state === "notAtTarget" ? InputStyle.panelBackgroundDarker : InputStyle.fontColorBright
+            iconSize: rootShape.height / 12
+            x: rootShape.centerX - width / 2
+            y: rootShape.centerY - height / 2
+          }
+
+          // Legends (1m, 0.5m)
+          Components.InputText {
+            text: qsTr("1 m")
+
+            color: navigationComponent.state === "notAtTarget" ? InputStyle.panelBackgroundDarker : InputStyle.fontColorBright
+
+            x: rootShape.centerX + outerArc.radiusX + InputStyle.tinyGap
+            y: rootShape.centerY
+          }
+
+          Components.InputText {
+            text: qsTr("0.5 m")
+
+            color: navigationComponent.state === "notAtTarget" ? InputStyle.panelBackgroundDarker : InputStyle.fontColorBright
+
+            x: rootShape.centerX + innerArc.radiusX + InputStyle.tinyGap
+            y: rootShape.centerY
+          }
+
+          // Position indicator with direction
           Item {
             id: positionMarker
 

--- a/app/qml/NavigationPanel.qml
+++ b/app/qml/NavigationPanel.qml
@@ -296,10 +296,10 @@ Item {
             anchors.fill: parent
 
             ShapePath {
-              strokeColor: navigationComponent.state === "notAtTarget" ? InputStyle.panelBackgroundDarker : InputStyle.fontColorBright
-              fillColor: navigationComponent.state === "notAtTarget" ? "transparent" : InputStyle.fontColorBright
+              strokeColor: navigationComponent.state === "notAtTarget" ? InputStyle.labelColor : InputStyle.fontColorBright
+              fillColor: navigationComponent.state === "notAtTarget" ? "white" : InputStyle.fontColorBright
 
-              strokeWidth: 5 * __dp
+              strokeWidth: 2 * __dp
 
               PathAngleArc {
                 id: innerArc
@@ -316,10 +316,10 @@ Item {
             }
 
             ShapePath {
-              strokeColor: navigationComponent.state === "notAtTarget" ? InputStyle.panelBackgroundDarker : InputStyle.fontColorBright
+              strokeColor: navigationComponent.state === "notAtTarget" ? InputStyle.labelColor : InputStyle.fontColorBright
               fillColor: "transparent"
 
-              strokeWidth: 3 * __dp
+              strokeWidth: 2 * __dp
 
               PathAngleArc {
                 id: outerArc
@@ -343,25 +343,6 @@ Item {
             iconSize: rootShape.height / 12
             x: rootShape.centerX - width / 2
             y: rootShape.centerY - height / 2
-          }
-
-          // Legends (1m, 0.5m)
-          Components.InputText {
-            text: qsTr("1 m")
-
-            color: navigationComponent.state === "notAtTarget" ? InputStyle.panelBackgroundDarker : InputStyle.fontColorBright
-
-            x: rootShape.centerX + outerArc.radiusX + InputStyle.tinyGap
-            y: rootShape.centerY
-          }
-
-          Components.InputText {
-            text: qsTr("0.5 m")
-
-            color: navigationComponent.state === "notAtTarget" ? InputStyle.panelBackgroundDarker : InputStyle.fontColorBright
-
-            x: rootShape.centerX + innerArc.radiusX + InputStyle.tinyGap
-            y: rootShape.centerY
           }
 
           // Position indicator with direction

--- a/app/qml/NavigationPanel.qml
+++ b/app/qml/NavigationPanel.qml
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -11,224 +11,308 @@ import QtQuick 2.14
 import QtQuick.Layouts 1.14
 import QtQuick.Controls 2.14
 import QtGraphicalEffects 1.0
+import QtQuick.Shapes 1.14
 
 import "."  // import InputStyle singleton
+import "./components" as Components
 
 Item {
-    id: navigationPanel
-    property real rowHeight: InputStyle.rowHeight
+  id: root
 
-    property var navigationTargetFeature
+  readonly property alias isOpen: drawer.opened
 
-    property string featureTitle
-    property string featureToGpsDistance: "0"
+  property real featureToGpsDistance: -1
+  property var navigationTargetFeature
 
-    property real previewHeight
+  property var mapCanvas
 
-    readonly property alias isOpen: drawer.opened
+  property bool autoFollow: true
+  property var calculatedNavigationExtent
+  property string mapStateBeforeNavigation
 
-    property var _map
+  property real distanceThresholdToShortMode: 1 // in metres
+  property real distanceThresholdToFinishNavigation: 0.1 // in metres
 
-    property bool autoFollow: true
-    property var calculatedNavigationExtent
-    property real previewPanelHeight
+  signal navigationEnded()
 
-    property string mapStateBeforeNavigation
+  function startNavigation() {
+    mapStateBeforeNavigation = mapCanvas.state
+    mapCanvas.state = "navigation"
+    drawer.open()
+  }
 
-    signal navigationEnded()
+  function endNavigation() {
+    if ( mapCanvas.state !== "navigation" )
+      return;
 
-    function startNavigation() {
-      mapStateBeforeNavigation = _map.state
-      _map.state = "navigation"
-      drawer.open()
-    }
+    autoFollow = true
+    updateNavigation()
+    autoFollow = false
+    mapCanvas.state = mapStateBeforeNavigation;
+    drawer.close()
+    navigationEnded()
+  }
 
-    function endNavigation() {
-      if ( _map.state !== "navigation" )
-        return;
+  function updateNavigation() {
+    if ( mapCanvas.state !== "navigation" )
+      return;
 
-      autoFollow = true
-      updateNavigation()
-      autoFollow = false
-      _map.state = mapStateBeforeNavigation;
-      drawer.close()
-      navigationEnded()
-    }
+    mapCanvas.navigationHighlightFeature = navigationTargetFeature
+    mapCanvas.navigationHighlightGpsPosition = __positionKit.positionCoordinate
 
-    function updateNavigation() {
-      if ( _map.state !== "navigation" )
-        return;
+    var previewPanelHeightRatio = drawer.height / mapCanvas.height;
+    calculatedNavigationExtent =  __inputUtils.navigationFeatureExtent(
+          mapCanvas.navigationHighlightFeature,
+          __positionKit.positionCoordinate,
+          mapCanvas.mapSettings,
+          previewPanelHeightRatio
+          );
 
-      _map.navigationHighlightFeature = navigationTargetFeature
-      _map.navigationHighlightGpsPosition = __positionKit.positionCoordinate
+    if ( autoFollow )
+      mapCanvas.mapSettings.extent = calculatedNavigationExtent;
 
-      var previewPanelHeightRatio = previewPanelHeight / _map.height;
-      calculatedNavigationExtent =  __inputUtils.navigationFeatureExtent( _map.navigationHighlightFeature, __positionKit.positionCoordinate, _map.mapSettings, previewPanelHeightRatio );
+    root.featureToGpsDistance = __inputUtils.distanceToFeature( __positionKit.positionCoordinate, root.navigationTargetFeature, root.mapCanvas.mapSettings );
+  }
 
-      if ( autoFollow )
-        _map.mapSettings.extent = calculatedNavigationExtent;
+  onAutoFollowChanged: updateNavigation()
 
-      navigationPanel.featureToGpsDistance = __inputUtils.distanceToFeature( __positionKit.positionCoordinate, navigationTargetFeature, _map.mapSettings );
-    }
+  onNavigationTargetFeatureChanged: {
+    mapCanvas.navigationHighlightFeature = navigationTargetFeature
+    autoFollow = true;
+    updateNavigation()
+  }
 
-    onAutoFollowChanged: {
-      updateNavigation()
-    }
-
-    onNavigationTargetFeatureChanged: {
-      navigationPanel.featureTitle = __inputUtils.featureTitle( navigationTargetFeature, __loader.project )
-      _map.navigationHighlightFeature = navigationTargetFeature
-      autoFollow = true;
-      updateNavigation()
-    }
-
-    Connections {
-      target: _map.mapSettings
-      onExtentChanged: {
-        if ( _map.state === "navigation" && _map.mapSettings.extent !== calculatedNavigationExtent )
-          autoFollow = false;
+  states: [
+    State {
+      name: "long"
+      when: featureToGpsDistance >= distanceThresholdToShortMode
+      PropertyChanges {
+        target: drawer
+        height: root.height / 6
+      }
+    },
+    State {
+      name: "short"
+      when: featureToGpsDistance >= 0 && featureToGpsDistance < distanceThresholdToShortMode
+      PropertyChanges {
+        target: drawer
+        height: root.height / 2
       }
     }
+  ]
 
-    Connections {
-        target: __positionKit
-        onPositionChanged: {
-          if ( _map.state === "navigation" && navigationTargetFeature )
-            updateNavigation();
+  Connections {
+    target: mapCanvas.mapSettings
+    onExtentChanged: {
+      if ( mapCanvas.state === "navigation" && mapCanvas.mapSettings.extent !== calculatedNavigationExtent )
+        autoFollow = false;
+    }
+  }
+
+  Connections {
+    target: __positionKit
+    onPositionChanged: {
+      if ( mapCanvas.state === "navigation" && navigationTargetFeature )
+        updateNavigation();
+    }
+  }
+
+  onStateChanged: updateNavigation()
+
+  Keys.onReleased: {
+    if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+      event.accepted = true;
+      endNavigation()
+    }
+  }
+
+  focus: true
+
+  Drawer {
+    id: drawer
+
+    onClosed: endNavigation()
+
+    Behavior on height {
+      PropertyAnimation { properties: "height"; easing.type: Easing.InOutQuad }
+    }
+
+    width: parent.width
+
+    modal: false
+    edge: Qt.BottomEdge
+
+    dragMargin: 0 // prevents opening the drawer by dragging.
+    closePolicy: Popup.CloseOnEscape // prevents the drawer closing while moving canvas
+
+    Rectangle {
+      anchors.fill: parent
+      color: InputStyle.clrPanelMain
+    }
+
+    Column {
+      id: body
+
+      anchors {
+        fill: parent
+        leftMargin: InputStyle.panelMargin
+        rightMargin: InputStyle.panelMargin
+      }
+
+      // Header - always there
+      RowLayout {
+        id: header
+
+        width: parent.width
+        height: InputStyle.rowHeight
+
+        Text {
+          Layout.preferredHeight: parent.height
+          Layout.preferredWidth: parent.width - closebtn.width
+
+          text: qsTr( "Stake out" )
+
+          font.pixelSize: InputStyle.fontPixelSizeBig
+
+          font.bold: true
+          elide: Qt.ElideRight
+          color: InputStyle.fontColor
+          horizontalAlignment: Text.AlignLeft
+          verticalAlignment: Text.AlignVCenter
         }
-    }
 
-    Drawer {
-      id: drawer
+        // TODO: add center to extent icon!
+        // TODO:   onClicked: autoFollow = true;
 
-      onClosed: endNavigation()
+        Item {
+          id: closebtn
 
-      Behavior on height {
-        PropertyAnimation { properties: "height"; easing.type: Easing.InOutQuad }
-      }
+          Layout.preferredHeight: parent.height
+          Layout.preferredWidth: parent.height
 
-      width: parent.width
-      height: navigationPanel.previewHeight
-      z: 0
-      modal: false
-      dragMargin: 0 // prevents opening the drawer by dragging.
-      edge: Qt.BottomEdge
-      closePolicy: Popup.CloseOnEscape // prevents the drawer closing while moving canvas
-
-      Rectangle {
-          anchors.fill: parent
-          color: InputStyle.clrPanelMain
-
-          Rectangle {
-              anchors.fill: parent
-              anchors.margins: InputStyle.panelMargin
-              anchors.topMargin: 0
-
-              Item {
-                  id: header
-                  width: parent.width
-                  height: navigationPanel.rowHeight
-                  Row {
-                    id: title
-                    height: rowHeight
-                    width: parent.width
-
-                    Text {
-                        id: titleText
-                        height: rowHeight
-                        width: parent.width - recenterIconContainer.width - iconContainer.width
-                        text: featureTitle
-                        font.pixelSize: InputStyle.fontPixelSizeBig
-                        color: InputStyle.fontColor
-                        font.bold: true
-                        horizontalAlignment: Text.AlignLeft
-                        verticalAlignment: Text.AlignVCenter
-                        elide: Qt.ElideRight
-                    }
-
-                    Item {
-                        id: recenterIconContainer
-                        height: rowHeight
-                        width: rowHeight
-
-                        MouseArea {
-                            id: recenterIconArea
-                            anchors.fill: recenterIconContainer
-                            onClicked: autoFollow = true;
-                        }
-
-                        Image {
-                            id: recenterIcon
-                            anchors.fill: parent
-                            anchors.margins: rowHeight/4
-                            anchors.rightMargin: 0
-                            source: InputStyle.zoomToProjectIcon
-                            sourceSize.width: width
-                            sourceSize.height: height
-                            fillMode: Image.PreserveAspectFit
-                        }
-
-                        ColorOverlay {
-                            anchors.fill: recenterIcon
-                            source: recenterIcon
-                            color: InputStyle.fontColor
-                        }
-                    }
-
-                    Item {
-                        id: iconContainer
-                        height: rowHeight
-                        width: rowHeight
-
-                        MouseArea {
-                            id: editArea
-                            anchors.fill: iconContainer
-                            onClicked: endNavigation()
-                        }
-
-                        Image {
-                            id: icon
-                            anchors.fill: parent
-                            anchors.margins: rowHeight/4
-                            anchors.rightMargin: 0
-                            source: InputStyle.closeIcon
-                            sourceSize.width: width
-                            sourceSize.height: height
-                            fillMode: Image.PreserveAspectFit
-                        }
-
-                        ColorOverlay {
-                            anchors.fill: icon
-                            source: icon
-                            color: InputStyle.fontColor
-                        }
-                    }
-                  }
-
-                  Rectangle {
-                      id: titleBorder
-                      width: parent.width
-                      height: 1
-                      color: InputStyle.fontColor
-                      anchors.bottom: title.bottom
-                  }
-
-                  Item {
-                      id: content
-                      width: parent.width
-                      anchors.top: header.bottom
-                      anchors.bottom: parent.bottom
-                      Text {
-                        text: "Distance: " + featureToGpsDistance
-                        font.pixelSize: InputStyle.fontPixelSizeNormal
-                        color: InputStyle.fontColor
-                        horizontalAlignment: Text.AlignLeft
-                        verticalAlignment: Text.AlignVCenter
-                        elide: Qt.ElideRight
-                      }
-                  }
-              }
+          Components.Symbol {
+            source: InputStyle.noIcon
+            iconSize: parent.height / 2
+            anchors.centerIn: parent
           }
+
+          MouseArea {
+            anchors.fill: parent
+            onClicked: endNavigation()
+          }
+        }
+      }
+
+      // Separator
+      Rectangle {
+          width: parent.width
+          height: 1
+          color: InputStyle.fontColor
+      }
+
+      // Content - changes based on state
+      ColumnLayout {
+        id: content
+
+        height: parent.height - header.height
+        width: parent.width
+
+        Row {
+          Layout.preferredHeight: root.state === "long" ? parent.height : ( parent.width * 1/6 )
+          Layout.preferredWidth: parent.width
+
+          Components.TextRowWithTitle {
+            id: featuretitle
+
+            height: parent.height
+            width: parent.width / 2
+
+            titleText: qsTr( "Feature" )
+            text: root.navigationTargetFeature ? __inputUtils.featureTitle( root.navigationTargetFeature, __loader.project ) : ""
+          }
+
+          Components.TextRowWithTitle {
+            id: distancetext
+
+            height: parent.height
+            width: parent.width / 2
+
+            titleText: qsTr( "Distance" )
+            text: __inputUtils.formatNumber( featureToGpsDistance, 2 ) + " m"
+          }
+        }
+
+        Item {
+          id: navigationComponent
+
+          Layout.fillHeight: true
+          Layout.fillWidth: true
+
+          visible: root.state === "short"
+
+          // enable antialiasing
+          layer.enabled: true
+          layer.samples: 4
+
+          Shape {
+            id: rootShape
+
+            property real centerX: width / 2
+            property real centerY: height / 2
+
+            anchors.fill: parent
+
+            ShapePath {
+
+              fillGradient: RadialGradient {
+                centerX: rootShape.centerX; centerY: rootShape.centerY
+                centerRadius: 100 * __dp
+                focalX: centerX; focalY: centerY
+                focalRadius: 10 * __dp
+                GradientStop { position: 0; color: "#006146" }
+                GradientStop { position: 1; color: "white" }
+              }
+
+              PathAngleArc {
+                id: innerArc
+
+                centerX: rootShape.centerX
+                centerY: rootShape.centerY
+
+                radiusX: 100 * __dp
+                radiusY: 100 * __dp
+
+                startAngle: 0
+                sweepAngle: 360
+              }
+            }
+
+            ShapePath {
+              id: positionArc
+
+              fillColor: "black"
+
+              PathAngleArc {
+                id: positionMarker
+
+                property real bearing: root.navigationTargetFeature ? __inputUtils.bearingToFeature(
+                                                                        __positionKit.positionCoordinate,
+                                                                        root.navigationTargetFeature,
+                                                                        root.mapCanvas.mapSettings ) : 0
+
+                centerX: rootShape.centerX + ( Math.sin( -bearing ) * root.featureToGpsDistance ) * innerArc.radiusX / root.distanceThresholdToShortMode * __dp
+                centerY: rootShape.centerY + ( Math.cos( -bearing ) * root.featureToGpsDistance ) * innerArc.radiusX / root.distanceThresholdToShortMode * __dp
+
+                radiusX: 10 * __dp
+                radiusY: 10 * __dp
+
+                startAngle: 0
+                sweepAngle: 360
+              }
+            }
+          }
+        }
       }
     }
+  }
 }

--- a/app/qml/NavigationPanel.qml
+++ b/app/qml/NavigationPanel.qml
@@ -74,7 +74,7 @@ Item {
     if ( autoFollow )
       mapCanvas.mapSettings.extent = calculatedNavigationExtent;
 
-    root.featureToGpsDistance = __inputUtils.distanceToFeature( __positionKit.positionCoordinate, root.navigationTargetFeature, root.mapCanvas.mapSettings );
+    root.featureToGpsDistance = __inputUtils.distanceBetweenGpsAndFeature( __positionKit.positionCoordinate, root.navigationTargetFeature, root.mapCanvas.mapSettings );
   }
 
   onAutoFollowChanged: updateNavigation()
@@ -184,8 +184,7 @@ Item {
           verticalAlignment: Text.AlignVCenter
         }
 
-        // TODO: add center to extent icon!
-        // TODO:   onClicked: autoFollow = true;
+        // TODO: add center to extent icon! onClicked: autoFollow = true;
 
         Item {
           id: closebtn
@@ -361,7 +360,7 @@ Item {
             Image {
                 id: direction
 
-                property real bearing: root.navigationTargetFeature ? __inputUtils.bearingToFeature(
+                property real bearing: root.navigationTargetFeature ? __inputUtils.angleBetweenGpsAndFeature(
                                                                         __positionKit.positionCoordinate,
                                                                         root.navigationTargetFeature,
                                                                         root.mapCanvas.mapSettings ) : 0

--- a/app/qml/components/InputText.qml
+++ b/app/qml/components/InputText.qml
@@ -1,0 +1,24 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+import QtQuick 2.14
+import ".."
+
+/*
+ * General purpose Text component
+ */
+
+Text {
+  color: InputStyle.fontColor
+
+  elide: Text.ElideRight
+  wrapMode: Text.WordWrap
+
+  font.pixelSize: InputStyle.fontPixelSizeSmall
+}

--- a/app/qml/components/SimpleTextWithIcon.qml
+++ b/app/qml/components/SimpleTextWithIcon.qml
@@ -43,7 +43,7 @@ Rectangle {
       width: height
       iconSize: height / 2
       source: root.source
-      fontColor: root.fontColor
+      iconColor: root.fontColor
     }
 
     Text {

--- a/app/qml/components/Symbol.qml
+++ b/app/qml/components/Symbol.qml
@@ -16,7 +16,7 @@ Rectangle {
   property real iconSize: InputStyle.rowHeight
   property string source: ""
   property color bgColor: "transparent"
-  property color fontColor: InputStyle.fontColor
+  property color iconColor: InputStyle.fontColor
 
   id: iconContainer
   height: iconContainer.iconSize
@@ -37,6 +37,6 @@ Rectangle {
   ColorOverlay {
     anchors.fill: icon
     source: icon
-    color: iconContainer.fontColor
+    color: iconContainer.iconColor
   }
 }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -347,6 +347,10 @@ ApplicationWindow {
       previewPanelHeight: formsStackManager.previewHeight
 
       _map: map
+
+      onNavigationEnded: {
+        formsStackManager.openForm( navigationPanel.navigationTargetFeature, "readOnly", "preview" )
+      }
     }
 
     Notification {
@@ -435,6 +439,7 @@ ApplicationWindow {
 
         navigationPanel.startNavigation();
         navigationPanel.navigationTargetFeature = feature;
+        closeDrawer()
       }
     }
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -343,10 +343,8 @@ ApplicationWindow {
 
       height: window.height
       width: window.width
-      previewHeight: window.height / 3
-      previewPanelHeight: formsStackManager.previewHeight
 
-      _map: map
+      mapCanvas: map
 
       onNavigationEnded: {
         formsStackManager.openForm( navigationPanel.navigationTargetFeature, "readOnly", "preview" )

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -291,6 +291,15 @@ Item {
         }
       }
     }
+
+    onLongPressed: {
+      // Alter position of simulated provider
+
+      if ( __positionKit.positionProvider && __positionKit.positionProvider.id() === "simulated" )
+      {
+        __positionKit.positionProvider.setPosition( __inputUtils.mapPointToGps( Qt.point( point.x, point.y ), _map.mapSettings ) )
+      }
+    }
   }
 
   MapPosition {

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/app/qml/qml.qrc
+++ b/app/qml/qml.qrc
@@ -107,5 +107,6 @@
         <file>misc/PositionProviderPage.qml</file>
         <file>misc/AddPositionProviderPage.qml</file>
         <file>components/BluetoothConnectionDialog.qml</file>
+        <file>components/InputText.qml</file>
     </qresource>
 </RCC>

--- a/app/test/testposition.cpp
+++ b/app/test/testposition.cpp
@@ -59,7 +59,7 @@ void TestPosition::simulatedPosition()
   QVERIFY( positionKit->hasPosition() );
 
   COMPARENEAR( positionKit->positionCoordinate().y(), 38.93, 1e-4 );
-  QVERIFY( positionKit->horizontalAccuracy() > 0 );
+  QVERIFY( positionKit->horizontalAccuracy() >= 0 );
   QVERIFY( positionKit->satellitesVisible() >= 0 );
   QVERIFY( positionKit->satellitesUsed() >= 0 );
 

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -104,6 +104,18 @@ void TestUtilsFunctions::transformedPoint()
                                  pointXY );
   COMPARENEAR( transformedPoint.x(), 5554843, 1.0 );
   COMPARENEAR( transformedPoint.y(), 1839491, 1.0 );
+
+  // Check transformation within the same CRS
+  transformedPoint = mUtils->transformPoint(
+                       crsGPS,
+                       crsGPS,
+                       QgsCoordinateTransformContext(),
+                       pointXY
+                     );
+
+  QVERIFY( !transformedPoint.isEmpty() );
+  COMPARENEAR( transformedPoint.x(), 49.9, 1e-4 );
+  COMPARENEAR( transformedPoint.y(), 16.3, 1e-4 );
 }
 
 void TestUtilsFunctions::formatPoint()
@@ -495,8 +507,8 @@ void TestUtilsFunctions::testMapPointToGps()
     }
     else
     {
-      QVERIFY( qgsDoubleNear( gpsPoint.x(), s.lat, 0.001 ) );
-      QVERIFY( qgsDoubleNear( gpsPoint.y(), s.lon, 0.001 ) );
+      COMPARENEAR( gpsPoint.x(), s.lat, 0.001 );
+      COMPARENEAR( gpsPoint.y(), s.lon, 0.001 );
     }
   }
 }

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -396,8 +396,7 @@ void TestUtilsFunctions::testDistanceToFeature()
 
   FeatureLayerPair pair( feature, &pointsLayer );
 
-  QString ditance = mUtils->distanceToFeature( gpsPos, pair, &ms );
-  QCOMPARE( ditance, QStringLiteral( "142.20 m" ) );
+  QCOMPARE( mUtils->distanceToFeature( gpsPos, pair, &ms ), 142.20 );
 }
 
 void TestUtilsFunctions::testIsPointLayerFeature()

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -395,8 +395,8 @@ void TestUtilsFunctions::testDistanceToFeature()
   feature.setGeometry( geom );
 
   FeatureLayerPair pair( feature, &pointsLayer );
-
-  QCOMPARE( mUtils->distanceToFeature( gpsPos, pair, &ms ), 142.20 );
+  qreal distance = mUtils->distanceToFeature( gpsPos, pair, &ms );
+  QCOMPARE( mUtils->formatNumber( distance, 2 ), "142.20" );
 }
 
 void TestUtilsFunctions::testIsPointLayerFeature()

--- a/app/test/testutilsfunctions.h
+++ b/app/test/testutilsfunctions.h
@@ -36,8 +36,10 @@ class TestUtilsFunctions: public QObject
     void testDirSize();
     void testExtractPointFromFeature();
     void testNavigationFeatureExtent();
-    void testDistanceToFeature();
+    void testDistanceBetweenGpsAndFeature();
+    void testAngleBetweenGpsAndFeature();
     void testIsPointLayerFeature();
+    void testMapPointToGps();
 
   private:
     void testFormatDuration( const QDateTime &t0, qint64 diffSecs, const QString &expectedResult );


### PR DESCRIPTION
PR adds short mode for stakeout. 
Short mode is activated when your position is below one meter from the destination point. It allows users with high-precision GNSS receivers to better orientate in the field when going close to a feature.

When distance between your position and target point is under 10 cm, navigation goes green.

Showcase:

https://user-images.githubusercontent.com/22449698/152962912-d8c143b0-14b6-45f8-adbe-ebeb154b8883.mp4

**Visual UPDATE:**

https://user-images.githubusercontent.com/22449698/153176776-96313f01-4d20-46e1-86fb-fae9598699a7.mp4

For test purposes I also added another feature - long tap on a map changes your position to the place you tapped. _This is working only when you use simulated provider_

There are few issues to address in next PR:
 - make the navigation scale properly on different screens - currently I use few hard coded values
 - show GPS panel button (+ handle back button properly)
 - ~~show "recenter button"~~
 - consider size of gps position marker when changing extent (so that your position is visible on the new extent)

Another part of #822 (basically almost all of that, but let's close it after those minor issues are fixed)