### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ on:
     - '.github/workflows/linux.yml'
 
   release:
-    types
+    types:
       - published
 
 env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,7 +11,7 @@ on:
 
   release:
     types:
-      - published
+      -   published
 
 env:
   CCACHE_DIR: ~/.ccache

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,8 +10,8 @@ on:
     - '.github/workflows/linux.yml'
 
   release:
-    types:
-      -          published
+    types
+      - published
 
 env:
   CCACHE_DIR: ~/.ccache

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,7 +11,7 @@ on:
 
   release:
     types:
-      -   published
+      -          published
 
 env:
   CCACHE_DIR: ~/.ccache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     rev: v3.2.0
     hooks:
     -   id: check-yaml
+        types: [yaml]
 
 -   repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,12 @@ repos:
     rev: v3.2.0
     hooks:
     -   id: check-yaml
+
+-   repo: local
+    hooks:
+    -   id: check-cpp
+        name: 'Check CPP formatting with astyle'
+        entry: './scripts/astyle.bash'
+        language: script
+        types_or: [c++, objective-c++]
+        files: ^(app|core|qgsquick)/

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -16,3 +16,4 @@ Other topics:
 - [Publishing](./publishing.md)
 - [Testing](./manual_test_plan.md)
 - [Secrets](./secrets.md)
+- [Code formatting](./code_formatting.md) 

--- a/docs/developers/code_formatting.md
+++ b/docs/developers/code_formatting.md
@@ -1,0 +1,13 @@
+# Code formatting
+
+We are using `astyle` to format CPP and Objective-C files.
+Format is similar to what QGIS have.
+
+We also use software [pre-commit](https://pre-commit.com/) to automatically check format when doing a commit.
+You need to install it via `brew`/`pip`, see [installation details](https://pre-commit.com/#installation).
+
+In order to start using the `pre-commit`, run `pre-commit install` in the repository root folder.
+
+To manually run the style check, run `pre-commit run --all-files` or optionally run script `format_cpp.sh` (we use this one in CI currently).
+
+In case you want to skip execution of pre-commit hooks, add additional flag `--no-verify` to your commit command, e.g.: `git commit -m "nit" --no-verify`

--- a/scripts/format_cpp.bash
+++ b/scripts/format_cpp.bash
@@ -5,5 +5,5 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PWD=`pwd`
 cd $DIR
-./astyle.bash `find ../client ../core ../app ../qgsquick -name \*.mm* -print -o -name \*.h* -print -o -name \*.c* -print`
+./astyle.bash `find ../core ../app ../qgsquick -name \*.mm* -print -o -name \*.h* -print -o -name \*.c* -print`
 cd $PWD


### PR DESCRIPTION
I wanted to add our `format_cpp.sh` script as pre-commit hook, but I came across this cool software called [pre-commit](https://pre-commit.com/#installation). It utilizes different pre-commit hooks and let's you easily set them up via yaml configs.

There are tons of already created hooks (https://pre-commit.com/hooks.html) we can try to add (in future). I tried the `check-yaml` and it seems to work fine.

I added docs so that anyone else can install it, but it is trivial actually - just `brew`/`pip` install and then one command: `pre-commit install` in the repo root.

![image](https://user-images.githubusercontent.com/22449698/157858427-dd679b30-e653-426d-92e9-113473501ed4.png)
