### PR TITLE
Unique user for autotests

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,15 +29,6 @@ jobs:
   macos_build:
     if: ( github.repository == 'lutraconsulting/input' ) && (!contains(github.event.head_commit.message, 'Translate '))
     runs-on: macos-10.15
-    # Set concurrency to this job so that there will be only one workflow instance
-    # running throughout all branches. This limitation can be removed once we
-    # solve https://github.com/lutraconsulting/input/issues/902 - have unique
-    # user for each run of tests. Until then we can run only one instance of tests
-    # at a time - concurrent runs could (and often does) harm each others state,
-    # resulting in failed autotests. There will be a maximum of two runs
-    # accepted - one will run and the other will be set as pending (wait until
-    # the first one finishes). Other runs are automatically canceled if there are two runs already.
-    concurrency: ci-autotests
     steps:
       - name: Checkout Input
         uses: actions/checkout@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,8 +15,6 @@ on:
 
 env:
   TEST_MERGIN_URL: https://test.dev.cloudmergin.com/
-  TEST_API_USERNAME: test_inputapp
-  TEST_API_PASSWORD: ${{ secrets.MERGINTEST_API_PASSWORD }}
   QT_VERSION: 5.14.2
   QMAKE_MACOSX_DEPLOYMENT_TARGET: 10.15.0
   INPUT_SDK_VERSION: mac-20220212-62

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -214,7 +214,7 @@ void TestMerginApi::testDownloadProjectSpecChars()
 
   // create an empty project on the server
   QSignalSpy spy( mApi, &MerginApi::projectCreated );
-  mApi->createProject( projectNamespace, projectName );
+  mApi->createProject( projectNamespace, projectName, true );
   QVERIFY( spy.wait( TestUtils::SHORT_REPLY ) );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toBool(), true );
@@ -251,7 +251,7 @@ void TestMerginApi::createRemoteProject( MerginApi *api, const QString &projectN
 {
   // create a project
   QSignalSpy spy( api, &MerginApi::projectCreated );
-  api->createProject( projectNamespace, projectName );
+  api->createProject( projectNamespace, projectName, true );
   QVERIFY( spy.wait( TestUtils::SHORT_REPLY ) );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toBool(), true );
@@ -340,7 +340,7 @@ void TestMerginApi::testCreateProjectTwice()
   QVERIFY( !_findProjectByName( projectNamespace, projectName, projects ).isValid() );
 
   QSignalSpy spy( mApi, &MerginApi::projectCreated );
-  mApi->createProject( projectNamespace, projectName );
+  mApi->createProject( projectNamespace, projectName, true );
   QVERIFY( spy.wait( TestUtils::SHORT_REPLY ) );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toBool(), true );
@@ -353,7 +353,7 @@ void TestMerginApi::testCreateProjectTwice()
 
   // Create again, expecting error
   QSignalSpy spy2( mApi, &MerginApi::networkErrorOccurred );
-  mApi->createProject( projectNamespace, projectName );
+  mApi->createProject( projectNamespace, projectName, true );
   QVERIFY( spy2.wait( TestUtils::SHORT_REPLY ) );
   QCOMPARE( spy2.count(), 1 );
 
@@ -401,7 +401,7 @@ void TestMerginApi::testCreateDeleteProject()
   QVERIFY( !_findProjectByName( projectNamespace, projectName, projects ).isValid() );
 
   QSignalSpy spy( mApi, &MerginApi::projectCreated );
-  mApi->createProject( projectNamespace, projectName );
+  mApi->createProject( projectNamespace, projectName, true );
   QVERIFY( spy.wait( TestUtils::SHORT_REPLY ) );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toBool(), true );
@@ -429,7 +429,7 @@ void TestMerginApi::testUploadProject()
   QString projectDir = mApi->projectsPath() + "/" + projectName;
 
   QSignalSpy spy0( mApiExtra, &MerginApi::projectCreated );
-  mApiExtra->createProject( projectNamespace, projectName );
+  mApiExtra->createProject( projectNamespace, projectName, true );
   QVERIFY( spy0.wait( TestUtils::LONG_REPLY ) );
   QCOMPARE( spy0.count(), 1 );
   QCOMPARE( spy0.takeFirst().at( 1 ).toBool(), true );

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -46,9 +46,8 @@ TestMerginApi::TestMerginApi( MerginApi *api )
 void TestMerginApi::initTestCase()
 {
   QString apiRoot, username, password;
-  TestUtils::mergin_auth( apiRoot, username, password );
+  TestUtils::mergin_auth( mApi, apiRoot, username, password );
 
-  mApi->setApiRoot( apiRoot );
   QSignalSpy spy( mApi, &MerginApi::authChanged );
   mApi->authorize( username, password );
   QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );

--- a/app/test/testpurchasing.cpp
+++ b/app/test/testpurchasing.cpp
@@ -56,9 +56,8 @@ void TestPurchasing::runPurchasingCommand( TestingPurchasingBackend::NextPurchas
 void TestPurchasing::initTestCase()
 {
   QString apiRoot, username, password;
-  TestUtils::mergin_auth( apiRoot, username, password );
+  TestUtils::mergin_auth( mApi, apiRoot, username, password );
 
-  mApi->setApiRoot( apiRoot );
   QSignalSpy spy( mApi, &MerginApi::authChanged );
   mApi->authorize( username, password );
   QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );

--- a/app/test/testutils.h
+++ b/app/test/testutils.h
@@ -12,13 +12,19 @@
 
 #include <QString>
 #include <qtestcase.h>
+#include "merginapi.h"
 
 namespace TestUtils
 {
   const int SHORT_REPLY = 5000;
   const int LONG_REPLY = 70000;
 
-  void mergin_auth( QString &apiRoot, QString &username, QString &password );
+  // Use credentials from env variables if they are set, otherwise register new user and set its credentials to env var
+  void mergin_auth( MerginApi *api, QString &apiRoot, QString &username, QString &password );
+
+  QString generateUsername();
+  QString generatePassword();
+
   QString testDataDir();
 
   /**

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -782,7 +782,7 @@ QString MerginApi::resetPasswordUrl()
   return QString();
 }
 
-void MerginApi::createProject( const QString &projectNamespace, const QString &projectName )
+void MerginApi::createProject( const QString &projectNamespace, const QString &projectName, bool isPublic )
 {
   if ( !validateAuthAndContinute() || mApiVersionStatus != MerginApiStatus::OK )
   {
@@ -801,7 +801,7 @@ void MerginApi::createProject( const QString &projectNamespace, const QString &p
   QJsonDocument jsonDoc;
   QJsonObject jsonObject;
   jsonObject.insert( QStringLiteral( "name" ), projectName );
-  jsonObject.insert( QStringLiteral( "public" ), false );
+  jsonObject.insert( QStringLiteral( "public" ), isPublic );
   jsonDoc.setObject( jsonObject );
   QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
 

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -340,11 +340,12 @@ class MerginApi: public QObject
     Q_INVOKABLE static QString getFullProjectName( QString projectNamespace, QString projectName );
 
     /**
-    * Creates an empty project on Mergin server.
+    * Creates an empty project on Mergin server. isPublic determines if the new project will be visible to all or private
     * \param projectNamespace
     * \param projectName
+    * \param isPublic
     */
-    void createProject( const QString &projectNamespace, const QString &projectName );
+    void createProject( const QString &projectNamespace, const QString &projectName, bool isPublic = false );
 
     // Test functions
     /**


### PR DESCRIPTION
PR makes auto tests fine to run in parallel by adding a unique user that is used during auto tests.

Autotests can now be used in two ways:
  1. We either pass env variables as we used before - in this case Input will use the provided credentials, or
  2. Do not pass credentials via env variables - in this case Input will register new unique user and fills its credentials to env var

I also made all test projects public, so that we have easier access to them if something goes wrong

Resolves #902 

#23dnz99[Review]