### PR TITLE
scale close range mode window

### DIFF
--- a/app/qml/StakeoutPanel.qml
+++ b/app/qml/StakeoutPanel.qml
@@ -329,8 +329,8 @@ Item {
                 centerX: rootShape.centerX
                 centerY: rootShape.centerY
 
-                radiusX: 50 * __dp
-                radiusY: 50 * __dp
+                radiusX: outerArc.radiusX / 2
+                radiusY: outerArc.radiusY / 2
 
                 startAngle: 0
                 sweepAngle: 360
@@ -346,11 +346,19 @@ Item {
               PathAngleArc {
                 id: outerArc
 
+                property real outerRadius: {
+                  if ( rootShape.height / 2.5 < 100 )
+                  {
+                    return 100 // minimum height
+                  }
+                  return rootShape.height / 2.5
+                }
+
                 centerX: rootShape.centerX
                 centerY: rootShape.centerY
 
-                radiusX: 100 * __dp
-                radiusY: 100 * __dp
+                radiusX: outerRadius * __dp
+                radiusY: outerRadius * __dp
 
                 startAngle: 0
                 sweepAngle: 360
@@ -403,8 +411,8 @@ Item {
                   *   scale by size of the outer circle /
                   *   distance of the outer circle in metres (closeRangeModeDistanceThreshold)
                   */
-                x: ( rootShape.centerX + ( Math.sin( -bearing ) * root.remainingDistance ) * outerArc.radiusX / root.closeRangeModeDistanceThreshold * __dp ) - width / 2
-                y: ( rootShape.centerY + ( Math.cos( -bearing ) * root.remainingDistance ) * outerArc.radiusX / root.closeRangeModeDistanceThreshold * __dp ) - height
+                x: ( rootShape.centerX + ( Math.sin( -bearing ) * root.remainingDistance ) * outerArc.outerRadius / root.closeRangeModeDistanceThreshold * __dp ) - width / 2
+                y: ( rootShape.centerY + ( Math.cos( -bearing ) * root.remainingDistance ) * outerArc.outerRadius / root.closeRangeModeDistanceThreshold * __dp ) - height
 
                 Behavior on rotation { RotationAnimation { properties: "rotation"; direction: RotationAnimation.Shortest; duration: 500 }}
             }
@@ -416,8 +424,8 @@ Item {
                 width: InputStyle.rowHeightHeader / 2
                 height: width
                 smooth: true
-                x: ( rootShape.centerX + ( Math.sin( -direction.bearing ) * root.remainingDistance ) * outerArc.radiusX / root.closeRangeModeDistanceThreshold * __dp ) - width / 2
-                y: ( rootShape.centerY + ( Math.cos( -direction.bearing ) * root.remainingDistance ) * outerArc.radiusX / root.closeRangeModeDistanceThreshold * __dp ) - height / 2
+                x: ( rootShape.centerX + ( Math.sin( -direction.bearing ) * root.remainingDistance ) * outerArc.outerRadius / root.closeRangeModeDistanceThreshold * __dp ) - width / 2
+                y: ( rootShape.centerY + ( Math.cos( -direction.bearing ) * root.remainingDistance ) * outerArc.outerRadius / root.closeRangeModeDistanceThreshold * __dp ) - height / 2
             }
           }
         }


### PR DESCRIPTION
PR alters close-range stakeout window so that it correctly represents distances on different screens. Two circles inside close-range stakeout represents distances:
 - inner circle -> 0.5m from target
 - outer circle -> 1m from target

Previously on different screens this did not show properly

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/22449698/153548024-0bcbc379-70b5-4b40-8e0f-a3214cc0a34e.png"  width="350"/></td>
    <td><img src="https://user-images.githubusercontent.com/22449698/153547995-7f341228-a975-40c0-b359-da3ffb478e13.png" width="350"/></td>
  </tr>
 </table>
