### PR TITLE
elide project name from the left side to keep project name more readable (fix #1996)

### DIFF
--- a/app/qml/components/ProjectDelegateItem.qml
+++ b/app/qml/components/ProjectDelegateItem.qml
@@ -164,7 +164,7 @@ Rectangle {
                else root.secondaryColor
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignBottom
-        elide: Text.ElideRight
+        elide: Text.ElideLeft
       }
 
       Text {


### PR DESCRIPTION
Some users/organisations have long names. This results in non-readable project names on small screens, as the names are eldided from the right side. To make project names more readable better to elide their names from the left.

Fixes #1996.

Before
![image](https://user-images.githubusercontent.com/776954/160097783-1a01d648-8c63-4fc0-8ad4-934ad42e22d2.png)
After
![image](https://user-images.githubusercontent.com/776954/160097823-8f068a05-b423-4a86-a33f-26a86862d2e5.png)
