### PR TITLE
Make navigation extent bigger to show GPS marker

### DIFF
--- a/app/qml/NavigationPanel.qml
+++ b/app/qml/NavigationPanel.qml
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -63,8 +63,11 @@ Item {
     mapCanvas.navigationHighlightFeature = navigationTargetFeature
     mapCanvas.navigationHighlightGpsPosition = __positionKit.positionCoordinate
 
-    var previewPanelHeightRatio = drawer.height / mapCanvas.height;
-    calculatedNavigationExtent =  __inputUtils.navigationFeatureExtent(
+    // reserve some space around canvas so that position marker is always visible in autofollow mode
+    let previewMargin = direction.height * 3
+    let previewPanelHeightRatio = ( drawer.height + previewMargin ) / mapCanvas.height
+
+    root.calculatedNavigationExtent =  __inputUtils.navigationFeatureExtent(
           mapCanvas.navigationHighlightFeature,
           __positionKit.positionCoordinate,
           mapCanvas.mapSettings,


### PR DESCRIPTION
PR changes calculation of map extent to include size of gps marker (+ direction indicator). Previously, you did not see GPS marker when approaching a target from the bottom of the screen

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/22449698/153198735-10f4a19a-5ebf-404a-8a21-aee9646daf4b.png" width="300"/></td>
    <td><img src="https://user-images.githubusercontent.com/22449698/153198732-af2a87c6-8fd2-44af-b4c0-53f7558dca48.png"  width="300"/></td>
  </tr>
 </table>

