### PR TITLE
Fix highlight numerical precision issues

### DIFF
--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -151,9 +151,9 @@ QtObject {
 
     property color highlightLineColor: Qt.rgba( 1, 0.2, 0.2, 1 )
     property color highlightFillColor: Qt.rgba( 1, 0.2, 0.2, InputStyle.lowHighlightOpacity )
-    property color highlighOutlineColor: "white"
+    property color highlightOutlineColor: "white"
     property real highlightLineWidth: 6 * __dp
-    property real highlighOutlinePenWidth: 1 * __dp
+    property real highlightOutlinePenWidth: 2 * __dp
 
     property real mapOutOfExtentBorder: scale(64) // when pair lays very close to device display border, center map extent
 

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -315,8 +315,8 @@ Item {
 
     fillColor: InputStyle.highlightFillColor
 
-    outlinePenWidth: InputStyle.highlighOutlinePenWidth
-    outlineColor: InputStyle.highlighOutlineColor
+    outlinePenWidth: InputStyle.highlightOutlinePenWidth
+    outlineColor: InputStyle.highlightOutlineColor
   }
 
   PositionMarker {
@@ -394,8 +394,8 @@ Item {
 
     fillColor: InputStyle.highlightFillColor
 
-    outlinePenWidth: InputStyle.highlighOutlinePenWidth
-    outlineColor: InputStyle.highlighOutlineColor
+    outlinePenWidth: InputStyle.highlightOutlinePenWidth
+    outlineColor: InputStyle.highlightOutlineColor
 
     markerType: "image"
     markerImageSource: InputStyle.mapMarkerIcon

--- a/app/qml/map/NavigationHighlight.qml
+++ b/app/qml/map/NavigationHighlight.qml
@@ -35,17 +35,21 @@ Item {
   // for transformation of the highlight to the correct location on the map
   property QgsQuick.MapSettings mapSettings
 
-  // transform used by line/path
-  property QgsQuick.MapTransform mapTransform: QgsQuick.MapTransform {
-    mapSettings: navHighlight.mapSettings
-  }
-
   // properties used by markers (not able to use values directly from mapTransform
   // (no direct access to matrix no mapSettings' visible extent)
   property real mapTransformScale: 1
   property real mapTransformOffsetX: 0
   property real mapTransformOffsetY: 0
   property real displayDevicePixelRatio: 1
+
+  // Reference view settings used for transformation of coordinates (needed for lines and polygons).
+  // We convert their coordinates to screen coordinates of the current view, and then as user pans/zooms
+  // the map, we use a transform to adjust the shape. The reason is that the transform uses single
+  // precision floats, and if we used just map coordinates, we get numerical errors when the map gets
+  // zoomed in. This approach is more stable (but does not avoid the issue 100%)
+  property real refTransformScale: 1
+  property real refTransformOffsetX: 0
+  property real refTransformOffsetY: 0
 
   property real _srcX: 0
   property real _srcY: 0
@@ -66,13 +70,17 @@ Item {
   {
     if ( !destinationPair || !gpsPosition || !mapSettings ) return
 
+    refTransformOffsetX = mapTransformOffsetX
+    refTransformOffsetY = mapTransformOffsetY
+    refTransformScale = mapTransformScale
+
     let gpsMapCRS = __inputUtils.transformPoint( __inputUtils.coordinateReferenceSystemFromEpsgId( 4326 ), mapSettings.destinationCrs, mapSettings.transformContext(), __inputUtils.pointXY( gpsPosition.x, gpsPosition.y ) );
     let targetMapCRS = __inputUtils.transformPoint( destinationPair.layer.crs, mapSettings.destinationCrs, mapSettings.transformContext(), __inputUtils.extractPointFromFeature( destinationPair ) );
 
-    _srcX = gpsMapCRS.x;
-    _srcY = gpsMapCRS.y;
-    _dstX = targetMapCRS.x;
-    _dstY = targetMapCRS.y;
+    _srcX =  ( gpsMapCRS.x + navHighlight.mapTransformOffsetX) * navHighlight.mapTransformScale / displayDevicePixelRatio
+    _srcY = -( gpsMapCRS.y + navHighlight.mapTransformOffsetY) * navHighlight.mapTransformScale / displayDevicePixelRatio
+    _dstX =  ( targetMapCRS.x + navHighlight.mapTransformOffsetX) * navHighlight.mapTransformScale / displayDevicePixelRatio
+    _dstY = -( targetMapCRS.y + navHighlight.mapTransformOffsetY) * navHighlight.mapTransformScale / displayDevicePixelRatio
   }
 
   onDestinationPairChanged: constructHighlights()
@@ -87,12 +95,26 @@ Item {
     id: shape
     anchors.fill: parent
 
-    transform: mapTransform
+    transform: Matrix4x4 {
+        // the formula for x coordinate for map to screen coordinates conversion goes like this:
+        //   x_screen = (x_map + offset_x) * scale / ddp
+        // this matrix is just doing transform from old view settings (scale, offset_x, offset_y) for which we have
+        // calculated coordinates in constructHighlight to new view settings (that are active now).
+        id: shapeTransform
+        property real scale: mapTransformScale / refTransformScale
+        property real offsetX:  (mapTransformOffsetX - refTransformOffsetX) * mapTransformScale / displayDevicePixelRatio
+        property real offsetY: -(mapTransformOffsetY - refTransformOffsetY) * mapTransformScale / displayDevicePixelRatio
+
+        matrix: Qt.matrix4x4( scale, 0,     0, offsetX,
+                              0,     scale, 0, offsetY,
+                              0,     0,     1, 0,
+                              0,     0,     0, 1)
+    }
 
     ShapePath {
       id: lineShapePath2
       strokeColor: "black"
-      strokeWidth: (navHighlight.lineWidth - navHighlight.outlinePenWidth * 2 + 5 * __dp) / navHighlight.mapTransformScale // negate scaling from the transform
+      strokeWidth: (navHighlight.lineWidth - navHighlight.outlinePenWidth * 2 + 5 * __dp) / shapeTransform.scale // negate scaling from the transform
       fillColor: "black"
       capStyle: ShapePath.RoundCap
       joinStyle: ShapePath.BevelJoin
@@ -106,7 +128,7 @@ Item {
     ShapePath {
       id: lineShapePath
       strokeColor: navHighlight.lineColor
-      strokeWidth: (navHighlight.lineWidth - navHighlight.outlinePenWidth * 2) / navHighlight.mapTransformScale  // negate scaling from the transform
+      strokeWidth: (navHighlight.lineWidth - navHighlight.outlinePenWidth * 2) / shapeTransform.scale  // negate scaling from the transform
       fillColor: "transparent"
       capStyle: ShapePath.RoundCap
       joinStyle: ShapePath.BevelJoin


### PR DESCRIPTION
Instead of using map coordinates for line/polygon shapes and then `Transform` for map to screen conversion, we now use screen coordinates at the time the highlight is constructed ("reference") and the `Transform` just adjusts to the change of scale/offset when the map is moved/zoomed. While both of these approaches seem equivalent, the difference is that in the former case, the `Transform` would deal with big numbers (for offsets), causing numerical issues due to single precision floating point math. Now the calculation with big numbers is done with doubles before creating shapes, and the transform deals with much smaller transforms. This does not make the issue go completely away, but it should be much less apparent under normal circumstances.

Also fixes typos "highligh" -> "highlight" and increases default polygon outline width from 1dp to 2dp as 1dp is a bit too thin.