### PR TITLE
Fix autotests - use created projects instead of all public projects

### DIFF
--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -132,12 +132,8 @@ void TestMerginApi::testListProject()
 {
   QString projectName = "testListProject";
 
-  // check that there's no hello world project
-  QSignalSpy spy0( mApi, &MerginApi::listProjectsFinished );
-  mApi->listProjects( QString() );
-  QVERIFY( spy0.wait( TestUtils::SHORT_REPLY ) );
-  QCOMPARE( spy0.count(), 1 );
-  MerginProjectsList projects = projectListFromSpy( spy0 );
+  // check that there's no testListProject
+  MerginProjectsList projects = getProjectList();
 
   QVERIFY( !_findProjectByName( mUsername, projectName, projects ).isValid() );
   QVERIFY( !mApi->localProjectsManager().projectFromMerginName( mUsername, projectName ).isValid() );
@@ -146,11 +142,7 @@ void TestMerginApi::testListProject()
   createRemoteProject( mApiExtra, mUsername, projectName, mTestDataPath + "/" + TEST_PROJECT_NAME + "/" );
 
   // check the project exists on the server
-  QSignalSpy spy( mApi, &MerginApi::listProjectsFinished );
-  mApi->listProjects( QString() );
-  QVERIFY( spy.wait( TestUtils::SHORT_REPLY ) );
-  QCOMPARE( spy.count(), 1 );
-  projects = projectListFromSpy( spy );
+  projects = getProjectList();
 
   QVERIFY( _findProjectByName( mUsername, projectName, projects ).isValid() );
 


### PR DESCRIPTION
`testListProject` has been using listProjects API without tag `created` which returned all public projects created on test server. This was fine when we had only one test user. Created project was always found in the first 50 public projects on the server (50 due to a pagination).

However, with #1953 each user creates tens of projects, so now the created project was not in the returned list (it would be on some other page).

I changed the test so that it queries only `created` projects of the current user - it is like this in other tests too.