### PR TITLE
Handle expired token in listProjectsByName API call

### DIFF
--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -157,13 +157,11 @@ void TestMerginApi::testListProjectsByName()
   createRemoteProject( mApiExtra, mUsername, projectName, mTestDataPath + "/" + TEST_PROJECT_NAME + "/" );
 
   // let's invalidate main client's auth token and see if the listProjectsByName gets new one
-  QDateTime now = QDateTime::currentDateTimeUtc();
+  // set token's expiration to 3 secs ago
+  QDateTime now = QDateTime::currentDateTimeUtc().addSecs( -3 );
   mApi->userAuth()->setTokenExpiration( now );
 
   QByteArray oldToken = mApi->userAuth()->authToken();
-
-  // wait for 3 seconds so that the token expires
-  QTest::qSleep( 3000 );
 
   QStringList projects;
   projects.append( MerginApi::getFullProjectName( mUsername, projectName ) );

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -37,6 +37,7 @@ class TestMerginApi: public QObject
     void cleanupTestCase();
 
     void testListProject();
+    void testListProjectsByName();
     void testDownloadProject();
     void testDownloadProjectSpecChars();
     void testCancelDownloadProject();

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -121,6 +121,15 @@ QString MerginApi::listProjects( const QString &searchExpression, const QString 
 
 QString MerginApi::listProjectsByName( const QStringList &projectNames )
 {
+  if ( mApiVersionStatus != MerginApiStatus::OK )
+  {
+    emit listProjectsFailed();
+    return QLatin1String();
+  }
+
+  // Authentification is optional in this case, as there might be public projects without the need to be logged in
+  validateAuthAndContinute();
+
   // construct JSON body
   QJsonDocument body;
   QJsonObject projects;
@@ -1087,7 +1096,7 @@ bool MerginApi::validateAuthAndContinute()
   if ( mUserAuth->authToken().isEmpty() || mUserAuth->tokenExpiration() < QDateTime().currentDateTime().toUTC() )
   {
     authorize( mUserAuth->username(), mUserAuth->password() );
-
+    CoreUtils::log( QStringLiteral( "MerginApi" ), QStringLiteral( "Requesting authorization because of missing or expired token." ) );
     mAuthLoopEvent.exec();
   }
   return true;


### PR DESCRIPTION
Calling `listProjectsByName` API was missing a check for auth token expiration. 
When token was expired, server returned for private projects 401, which in Input was understood as user without sufficient rights and did not allow user to sync the project.

I also added check for API status - it is in all other calls too.

Resolves #1499 