### PR TITLE
Change reconnection time to GPS receiver to 5 sec

### DIFF
--- a/app/position/bluetoothpositionprovider.h
+++ b/app/position/bluetoothpositionprovider.h
@@ -47,7 +47,7 @@ class BluetoothPositionProvider : public AbstractPositionProvider
     enum ReconnectDelay
     {
       ShortDelay = 3000,
-      LongDelay = 10000
+      LongDelay = 5000
     };
 
   public:


### PR DESCRIPTION
Changes reconnection "try again" timeout to 5 secs (from previous 10). It turned out to be too long to wait 10 secs