### PR TITLE
Fix camera issue on Android 12

### DIFF
--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -110,7 +110,7 @@
     <!-- Camera permissions -->
     <uses-permission android:name="android.permission.CAMERA"/>
 
-    <!-- In order to target Android 12 (API LVL 31), uncomment this permission, it is used for orientation sensor! -->
+    <!-- Add the following permission when app should target Android 12 (API LVL 31), it is used for orientation sensor! -->
     <!-- <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/> -->
 
     <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.

--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -110,6 +110,9 @@
     <!-- Camera permissions -->
     <uses-permission android:name="android.permission.CAMERA"/>
 
+    <!-- In order to target Android 12 (API LVL 31), uncomment this permission, it is used for orientation sensor! -->
+    <!-- <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/> -->
+
     <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
          Remove the comment if you do not require these default features. -->
     <!-- %%INSERT_FEATURES -->
@@ -117,4 +120,12 @@
     <!-- Bluetooth feature - our app can run even without bluetooth -->
     <uses-feature android:name="android.hardware.bluetooth" android:required="false"/>
 
+    <uses-feature android:name="android.hardware.camera.any" android:required="false"/>
+
+    <!-- Explicitly mention that we need to use external app for capturing an image -->
+    <queries>
+      <intent>
+        <action android:name="android.media.action.IMAGE_CAPTURE" />
+      </intent>
+    </queries>
 </manifest>

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 


### PR DESCRIPTION
Android introduced property `queries` in manifest that should contain information about our use of external applications. It is called `Package visibility`. As we did not declare it, they disabled our access to device's camera.

In order to use the new `queries` keyword **we needed to update Gradle version** to new point release that Google released for [this use case](https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html).

In the end the issue had nothing to do with `HIGH_SAMPLING_RATE_SENSORS` permission. However, on Android 12, sensor `TYPE_MAGNETIC_FIELD` (we use it in `OrientationSensor.java` to determine orientation when taking a photo) does not allow us to read data like we read it now (ASAP). 

_One more thing to note: Updating Gradle creates a mismatch between our and Qt 5.14.2's Gradle version. It is a difference only in point release_ 

Read more:
https://developer.android.com/training/package-visibility
https://developer.android.com/training/package-visibility/declaring
https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html
https://stackoverflow.com/questions/67455534/how-to-add-queries-declaration-in-the-manifest-for-using-camera

Fixes #1904 