### PR TITLE
QRCode autofocus & ability to scan the same code twice

### DIFF
--- a/app/codefilter.cpp
+++ b/app/codefilter.cpp
@@ -73,23 +73,12 @@ CodeFilter::CodeFilter()
 {
   mDecoder = std::shared_ptr<QRDecoder>( new QRDecoder );
 
-  QObject::connect( mDecoder.get(), &QRDecoder::capturedChanged, this, &CodeFilter::setCapturedData );
+  QObject::connect( mDecoder.get(), &QRDecoder::capturedText, this, &CodeFilter::dataCaptured );
 }
 
 QVideoFilterRunnable *CodeFilter::createFilterRunnable()
 {
   return new QRRunnable( this );
-}
-
-QString CodeFilter::capturedData()
-{
-  return mCapturedData;
-}
-
-void CodeFilter::setCapturedData( const QString &newValue )
-{
-  mCapturedData = newValue;
-  emit capturedDataChanged();
 }
 
 bool CodeFilter::isDecoding() const

--- a/app/codefilter.h
+++ b/app/codefilter.h
@@ -23,12 +23,11 @@
 class CodeFilter : public QAbstractVideoFilter
 {
     Q_OBJECT
-    Q_PROPERTY( QString capturedData READ capturedData NOTIFY capturedDataChanged )
     Q_PROPERTY( bool isDecoding READ isDecoding NOTIFY isDecodingChanged )
+
   public:
     CodeFilter();
 
-    QString capturedData();
     bool isDecoding() const;
     std::shared_ptr<QRDecoder> decoder() const;
     QFuture<void> futureThread() const;
@@ -42,14 +41,10 @@ class CodeFilter : public QAbstractVideoFilter
     QVideoFilterRunnable *createFilterRunnable() override;
 
   signals:
-    void capturedDataChanged();
+    void dataCaptured( const QString &data );
     void isDecodingChanged( bool isDecoding );
 
-  private slots:
-    void setCapturedData( const QString &capturedData );
-
   private:
-    QString mCapturedData;
     bool mIsDecoding;
     std::shared_ptr<QRDecoder> mDecoder = nullptr;
     QFuture<void> mFutureThread;

--- a/app/qml/CodeReader.qml
+++ b/app/qml/CodeReader.qml
@@ -32,8 +32,8 @@ Drawer {
   CodeFilter {
     id: zxingFilter
 
-    onCapturedDataChanged: {
-      codeReader.scanFinished(capturedData)
+    onDataCaptured: {
+      codeReader.scanFinished( data )
       camera.cameraState = Camera.UnloadedState
       codeReaderTimer.start()
     }

--- a/app/qml/CodeReader.qml
+++ b/app/qml/CodeReader.qml
@@ -41,10 +41,12 @@ Drawer {
 
   Camera {
     id: camera
-    onDeviceIdChanged: {
-      focus.focusMode = CameraFocus.FocusContinuous
-      focus.focusPointMode = CameraFocus.FocusPointAuto
+
+    focus {
+        focusMode: Camera.FocusContinuous
+        focusPointMode: Camera.FocusPointAuto
     }
+
     cameraState: Camera.UnloadedState
     onError: __inputUtils.showNotificationRequested(errorString)
   }

--- a/app/qrdecoder.cpp
+++ b/app/qrdecoder.cpp
@@ -80,22 +80,6 @@ QRDecoder::QRDecoder( QObject *parent ) : QObject( parent )
 
 }
 
-QString QRDecoder::captured() const
-{
-  return _captured;
-}
-
-void QRDecoder::setCaptured( QString captured )
-{
-  if ( _captured == captured )
-  {
-    return;
-  }
-
-  _captured = captured;
-  emit capturedChanged( _captured );
-}
-
 void QRDecoder::setIsDecoding( bool isDecoding )
 {
   if ( _isDecoding == isDecoding )
@@ -131,7 +115,7 @@ void QRDecoder::process( const QImage capturedImage )
 
   if ( result.isValid() )
   {
-    setCaptured( result.text() );
+    emit capturedText( result.text() );
   }
 
   setIsDecoding( false );

--- a/app/qrdecoder.h
+++ b/app/qrdecoder.h
@@ -12,8 +12,8 @@
 class QRDecoder : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY( QString captured READ captured WRITE setCaptured NOTIFY capturedChanged )
     Q_PROPERTY( bool isDecoding READ isDecoding WRITE setIsDecoding NOTIFY isDecodingChanged )
+
   public:
     explicit QRDecoder( QObject *parent = nullptr );
     QString captured() const;
@@ -29,16 +29,14 @@ class QRDecoder : public QObject
     void process( const QImage capturedImage );
 
   signals:
-    void capturedChanged( QString captured );
+    void capturedText( QString capturedText );
     void isDecodingChanged( bool isDecoding );
 
   private:
-    QString _captured = "";
     QOpenGLContext *_ctx;
     bool _isDecoding = false;
     QVideoFrame _videoFrame;
 
-    void setCaptured( QString captured );
     void setIsDecoding( bool isDecoding );
 };
 


### PR DESCRIPTION
PR fixes two things:
 1. Fixes QRCode autofocus - it was there, but not enabled
 2. Fixes / Adds ability to scan the same code twice in a row. There was a `Q_PROPERTY` that did not signalize its change (as the new scanned value was the same one as previous). I changed this to simple signal emission that we listen to in QML called `dataCaptured( data )`


https://user-images.githubusercontent.com/22449698/159451861-8693ed64-78b3-45d9-a936-0b217009b7f2.mp4


Resolves #1949 
Resolves #1647 