### PR TITLE
Stakeout extent movements

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1028,6 +1028,13 @@ bool InputUtils::equals( const QPointF &a, const QPointF &b, double epsilon )
 
 bool InputUtils::equals( const QgsPointXY &a, const QgsPointXY &b, double epsilon )
 {
+  if ( a.isEmpty() && b.isEmpty() )
+    return true;
+  if ( a.isEmpty() && !b.isEmpty() )
+    return false;
+  if ( !a.isEmpty() && b.isEmpty() )
+    return false;
+
   return qgsDoubleNear( a.x(), b.x(), epsilon ) && qgsDoubleNear( a.y(), b.y(), epsilon );
 }
 

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -1019,6 +1019,16 @@ qreal InputUtils::calculateDpRatio()
   }
 
   return 1;
+}
+
+bool InputUtils::equals( const QPointF &a, const QPointF &b, double epsilon )
+{
+  return qgsDoubleNear( a.x(), b.x(), epsilon ) && qgsDoubleNear( a.y(), b.y(), epsilon );
+}
+
+bool InputUtils::equals( const QgsPointXY &a, const QgsPointXY &b, double epsilon )
+{
+  return qgsDoubleNear( a.x(), b.x(), epsilon ) && qgsDoubleNear( a.y(), b.y(), epsilon );
 }
 
 QString InputUtils::formatPoint(

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1312,7 +1312,7 @@ QgsQuickMapSettings *InputUtils::setupMapSettings( QgsProject *project, QgsQuick
   return settings;
 }
 
-void InputUtils::setStakeoutPathExtent(
+QgsRectangle InputUtils::stakeoutPathExtent(
   MapPosition *mapPositioner,
   const FeatureLayerPair &targetFeature,
   QgsQuickMapSettings *mapSettings,
@@ -1320,14 +1320,16 @@ void InputUtils::setStakeoutPathExtent(
 )
 {
   if ( !mapPositioner || !mapSettings || !targetFeature.isValid() )
-    return;
+    return QgsRectangle();
+
+  QgsRectangle extent = mapSettings->extent();
 
   // We currently support only point geometries
   if ( targetFeature.layer()->geometryType() != QgsWkbTypes::PointGeometry )
-    return;
+    return extent;
 
   if ( !mapPositioner->positionKit() || !mapPositioner->mapSettings() )
-    return;
+    return extent;
 
   //
   // In order to compute stakeout extent, we first compute distance to target feature and
@@ -1350,7 +1352,7 @@ void InputUtils::setStakeoutPathExtent(
   if ( gpsPointInMapCRS.isEmpty() )
   {
     // unsuccessful transform
-    return;
+    return extent;
   }
 
   QgsPointXY gpsPointInCanvasXY = mapPositioner->screenPosition();
@@ -1363,8 +1365,6 @@ void InputUtils::setStakeoutPathExtent(
   {
     panelOffset = mapExtentOffset / 2;
   }
-
-  QgsRectangle extent;
 
   if ( distance > 10 )
   {
@@ -1406,7 +1406,7 @@ void InputUtils::setStakeoutPathExtent(
     if ( targetPointInMapCRS.isEmpty() )
     {
       // unsuccessful transform
-      return;
+      return extent;
     }
 
     QgsPointXY targetPointInCanvasXY = mapSettings->coordinateToScreen( QgsPoint( targetPointInMapCRS ) );
@@ -1416,7 +1416,7 @@ void InputUtils::setStakeoutPathExtent(
     extent = mapSettings->mapSettings().computeExtentForScale( center, scale );
   }
 
-  mapSettings->setExtent( extent );
+  return extent;
 }
 
 qreal InputUtils::distanceBetweenGpsAndFeature( QgsPoint gpsPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings )

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -1030,9 +1030,7 @@ bool InputUtils::equals( const QgsPointXY &a, const QgsPointXY &b, double epsilo
 {
   if ( a.isEmpty() && b.isEmpty() )
     return true;
-  if ( a.isEmpty() && !b.isEmpty() )
-    return false;
-  if ( !a.isEmpty() && b.isEmpty() )
+  if ( a.isEmpty() != b.isEmpty() )
     return false;
 
   return qgsDoubleNear( a.x(), b.x(), epsilon ) && qgsDoubleNear( a.y(), b.y(), epsilon );
@@ -1320,13 +1318,13 @@ QgsQuickMapSettings *InputUtils::setupMapSettings( QgsProject *project, QgsQuick
 }
 
 QgsRectangle InputUtils::stakeoutPathExtent(
-  MapPosition *mapPositioner,
+  MapPosition *mapPosition,
   const FeatureLayerPair &targetFeature,
   QgsQuickMapSettings *mapSettings,
   double mapExtentOffset
 )
 {
-  if ( !mapPositioner || !mapSettings || !targetFeature.isValid() )
+  if ( !mapPosition || !mapSettings || !targetFeature.isValid() )
     return QgsRectangle();
 
   QgsRectangle extent = mapSettings->extent();
@@ -1335,7 +1333,7 @@ QgsRectangle InputUtils::stakeoutPathExtent(
   if ( targetFeature.layer()->geometryType() != QgsWkbTypes::PointGeometry )
     return extent;
 
-  if ( !mapPositioner->positionKit() || !mapPositioner->mapSettings() )
+  if ( !mapPosition->positionKit() || !mapPosition->mapSettings() )
     return extent;
 
   //
@@ -1345,7 +1343,7 @@ QgsRectangle InputUtils::stakeoutPathExtent(
   // it is centered to GPS position. This has been added in order to reduce "jumps" of canvas when user is near the target.
   //
 
-  QgsPoint gpsPointRaw = mapPositioner->positionKit()->positionCoordinate();
+  QgsPoint gpsPointRaw = mapPosition->positionKit()->positionCoordinate();
 
   qreal distance = distanceBetweenGpsAndFeature( gpsPointRaw, targetFeature, mapSettings );
   qreal scale = distanceToScale( distance );
@@ -1353,7 +1351,7 @@ QgsRectangle InputUtils::stakeoutPathExtent(
 
   if ( mapExtentOffset > 0 )
   {
-    panelOffset = mapExtentOffset / 2;
+    panelOffset = mapExtentOffset / 2.0;
   }
 
   if ( distance <= 1 )
@@ -1382,7 +1380,7 @@ QgsRectangle InputUtils::stakeoutPathExtent(
   else
   {
     // center to GPS position
-    QgsPointXY gpsPointInCanvasXY = mapPositioner->screenPosition();
+    QgsPointXY gpsPointInCanvasXY = mapPosition->screenPosition();
     QgsPointXY centerInCanvasXY( gpsPointInCanvasXY.x(), gpsPointInCanvasXY.y() + panelOffset );
     QgsPointXY center = mapSettings->screenToCoordinate( centerInCanvasXY.toQPointF() );
 

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -412,8 +412,8 @@ class InputUtils: public QObject
     // Returns a point geometry from point feature
     Q_INVOKABLE static QgsPointXY extractPointFromFeature( const FeatureLayerPair &feature );
 
-    // Returns an extent showing both pair and gpsPosition
-    Q_INVOKABLE void setStakeoutPathExtent( MapPosition *mapPositioner, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings, double mapExtentOffset );
+    // Returns an extent for stakeout based on distance between gps position and target feature
+    Q_INVOKABLE QgsRectangle stakeoutPathExtent( MapPosition *mapPositioner, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings, double mapExtentOffset );
 
     // Returns the distance from \a gpsPos to the feature \a pair
     Q_INVOKABLE qreal distanceBetweenGpsAndFeature( QgsPoint gpsPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings );

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -413,7 +413,7 @@ class InputUtils: public QObject
     Q_INVOKABLE static QgsPointXY extractPointFromFeature( const FeatureLayerPair &feature );
 
     // Returns an extent showing both pair and gpsPosition
-    Q_INVOKABLE void setStakeoutPathExtent( MapPosition *mapPositioner, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings, double mapWidth, double mapHeight, double mapExtentOffset, double mapMargin );
+    Q_INVOKABLE void setStakeoutPathExtent( MapPosition *mapPositioner, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings, double mapExtentOffset );
 
     // Returns the distance from \a gpsPos to the feature \a pair
     Q_INVOKABLE qreal distanceBetweenGpsAndFeature( QgsPoint gpsPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings );

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -430,6 +430,10 @@ class InputUtils: public QObject
     // Calculates ratio between real DPR calculated by us with DPR calculated by QT that is later used in qml sizing
     static qreal calculateDpRatio();
 
+    // Compares two variables and returns true if they are equal. For floating point values it uses provided epsilon for comparison
+    static bool equals( const QPointF &a, const QPointF &b, double epsilon = 0.001 );
+    static bool equals( const QgsPointXY &a, const QgsPointXY &b, double epsilon = 0.001 );
+
     // Returns whether geometry of the feature is an actual Point feature (Used because some )
     Q_INVOKABLE static bool isPointLayerFeature( const FeatureLayerPair &pair );
   signals:

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -435,6 +435,7 @@ class InputUtils: public QObject
 
     // Compares two variables and returns true if they are equal. For floating point values it uses provided epsilon for comparison
     static bool equals( const QPointF &a, const QPointF &b, double epsilon = 0.001 );
+    // Convinient comparison function with possibility to pass custom epsilon value (not possible in QGIS API)
     static bool equals( const QgsPointXY &a, const QgsPointXY &b, double epsilon = 0.001 );
 
     // Returns whether geometry of the feature is an actual Point feature (Used because some )

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -413,7 +413,7 @@ class InputUtils: public QObject
     Q_INVOKABLE static QgsPointXY extractPointFromFeature( const FeatureLayerPair &feature );
 
     // Returns an extent for stakeout based on distance between gps position and target feature
-    Q_INVOKABLE QgsRectangle stakeoutPathExtent( MapPosition *mapPositioner, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings, double mapExtentOffset );
+    Q_INVOKABLE QgsRectangle stakeoutPathExtent( MapPosition *mapPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings, double mapExtentOffset );
 
     // Translates distance to target point into scale factor that should be used for map canvas during stakeout
     qreal distanceToScale( qreal distance );

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -38,6 +38,7 @@
 #include "qgsquickmapsettings.h"
 #include "featurelayerpair.h"
 #include "qgscoordinateformatter.h"
+#include "position/mapposition.h"
 
 class QgsFeature;
 class QgsVectorLayer;
@@ -412,7 +413,7 @@ class InputUtils: public QObject
     Q_INVOKABLE static QgsPointXY extractPointFromFeature( const FeatureLayerPair &feature );
 
     // Returns an extent showing both pair and gpsPosition
-    Q_INVOKABLE QgsRectangle stakeoutFeatureExtent( const FeatureLayerPair &pair, QgsPoint gpsPosition, QgsQuickMapSettings *mapSettings, double panelOffsetRatio );
+    Q_INVOKABLE void setStakeoutPathExtent( MapPosition *mapPositioner, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings, double mapWidth, double mapHeight, double mapExtentOffset, double mapMargin );
 
     // Returns the distance from \a gpsPos to the feature \a pair
     Q_INVOKABLE qreal distanceBetweenGpsAndFeature( QgsPoint gpsPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings );

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -415,6 +415,9 @@ class InputUtils: public QObject
     // Returns an extent for stakeout based on distance between gps position and target feature
     Q_INVOKABLE QgsRectangle stakeoutPathExtent( MapPosition *mapPositioner, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings, double mapExtentOffset );
 
+    // Translates distance to target point into scale factor that should be used for map canvas during stakeout
+    qreal distanceToScale( qreal distance );
+
     // Returns the distance from \a gpsPos to the feature \a pair
     Q_INVOKABLE qreal distanceBetweenGpsAndFeature( QgsPoint gpsPosition, const FeatureLayerPair &targetFeature, QgsQuickMapSettings *mapSettings );
 

--- a/app/position/mapposition.cpp
+++ b/app/position/mapposition.cpp
@@ -73,7 +73,7 @@ QgsPoint MapPosition::mapPosition() const
   return mMapPosition;
 }
 
-QPointF MapPosition::screenPosition() const
+QgsPointXY MapPosition::screenPosition() const
 {
   return mScreenPosition;
 }
@@ -127,14 +127,16 @@ void MapPosition::recalculateMapPosition()
 
 void MapPosition::recalculateScreenPosition()
 {
-  QPointF newScreenPosition;
+  QgsPointXY newScreenPosition;
 
   if ( mMapSettings && mPositionKit )
   {
     newScreenPosition = mapSettings()->coordinateToScreen( mMapPosition );
   }
 
-  if ( mScreenPosition != newScreenPosition )
+  // We use comparison with higher epsilon to limit issues with floating point precision (in QPointF) and
+  // make less updates as 0.001 precision is well enough for us. QgsPointXY internally uses 1E-8 precision
+  if ( !InputUtils::equals( mScreenPosition, newScreenPosition, 0.001 ) )
   {
     mScreenPosition = newScreenPosition;
     emit screenPositionChanged( mScreenPosition );

--- a/app/position/mapposition.h
+++ b/app/position/mapposition.h
@@ -28,7 +28,7 @@ class MapPosition : public QObject
     Q_PROPERTY( QgsPoint mapPosition READ mapPosition NOTIFY mapPositionChanged )
 
     // GPS position in device coords (pixels)
-    Q_PROPERTY( QPointF screenPosition READ screenPosition NOTIFY screenPositionChanged )
+    Q_PROPERTY( QgsPointXY screenPosition READ screenPosition NOTIFY screenPositionChanged )
 
     // Screen horizontal accuracy, 2 if not available or resolution is too small
     Q_PROPERTY( double screenAccuracy READ screenAccuracy NOTIFY screenAccuracyChanged )
@@ -47,7 +47,7 @@ class MapPosition : public QObject
     void setMapSettings( QgsQuickMapSettings *newMapSettings );
 
     QgsPoint mapPosition() const;
-    QPointF screenPosition() const;
+    QgsPointXY screenPosition() const;
     double screenAccuracy() const;
 
   signals:
@@ -55,7 +55,7 @@ class MapPosition : public QObject
     void mapSettingsChanged( QgsQuickMapSettings * );
 
     void mapPositionChanged( QgsPoint );
-    void screenPositionChanged( QPointF );
+    void screenPositionChanged( QgsPointXY );
     void screenAccuracyChanged( double );
 
   public slots:
@@ -68,7 +68,7 @@ class MapPosition : public QObject
     void recalculateScreenAccuracy();
 
     QgsPoint mMapPosition;
-    QPointF mScreenPosition;
+    QgsPointXY mScreenPosition;
     double mScreenAccuracy = 2;
 
     PositionKit *mPositionKit = nullptr; // not owned

--- a/app/qml/StakeoutPanel.qml
+++ b/app/qml/StakeoutPanel.qml
@@ -107,7 +107,7 @@ Item {
 
     modal: false
     edge: Qt.BottomEdge
-
+    interactive: false // prevents closing by swiping the window down
     dragMargin: 0 // prevents opening the drawer by dragging.
     closePolicy: Popup.NoAutoClose
 

--- a/app/qml/form/PreviewPanel.qml
+++ b/app/qml/form/PreviewPanel.qml
@@ -27,13 +27,6 @@ Item {
     signal editClicked()
     signal stakeoutFeature( var feature )
 
-    Connections {
-      target: controller
-      onFeatureLayerPairChanged: {
-        stakeoutIconContainer.visible = __inputUtils.isPointLayerFeature( controller.featureLayerPair );
-      }
-    }
-
     MouseArea {
       anchors.fill: parent
       onClicked: {
@@ -77,31 +70,38 @@ Item {
                   }
 
                   Item {
-                      id: stakeoutIconContainer
-                      visible: __inputUtils.isPointLayerFeature( controller.featureLayerPair )
+                      id: stakeoutIconContainerSpace
                       height: rowHeight
                       width: rowHeight
 
-                      MouseArea {
-                          anchors.fill: stakeoutIconContainer
-                          onClicked: previewPanel.stakeoutFeature( controller.featureLayerPair )
-                      }
+                      Item {
+                        visible: __inputUtils.isPointLayerFeature( controller.featureLayerPair )
+                        enabled: visible
 
-                      Image {
-                          id: stakeoutIcon
-                          anchors.fill: parent
-                          anchors.margins: rowHeight/8
-                          anchors.rightMargin: 0
-                          source: InputStyle.stakeoutIcon
-                          sourceSize.width: width
-                          sourceSize.height: height
-                          fillMode: Image.PreserveAspectFit
-                      }
+                        anchors.fill: parent
 
-                      ColorOverlay {
-                          anchors.fill: stakeoutIcon
-                          source: stakeoutIcon
-                          color: InputStyle.fontColor
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: previewPanel.stakeoutFeature( controller.featureLayerPair )
+                        }
+
+                        Image {
+                            id: stakeoutIcon
+
+                            anchors.fill: parent
+                            anchors.margins: rowHeight/8
+                            anchors.rightMargin: 0
+                            source: InputStyle.stakeoutIcon
+                            sourceSize.width: width
+                            sourceSize.height: height
+                            fillMode: Image.PreserveAspectFit
+                        }
+
+                        ColorOverlay {
+                            anchors.fill: stakeoutIcon
+                            source: stakeoutIcon
+                            color: InputStyle.fontColor
+                        }
                       }
                   }
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -404,6 +404,9 @@ ApplicationWindow {
           formsStackManager.openForm( targetPair, "readOnly", "preview" )
           stakeoutPanelLoader.active = false
         }
+
+        onAutoFollowClicked: map.autoFollowStakeoutPath = true
+        onPanelHeightUpdated: map.updatePosition()
       }
     }
 

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -166,7 +166,7 @@ Item {
     {
       if ( root.autoFollowStakeoutPath )
       {
-        __inputUtils.setStakeoutPathExtent( _mapPosition, _stakeoutHighlight.destinationPair, _map.mapSettings, mapExtentOffset )
+        _map.mapSettings.extent = __inputUtils.stakeoutPathExtent( _mapPosition, _stakeoutHighlight.destinationPair, _map.mapSettings, mapExtentOffset )
       }
     }
     else if ( root.state === "view" )

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -166,7 +166,7 @@ Item {
     {
       if ( root.autoFollowStakeoutPath )
       {
-        __inputUtils.setStakeoutPathExtent( _mapPosition, _stakeoutHighlight.destinationPair, _map.mapSettings, _map.width, _map.height, mapExtentOffset, InputStyle.mapOutOfExtentBorder )
+        __inputUtils.setStakeoutPathExtent( _mapPosition, _stakeoutHighlight.destinationPair, _map.mapSettings, mapExtentOffset )
       }
     }
     else if ( root.state === "view" )

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -32,6 +32,7 @@ Item {
   readonly property alias compass: _compass
 
   property bool isInRecordState
+  property var extentBeforeStakeout
 
   signal featureIdentified( var pair )
   signal nothingIdentified()
@@ -177,6 +178,7 @@ Item {
   {
     _stakeoutHighlight.destinationPair = feature
     state = "stakeout"
+    root.extentBeforeStakeout = _map.mapSettings.extent
     stakeoutStarted( feature )
   }
 
@@ -186,7 +188,8 @@ Item {
     let pair = _stakeoutHighlight.destinationPair
     state = "view"
 
-    centerToPair( pair )
+    // return map extent to position it was before starting stakeout
+    _map.mapSettings.extent = root.extentBeforeStakeout
     highlightPair( pair )
     _stakeoutHighlight.destinationPair = null
   }

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -381,12 +381,12 @@ void TestUtilsFunctions::testStakeoutFeatureExtent()
 
   FeatureLayerPair pair( feature, &pointsLayer );
 
-  QgsRectangle rect = mUtils->stakeoutFeatureExtent( pair, gpsPos, &ms, 0 );
-  QgsRectangle acceptedExtent( 36.773085939, 3.059613648845, 36.7745297063, 3.06012863296 );
-  QCOMPARE( rect.xMinimum(), acceptedExtent.xMinimum() );
-  QCOMPARE( rect.yMinimum(), acceptedExtent.yMinimum() );
-  QCOMPARE( rect.xMaximum(), acceptedExtent.xMaximum() );
-  QCOMPARE( rect.yMaximum(), acceptedExtent.yMaximum() );
+//  QgsRectangle rect = mUtils->stakeoutFeatureExtent( pair, gpsPos, &ms, 0 );
+//  QgsRectangle acceptedExtent( 36.773085939, 3.059613648845, 36.7745297063, 3.06012863296 );
+//  QCOMPARE( rect.xMinimum(), acceptedExtent.xMinimum() );
+//  QCOMPARE( rect.yMinimum(), acceptedExtent.yMinimum() );
+//  QCOMPARE( rect.xMaximum(), acceptedExtent.xMaximum() );
+//  QCOMPARE( rect.yMaximum(), acceptedExtent.yMaximum() );
 }
 
 void TestUtilsFunctions::testDistanceBetweenGpsAndFeature()

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -568,3 +568,57 @@ void TestUtilsFunctions::testMapPointToGps()
     }
   }
 }
+
+void TestUtilsFunctions::testEquals()
+{
+  // Test different InputUtils::equals overloads
+
+  struct testcaseQPointF
+  {
+    QPointF a;
+    QPointF b;
+    qreal epsilon;
+    bool shouldEqual;
+  };
+
+  QVector<testcaseQPointF> testcasesQPointFs =
+  {
+    { QPointF(),             QPointF(),       0.001, true  },
+    { QPointF( 1, 1 ),       QPointF( 1, 1 ), 0.001, true  },
+    { QPointF( 1, 1 ),       QPointF(),       0.001, false },
+    { QPointF(),             QPointF( 1, 1 ), 0.001, false },
+    { QPointF( 0, -5 ),      QPointF( 0, 5 ), 0.1,   false },
+    { QPointF( 1.15005, 5 ), QPointF( 1.15, 5 ), 0.01,    true  },
+    { QPointF( 1.15005, 5 ), QPointF( 1.15, 5 ), 0.001,   true  },
+    { QPointF( 1.15005, 5 ), QPointF( 1.15, 5 ), 0.00001, false },
+  };
+
+  for ( const auto &test : testcasesQPointFs )
+  {
+    QCOMPARE( InputUtils::equals( test.a, test.b, test.epsilon ), test.shouldEqual );
+  }
+
+  struct testcaseQgsPointXY
+  {
+    QgsPointXY a;
+    QgsPointXY b;
+    qreal epsilon;
+    bool shouldEqual;
+  };
+
+  QVector<testcaseQgsPointXY> testcasesQgsPointXY =
+  {
+    { QgsPointXY(),        QgsPointXY(),        0.0001, true  },
+    { QgsPointXY(),        QgsPointXY( 1, 6 ),  0.0001, false },
+    { QgsPointXY( -5, 5 ), QgsPointXY(),        0.0001, false },
+    { QgsPointXY( -5, 5 ), QgsPointXY( -5, 5 ), 0.0001, true  },
+    { QgsPointXY( -5, 5 ), QgsPointXY( 5, 5 ),  0.1,    false },
+    { QgsPointXY( 1.15005, 5 ), QgsPointXY( 1.15, 5 ), 0.001,   true  },
+    { QgsPointXY( 1.15005, 5 ), QgsPointXY( 1.15, 5 ), 0.00001, false },
+  };
+
+  for ( const auto &test : testcasesQgsPointXY )
+  {
+    QCOMPARE( InputUtils::equals( test.a, test.b, test.epsilon ), test.shouldEqual );
+  }
+}

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -415,6 +415,34 @@ void TestUtilsFunctions::testStakeoutPathExtent()
     ms.setExtent( extent );
     QCOMPARE( ( int )ms.mapSettings().scale(), test.expectedScale );
   }
+
+  // Test stakeout distance2scale
+  struct testcaseDistance2Scale
+  {
+    qreal distance;
+    qreal expectedScale;
+  };
+
+  QVector<testcaseDistance2Scale> testcasesDistance2Scale =
+  {
+    { 150, 205 },
+    { 15, 205 },
+    { 10.1, 205 },
+    { 8, 105 },
+    { 4, 105 },
+    { 2, 55 },
+    { 1.5, 55 },
+    { 1.10320432, 55 },
+    { 0.9, 25 },
+    { 0.1, 25 },
+    { 0, 25 },
+    { -15, 25 }
+  };
+
+  for ( const auto &test : testcasesDistance2Scale )
+  {
+    COMPARENEAR( mUtils->distanceToScale( test.distance ), test.expectedScale, 0.1 );
+  }
 }
 
 void TestUtilsFunctions::testDistanceBetweenGpsAndFeature()

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -360,33 +360,59 @@ void TestUtilsFunctions::testExtractPointFromFeature()
   QCOMPARE( mUtils->extractPointFromFeature( pointPair ), QgsPointXY( 1, 2 ) );
 }
 
-void TestUtilsFunctions::testStakeoutFeatureExtent()
+void TestUtilsFunctions::testStakeoutPathExtent()
 {
-  QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromEpsgId( 6326 );
+  QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromEpsgId( 4326 );
 
   QgsQuickMapSettings ms;
   ms.setDestinationCrs( crs );
   ms.setExtent( QgsRectangle( 49, 16, 50, 17 ) );
-  ms.setOutputSize( QSize( 1000, 500 ) );
+  ms.setOutputSize( QSize( 400, 620 ) );
 
-  QgsPoint gpsPos( 36.77320625296759, 3.060085717615282 );
-  QgsPoint *point = new QgsPoint( 36.77440939232914, 3.0596565641869136 );
+  PositionKit positionKit;
+  positionKit.setPositionProvider( PositionKit::constructProvider( "internal", "simulated", "simulated" ) );
+  AbstractPositionProvider *provider = positionKit.positionProvider();
+
+  MapPosition mapPositioner;
+  mapPositioner.setMapSettings( &ms );
+  mapPositioner.setPositionKit( &positionKit );
 
   QgsVectorLayer pointsLayer( QStringLiteral( "point?crs=%1" ).arg( "EPSG:4326" ), "pointsLayer", "memory" );
 
+  QgsPoint *target = new QgsPoint( 47.48117696934868, 19.064282309621444 );
+
+  // We want to test if extent has correct scale and center
+  struct testcase {
+      QgsPoint gpsPosition;
+      QgsPoint expectedCenter;
+      int expectedScale;
+  };
+
+  QVector< testcase > testcases = {
+    { QgsPoint( 48.1141526157956, 17.267434685006886 ),  QgsPoint( 48.1141526157956, 17.267434685006886 ),  204 }, // far far away
+    { QgsPoint( 47.48127984125111, 19.064443912646784 ), QgsPoint( 47.48127984125111, 19.064443912646784 ), 204 }, // > 20m from target
+    { QgsPoint( 47.481122740577486, 19.06433009357165 ), QgsPoint( 47.481122740577486, 19.06433009357165 ), 105 }, // ~ 8m from target
+    { QgsPoint( 47.481185467, 19.064302897 ),            QgsPoint( 47.481185467, 19.064302897 ),            55  }, // ~ 2m from target
+    { QgsPoint( 47.481177379, 19.064283071 ),            QgsPoint( 47.48117696934868, 19.064282309621444 ), 25  }  // ~ 10cm from target
+  };
+
   QgsFeature feature;
   QgsGeometry geom;
-  geom.set( point );
+  geom.set( target );
   feature.setGeometry( geom );
 
   FeatureLayerPair pair( feature, &pointsLayer );
 
-//  QgsRectangle rect = mUtils->stakeoutFeatureExtent( pair, gpsPos, &ms, 0 );
-//  QgsRectangle acceptedExtent( 36.773085939, 3.059613648845, 36.7745297063, 3.06012863296 );
-//  QCOMPARE( rect.xMinimum(), acceptedExtent.xMinimum() );
-//  QCOMPARE( rect.yMinimum(), acceptedExtent.yMinimum() );
-//  QCOMPARE( rect.xMaximum(), acceptedExtent.xMaximum() );
-//  QCOMPARE( rect.yMaximum(), acceptedExtent.yMaximum() );
+  for ( const auto &test : testcases )
+  {
+    provider->setPosition( test.gpsPosition );
+    QgsRectangle extent = mUtils->stakeoutPathExtent( &mapPositioner, pair, &ms, 0 );
+
+    QVERIFY( mUtils->equals( extent.center(), test.expectedCenter ) );
+
+    ms.setExtent( extent );
+    QCOMPARE( (int)ms.mapSettings().scale(), test.expectedScale );
+  }
 }
 
 void TestUtilsFunctions::testDistanceBetweenGpsAndFeature()

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -382,13 +382,15 @@ void TestUtilsFunctions::testStakeoutPathExtent()
   QgsPoint *target = new QgsPoint( 47.48117696934868, 19.064282309621444 );
 
   // We want to test if extent has correct scale and center
-  struct testcase {
-      QgsPoint gpsPosition;
-      QgsPoint expectedCenter;
-      int expectedScale;
+  struct testcase
+  {
+    QgsPoint gpsPosition;
+    QgsPoint expectedCenter;
+    int expectedScale;
   };
 
-  QVector< testcase > testcases = {
+  QVector< testcase > testcases =
+  {
     { QgsPoint( 48.1141526157956, 17.267434685006886 ),  QgsPoint( 48.1141526157956, 17.267434685006886 ),  204 }, // far far away
     { QgsPoint( 47.48127984125111, 19.064443912646784 ), QgsPoint( 47.48127984125111, 19.064443912646784 ), 204 }, // > 20m from target
     { QgsPoint( 47.481122740577486, 19.06433009357165 ), QgsPoint( 47.481122740577486, 19.06433009357165 ), 105 }, // ~ 8m from target
@@ -411,7 +413,7 @@ void TestUtilsFunctions::testStakeoutPathExtent()
     QVERIFY( mUtils->equals( extent.center(), test.expectedCenter ) );
 
     ms.setExtent( extent );
-    QCOMPARE( (int)ms.mapSettings().scale(), test.expectedScale );
+    QCOMPARE( ( int )ms.mapSettings().scale(), test.expectedScale );
   }
 }
 

--- a/app/test/testutilsfunctions.h
+++ b/app/test/testutilsfunctions.h
@@ -35,7 +35,7 @@ class TestUtilsFunctions: public QObject
     void resolveTargetDir();
     void testDirSize();
     void testExtractPointFromFeature();
-    void testStakeoutFeatureExtent();
+    void testStakeoutPathExtent();
     void testDistanceBetweenGpsAndFeature();
     void testAngleBetweenGpsAndFeature();
     void testIsPointLayerFeature();

--- a/app/test/testutilsfunctions.h
+++ b/app/test/testutilsfunctions.h
@@ -40,6 +40,7 @@ class TestUtilsFunctions: public QObject
     void testAngleBetweenGpsAndFeature();
     void testIsPointLayerFeature();
     void testMapPointToGps();
+    void testEquals();
 
   private:
     void testFormatDuration( const QDateTime &t0, qint64 diffSecs, const QString &expectedResult );

--- a/qgsquick/plugin/qgsquickmapcanvas.qml
+++ b/qgsquick/plugin/qgsquickmapcanvas.qml
@@ -64,6 +64,10 @@ Item {
   //! Emitted when a release happens after a long press
   signal longPressReleased()
 
+  //! Emitted when user does some interaction with map canvas (pan, zoom)
+  //! This is helpful to determine whether the map extent changed programatically or by user interaction
+  signal userInteractedWithMap()
+
   /**
    * Freezes the map canvas refreshes.
    *
@@ -78,6 +82,8 @@ Item {
   function freeze(id) {
     mapCanvasWrapper.__freezecount[id] = true
     mapCanvasWrapper.freeze = true
+
+    userInteractedWithMap()
   }
 
   function unfreeze(id) {
@@ -329,6 +335,8 @@ Item {
       {
         zoomOut(point.position)
       }
+
+      userInteractedWithMap()
     }
   }
 }


### PR DESCRIPTION
Previous movement of map extent during stakeout was "very shaky". Extent have been unlimitedly zoomed in resulting in scales like 5mm or even smaller -> in that case even smallest change of gps position looked like movement of a 1 meter.

We are now moving extent based on conditions mentioned here: https://github.com/lutraconsulting/input/compare/stakeout-extent?expand=1#diff-7855d101d45d951847ae00d48eb0839f4cae76de50783fd4a4db4682b781e522R1334-R1341 Generally, we use distance between GPS and target point to determine the correct scale factor. We also do not zoom in more than 1:25 scale.

There were also several other issues fixed / enhancements:
 - in `PreviewPanel.qml` I removed redundant `Connections` component and  used property binding
 - in `PreviewPanel.qml` edit icon was shifted to the left when stakeout icon was invisible (for non-point layers)
 - in `MapPosition.cpp` I replaced use of QPointF with QgsPointXY. QPointF uses floats internally which led to other problems with floating point precision, mainly unterminated loops
 - Computation of map extent is moved to `MapWrapper`, it should not be anywhere else
 - Added signal to `qgsquickmapcanvas.qml` to be able to determine whether user iteracted with map

<table>
  <tr>
    <th>Previous</th>
    <th>New</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/22449698/154050802-672892d3-fd93-4136-b50d-cd73a25c0f99.gif" width="300"/></td>
    <td><img src="https://user-images.githubusercontent.com/22449698/154050794-fde1be96-bd64-4cf4-9866-450adc1c3b1b.gif"  width="300"/></td>
  </tr>
 </table>

There is a change to `qgsquickmapcanvas.qml` component (from qgs quick), created PR to QGIS: https://github.com/qgis/QGIS/pull/47364

#{23djxek}[Review]