### PR TITLE
clear render cache and refresh canvas after sync (fix #2007) + QgsQuick update

### DIFF
--- a/.github/workflows/qgsquick.yml
+++ b/.github/workflows/qgsquick.yml
@@ -12,7 +12,7 @@ on:
       - published
 
 env:
-  QGIS_COMMIT_HASH: df3695aa85ed5eaa3071befa8f20e7a383473b43
+  QGIS_COMMIT_HASH: 2a0e3748b1dce677870480734937f7f0b8bdc0bd
 
 jobs:
   qgsquick_up_to_date:

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -303,7 +303,7 @@ Item {
       case "inactive": {
         break
       }
-    }    
+    }
   }
 
   state: "view"
@@ -710,6 +710,8 @@ Item {
           {
             // just banner
             syncSuccessfulBanner.show()
+            // refresh canvas
+            _map.refresh()
           }
         }
       }

--- a/qgsquick/plugin/qgsquickmapcanvas.qml
+++ b/qgsquick/plugin/qgsquickmapcanvas.qml
@@ -65,7 +65,6 @@ Item {
   signal longPressReleased()
 
   //! Emitted when user does some interaction with map canvas (pan, zoom)
-  //! This is helpful to determine whether the map extent changed programatically or by user interaction
   signal userInteractedWithMap()
 
   /**

--- a/qgsquick/plugin/qgsquickmapcanvas.qml
+++ b/qgsquick/plugin/qgsquickmapcanvas.qml
@@ -99,6 +99,11 @@ Item {
     mapCanvasWrapper.zoom(point, 1.5)
   }
 
+  function refresh() {
+    mapCanvasWrapper.clearCache()
+    mapCanvasWrapper.refresh()
+  }
+
   QgsQuick.MapCanvasMap {
     id: mapCanvasWrapper
 

--- a/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/qgsquick/qgsquickmapcanvasmap.cpp
@@ -424,3 +424,9 @@ void QgsQuickMapCanvasMap::refresh()
   if ( !mFreeze )
     mRefreshTimer.start( 1 );
 }
+
+void QgsQuickMapCanvasMap::clearCache()
+{
+  if ( mCache )
+    mCache->clear();
+}

--- a/qgsquick/qgsquickmapcanvasmap.h
+++ b/qgsquick/qgsquickmapcanvasmap.h
@@ -166,6 +166,11 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
      */
     void refresh();
 
+    /**
+     * Clears rendering cache
+     */
+    void clearCache();
+
   private slots:
     void refreshMap();
     void renderJobUpdated();

--- a/qgsquick/qgsquickmapcanvasmap.h
+++ b/qgsquick/qgsquickmapcanvasmap.h
@@ -172,9 +172,10 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
     void clearCache();
 
   private slots:
-    void refreshMap();
+    void refreshMap( bool silent = false );
     void renderJobUpdated();
     void renderJobFinished();
+    void layerRepaintRequested( bool deferred );
     void onWindowChanged( QQuickWindow *window );
     void onScreenChanged( QScreen *screen );
     void onExtentChanged();
@@ -204,6 +205,7 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
     QList<QMetaObject::Connection> mLayerConnections;
     QTimer mMapUpdateTimer;
     bool mIncrementalRendering = false;
+    bool mDeferredRefreshPending = false;
 
     QQuickWindow *mWindow = nullptr;
 };


### PR DESCRIPTION
Without this user needs to pan/zoom canvas to see new/deleted features after sync.

Fixes #2007.