### PR TITLE
Add missing notify property

### DIFF
--- a/app/inputhelp.h
+++ b/app/inputhelp.h
@@ -35,7 +35,7 @@ class InputHelp: public QObject
     Q_PROPERTY( QString howToSetupProj READ howToSetupProj NOTIFY linkChanged )
     Q_PROPERTY( QString gpsAccuracyHelpLink READ gpsAccuracyHelpLink NOTIFY linkChanged )
     Q_PROPERTY( QString howToConnectGPSLink READ howToConnectGPSLink NOTIFY linkChanged )
-    Q_PROPERTY( QString merginTermsLink READ merginTermsLink )
+    Q_PROPERTY( QString merginTermsLink READ merginTermsLink NOTIFY linkChanged )
 
     //! When adding new link, make sure you also create unit test for it in TestLinks
 


### PR DESCRIPTION
We had this issue in the console:
```
QQmlExpression: Expression qrc:/RegistrationForm.qml:214:9 depends on non-NOTIFYable properties:
    InputHelp::merginTermsLink
```

`merginTermsLink` property was missing a required signal when its value changes. It must be there even though it is a constant value. 