### PR TITLE
fix issue when listprojectsbyname asks for login

### DIFF
--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -582,6 +582,10 @@ class MerginApi: public QObject
     //! Removes temp folder for project
     void removeProjectsTempFolder( const QString &projectNamespace, const QString &projectName );
 
+    //! Refreshes auth token if it is expired. It does a blocking call to authorize.
+    //! Works only when login, password and token is set in UserAuth
+    void refreshAuthToken();
+
     QNetworkRequest getDefaultRequest( bool withAuth = true );
 
     bool projectFileHasBeenUpdated( const ProjectDiff &diff );


### PR DESCRIPTION
In last sprint we fixed an issue with expired token in `ListProjectsByName` API.
This fix, however, did not only refresh the expired token, but also opted user to log in when his/her credentials were not set (not logged in).
Now it really just refreshes the token is auth data are set.

Before fix:

https://user-images.githubusercontent.com/22449698/158348713-940270cb-dd7b-4111-8a00-1613c95efb79.mp4

Now with fix it does not happen :)
