### PR TITLE
Stake out - show gps panel

### DIFF
--- a/app/qml/FormsStackManager.qml
+++ b/app/qml/FormsStackManager.qml
@@ -53,7 +53,7 @@ Item {
       latest.formState = formState
       latest.panelState = panelState
     }
-    takenPanelsSpace = previewHeight - InputStyle.rowHeightHeader
+    takenPanelsSpace = previewHeight
   }
 
   function _getActiveForm() {

--- a/app/qml/NavigationPanel.qml
+++ b/app/qml/NavigationPanel.qml
@@ -152,7 +152,19 @@ Item {
     edge: Qt.BottomEdge
 
     dragMargin: 0 // prevents opening the drawer by dragging.
-    closePolicy: Popup.CloseOnEscape // prevents the drawer closing while moving canvas
+    closePolicy: Popup.NoAutoClose
+
+    Item {
+      // back handler
+      focus: true
+
+      Keys.onReleased: {
+        if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+          event.accepted = true;
+          endStakeout()
+        }
+      }
+    }
 
     Rectangle {
       anchors.fill: parent

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -127,7 +127,9 @@ ApplicationWindow {
 
       mapExtentOffset: {
         // offset depends on what panels are visible.
-        // we need to subtract mainPanel (toolbar)'s height from
+        // we need to subtract mainPanel (toolbar)'s height from any visible panel
+        // because panels start at the bottom of the screen, but map canvas's height is lowered
+        // by mainPanels's height.
         if ( stakeoutPanelLoader.active )
         {
           // if stakeout panel is opened

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -130,9 +130,15 @@ ApplicationWindow {
         // we need to subtract mainPanel (toolbar)'s height from
         if ( stakeoutPanelLoader.active )
         {
+          // if stakeout panel is opened
           return stakeoutPanelLoader.item.panelHeight - mainPanel.height
         }
-        return formsStackManager.takenPanelsSpace - mainPanel.height
+        else if ( formsStackManager.takenPanelsSpace > 0 )
+        {
+          // if feature preview panel is opened
+          return formsStackManager.takenPanelsSpace - mainPanel.height
+        }
+        return 0
       }
 
       onFeatureIdentified: formsStackManager.openForm( pair, "readOnly", "preview" );

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -289,7 +289,10 @@ ApplicationWindow {
       GpsDataPage {
         id: gpsDataPage
 
-        onBack: gpsDataPageLoader.active = false
+        onBack: {
+          mainPanel.focus = true
+          gpsDataPageLoader.active = false
+        }
 
         mapSettings: map.mapSettings
 
@@ -303,6 +306,7 @@ ApplicationWindow {
 
       asynchronous: true
       active: false
+      focus: true
       sourceComponent: gpsDataPageComponent
       onActiveChanged: {
         if ( gpsDataPageLoader.active )
@@ -420,6 +424,10 @@ ApplicationWindow {
         if ( browseDataPanel.visible ) {
           browseDataPanel.refreshFeaturesData()
           browseDataPanel.focus = true
+        }
+        else if ( gpsDataPageLoader.active )
+        {
+          // do nothing, gps page already has focus
         }
         else mainPanel.focus = true
 

--- a/app/qml/map/NavigationHighlight.qml
+++ b/app/qml/map/NavigationHighlight.qml
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -30,7 +30,7 @@ Item {
 
   // feature+layer pair which determines what geometry is highlighted
   property var destinationPair: null
-  property var gpsPosition: null
+  property var gpsPosition: __positionKit.positionCoordinate
 
   // for transformation of the highlight to the correct location on the map
   property QgsQuick.MapSettings mapSettings

--- a/app/qml/misc/GpsDataPage.qml
+++ b/app/qml/misc/GpsDataPage.qml
@@ -25,7 +25,12 @@ Item {
 
   signal back()
 
-  focus: true
+  Keys.onReleased: {
+    if ( event.key === Qt.Key_Back || event.key === Qt.Key_Escape ) {
+      event.accepted = true
+      root.back()
+    }
+  }
 
   StackView {
     id: additionalContent
@@ -40,12 +45,15 @@ Item {
     Page {
       id: gpsPage
 
+      focus: true
       Keys.onReleased: {
         if ( event.key === Qt.Key_Back || event.key === Qt.Key_Escape ) {
           event.accepted = true
           root.back()
         }
       }
+
+      Component.onCompleted: forceActiveFocus()
 
       MapPosition {
         id: mapPositioning


### PR DESCRIPTION
PR adds possibility to open GPS panel during stakeout. It no longer stops stakeout. Stakeout continues after GPS data panel is closed. In order to do that, I needed to do a small refactoring of how we do the stakeout. It now goes like this:

`
PreviewPanel (FormsStackManager) ---(sends signal that user wants to stake out)--> MapWrapper (starts navigation highlight and emits signal that stakeout started) --> NavigationPanel handles the signal and shows itself.
`

Previously `FormsStackManager` directly called NavigationPanel.

I also started to name new components "stakeout<xyz>" instead of navigation. Navigation is more like routing. I will rename all remaining components once this one is merged - did not want to make this one unreadable :) 

It also includes few other enhancements:
 - back button handling in GPS data panel
 - change of icon for "recenter" from ![image](https://user-images.githubusercontent.com/22449698/153359153-b0ff94b2-43a4-4172-96e3-279deb82724f.png) to ![image](https://user-images.githubusercontent.com/22449698/153359228-4a19a3f5-c1fb-41bb-b6c8-3625aa22cd75.png)
 - NavigationPanel is now instantiated dynamically (only when we need it), not at app startup
