### PR TITLE
Let ListProjectsByName API call not opt for credentials

### DIFF
--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -127,8 +127,10 @@ QString MerginApi::listProjectsByName( const QStringList &projectNames )
     return QLatin1String();
   }
 
-  // Authentification is optional in this case, as there might be public projects without the need to be logged in
-  validateAuthAndContinute();
+  // Authentification is optional in this case, as there might be public projects without the need to be logged in.
+  // We only want to include auth token when user is logged in.
+  // User's token, however, might have already expired, so let's just refresh it.
+  refreshAuthToken();
 
   // construct JSON body
   QJsonDocument body;
@@ -2725,6 +2727,22 @@ MerginProjectsList MerginApi::parseProjectsFromJson( const QJsonDocument &doc )
   return result;
 }
 
+void MerginApi::refreshAuthToken()
+{
+  if ( !mUserAuth->hasAuthData() ||
+       mUserAuth->authToken().isEmpty() )
+  {
+    CoreUtils::log( QStringLiteral( "Auth" ), QStringLiteral( "Can not refresh token, insufficient credentials" ) );
+    return;
+  }
+
+  if ( mUserAuth->tokenExpiration() < QDateTime::currentDateTimeUtc() )
+  {
+    CoreUtils::log( QStringLiteral( "Auth" ), QStringLiteral( "Token has expired, requesting new one" ) );
+    authorize( mUserAuth->username(), mUserAuth->password() );
+    mAuthLoopEvent.exec();
+  }
+}
 
 QStringList MerginApi::generateChunkIdsForSize( qint64 fileSize )
 {

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -2732,7 +2732,7 @@ void MerginApi::refreshAuthToken()
   if ( !mUserAuth->hasAuthData() ||
        mUserAuth->authToken().isEmpty() )
   {
-    CoreUtils::log( QStringLiteral( "Auth" ), QStringLiteral( "Can not refresh token, insufficient credentials" ) );
+    CoreUtils::log( QStringLiteral( "Auth" ), QStringLiteral( "Can not refresh token, missing credentials" ) );
     return;
   }
 

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -578,6 +578,10 @@ class MerginApi: public QObject
     //! Removes temp folder for project
     void removeProjectsTempFolder( const QString &projectNamespace, const QString &projectName );
 
+    //! Refreshes auth token if it is expired. It does a blocking call to authorize.
+    //! Works only when login, password and token is set in UserAuth
+    void refreshAuthToken();
+
     QNetworkRequest getDefaultRequest( bool withAuth = true );
 
     bool projectFileHasBeenUpdated( const ProjectDiff &diff );


### PR DESCRIPTION
In last sprint we fixed an issue with expired token in `ListProjectsByName` API.
This fix, however, did not only refresh the expired token, but also opted user to log in when his/her credentials were not set (not logged in).
Now it really just refreshes the token is auth data are set.

Before fix:

https://user-images.githubusercontent.com/22449698/158348713-940270cb-dd7b-4111-8a00-1613c95efb79.mp4

Now with fix it does not happen :)
