### PR TITLE
Trigger repaint for empty geometry of guideline path

### DIFF
--- a/app/qml/map/Highlight.qml
+++ b/app/qml/map/Highlight.qml
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -201,13 +201,16 @@ Item {
     guideLine.pathElements = newGuideLineElements
   }
 
-  onFeatureLayerPairChanged: { // highlighting features
-    constructHighlights()
-  }
+  onFeatureLayerPairChanged: constructHighlights()
 
   onGuideLineAllowedChanged: constructHighlights()
 
-  onPositionChanged: constructHighlights()
+  onPositionChanged: {
+    if ( highlight.recordingInProgress )
+    {
+      constructHighlights()
+    }
+  }
 
   // keeps list of currently displayed marker items (an internal property)
   property var markerItems: []

--- a/app/qml/map/Highlight.qml
+++ b/app/qml/map/Highlight.qml
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -187,12 +187,14 @@ Item {
       }
     }
 
-    // reset shapes
+    // trigger repaint for empty geometries
     markerItems = markerItems.map( function (marker) { return marker.destroy() } )
     if ( newLineElements.length === 0 )
       newLineElements.push( componentMoveTo.createObject( lineShapePath ) )
     if ( newPolygonElements.length === 0 )
       newPolygonElements.push( componentMoveTo.createObject( polygonShapePath ) )
+    if ( newGuideLineElements.length === 0 )
+      newGuideLineElements.push( componentMoveTo.createObject( guideLine ) )
 
     markerItems = newMarkerItems
     polygonShapePath.pathElements = newPolygonElements


### PR DESCRIPTION
In #1950 I removed the entire `updateGuideline` function as we moved to a different handling of transformations in `Highlight.qml`.

However, I forgot to add a piece of code that triggers repaint of QML shape when the geometry is empty. Here: https://github.com/lutraconsulting/input/commit/59ed5f89ee45d5031fbae19725073a6eab7ab6a2#diff-c1350d1e69584b4f380f7721e2721f360b8f1417f9b94629abfd240dfd3df883L94-L98

Thus, the issue was that QML shape responsible for painting guideline did not repaint itself when it received empty geometry (newGuideLineElements was empty).

I have also added a little optimization - we do not need to reconstruct highlight when position changed in _NOT_ recording state. It is used only in guideline and that is visible only when we are in recording state.

Closes #1958 