### PR TITLE
Add script to check if info.plist contains all translated langs

### DIFF
--- a/app/ios/Info.plist
+++ b/app/ios/Info.plist
@@ -46,16 +46,23 @@
 	<array>
 		<string>en</string>
 		<string>fi</string>
+		<string>fi_FI</string>
 		<string>et</string>
+		<string>et_EE</string>
 		<string>es</string>
+		<string>es_ES</string>
 		<string>fr</string>
+		<string>fr_FR</string>
 		<string>ko</string>
+		<string>ko_KR</string>
 		<string>sl</string>
+		<string>sl_SI</string>
 		<string>zh</string>
 		<string>he</string>
 		<string>zh_CN</string>
 		<string>uk_UA</string>
 		<string>ru_RU</string>
+		<string>pt_BR</string>
 		<string>nl</string>
         	<string>de</string>
        		<string>it</string>

--- a/scripts/check_ios_translations.py
+++ b/scripts/check_ios_translations.py
@@ -5,7 +5,6 @@ import plistlib
 import xml.etree.ElementTree as ET
 
 if len(sys.argv) != 3:
-    print(sys.argv)
     print("Wrong args, correct run: check_ios_translation INFOPLIST_PATH INPUTI18N_QRC_PATH")
     exit(1)
 

--- a/scripts/check_ios_translations.py
+++ b/scripts/check_ios_translations.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import sys
+import plistlib
+import xml.etree.ElementTree as ET
+
+if len(sys.argv) != 3:
+    print(sys.argv)
+    print("Wrong args, correct run: check_ios_translation INFOPLIST_PATH INPUTI18N_QRC_PATH")
+    exit(1)
+
+infoplistpath = sys.argv[1]
+input18npath = sys.argv[2]
+
+# parse info plist
+ioslangs = []
+
+with open(infoplistpath, "rb") as f:
+    plistdata = plistlib.load(f)
+    ioslangs = plistdata['CFBundleLocalizations']
+
+# parse input_i18n.qrc (xml)
+i18nlangs = []
+rcc = ET.parse(input18npath).getroot()
+
+for lang in rcc.findall('qresource/file'):
+    i18nlangs.append(lang.text)
+
+# convert i18n langs to ios format, e.g. 'input_es.qm' -> 'es'
+i18nlangs = list(
+    map(
+        lambda l: l.split('.qm')[0],
+        map(
+            lambda la: la.split('input_')[1],
+            i18nlangs
+        )
+    )
+)
+
+# find missing langs
+missinglangs = [lang for lang in i18nlangs if lang not in ioslangs]
+
+if len(missinglangs) == 0:
+    print("Success, all languages are in info.plist")
+    exit(0)
+else:
+    print("Failure, Info.plist is missing languages:", missinglangs)
+    exit(1)


### PR DESCRIPTION
We have way too many translations to check if Info.plist contains all of them manually. 
PR adds script `scripts/check_ios_translations.py` that goes via `input_i18n.qrc` languages and finds those that are missing in `Info.plist` file.

Run it like `scripts/check_ios_translations.py PATH_TO_INFOPLIST PATH_TO_INPUT18N_QRC`

Would be good to add this script to CI in future. Related to #1966