### PR TITLE
Fix replaced lat/long in GPS data panel

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -246,10 +246,12 @@ QString InputUtils::degreesString( const QgsPoint &point )
 {
   if ( point.isEmpty() )
   {
-    return QStringLiteral();
+    return QLatin1String();
   }
 
-  return QGeoCoordinate( point.x(), point.y() ).toString( QGeoCoordinate::DegreesMinutesWithHemisphere );
+  // QGeoCoordinate formatter uses lat/long order, but we (and QGIS) use long/lat order,
+  // so here we need to first pass y and then x.
+  return QGeoCoordinate( point.y(), point.x() ).toString( QGeoCoordinate::DegreesMinutesWithHemisphere );
 }
 
 double InputUtils::convertRationalNumber( const QString &rationalValue )

--- a/app/qml/misc/GpsDataPage.qml
+++ b/app/qml/misc/GpsDataPage.qml
@@ -142,7 +142,7 @@ Item {
 
               let coordParts = root.coordinatesInDegrees.split(", ")
               if ( coordParts.length > 1 )
-                return coordParts[0]
+                return coordParts[1]
 
               return qsTr( "N/A" )
             }
@@ -161,7 +161,7 @@ Item {
 
               let coordParts = root.coordinatesInDegrees.split(", ")
               if ( coordParts.length > 1 )
-                return coordParts[1]
+                return coordParts[0]
 
               return qsTr( "N/A" )
             }


### PR DESCRIPTION
`QGeoCoordinate::toString` function takes input in order `(lat, long)` which is different than in QGIS (and Input too) - `(long,lat)`.

![Screenshot 2022-02-22 at 14 15 31](https://user-images.githubusercontent.com/22449698/155139759-1d387bc2-cb12-4774-943b-1ead1cb0b609.png)

Good catch @jozef-budac!!

#26mg000[review]
Closes #1960 