### PR TITLE
Add missing languages to ios

### DIFF
--- a/app/ios/Info.plist
+++ b/app/ios/Info.plist
@@ -45,11 +45,18 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
+		<string>fi</string>
+		<string>et</string>
 		<string>es</string>
 		<string>fr</string>
+		<string>ko</string>
+		<string>sl</string>
 		<string>zh</string>
 		<string>he</string>
 		<string>zh_CN</string>
+		<string>uk_UA</string>
+		<string>ru_RU</string>
+		<string>nl</string>
         	<string>de</string>
        		<string>it</string>
         	<string>pl</string>


### PR DESCRIPTION
Updated list of translated languages in `Info.plist` based on current list of translated languages in `i18n/input_i18n.qrc`: https://github.com/lutraconsulting/input/blob/a4a0dbf4942db0240f70b1696bd8d803d7931ca1/app/i18n/input_i18n.qrc