### PR TITLE
add special handling for the names of the conflicted files for QGIS project files

### DIFF
--- a/app/test/testcoreutils.cpp
+++ b/app/test/testcoreutils.cpp
@@ -42,7 +42,9 @@ void TestCoreUtils::testConflictFileNames()
     { "/home/test/geo.gpkg", "", 10, "/home/test/geo (conflicted copy,  v10).gpkg" },
     { "/home/test/geo.gpkg", "jack", -1, "/home/test/geo (conflicted copy, jack v-1).gpkg" },
     { "/home/test/geo.tar.gz", "jack", 100, "/home/test/geo (conflicted copy, jack v100).tar.gz" },
-    { "", "jack", 1, "" }
+    { "", "jack", 1, "" },
+    { "/home/test/survey.qgs", "jack", 10, "/home/test/survey (conflicted copy, jack v10).qgs~" },
+    { "/home/test/survey.QGZ", "jack", 10, "/home/test/survey (conflicted copy, jack v10).QGZ~" }
   };
 
   for ( const auto &c : testcasesCopyConflicts )

--- a/app/test/testcoreutils.cpp
+++ b/app/test/testcoreutils.cpp
@@ -154,9 +154,9 @@ void TestCoreUtils::testFindUniquePath()
   }
 }
 
-void TestCoreUtils::testHasProjecFileExtension()
+void TestCoreUtils::testHasProjectFileExtension()
 {
-  QVERIFY( CoreUtils::hasProjecFileExtension( QStringLiteral( "project.qgs" ) ) );
-  QVERIFY( CoreUtils::hasProjecFileExtension( QStringLiteral( "project.QGZ" ) ) );
-  QVERIFY( !CoreUtils::hasProjecFileExtension( QStringLiteral( "project.qg" ) ) );
+  QVERIFY( CoreUtils::hasProjectFileExtension( QStringLiteral( "project.qgs" ) ) );
+  QVERIFY( CoreUtils::hasProjectFileExtension( QStringLiteral( "project.QGZ" ) ) );
+  QVERIFY( !CoreUtils::hasProjectFileExtension( QStringLiteral( "project.qg" ) ) );
 }

--- a/app/test/testcoreutils.cpp
+++ b/app/test/testcoreutils.cpp
@@ -153,3 +153,10 @@ void TestCoreUtils::testFindUniquePath()
     QCOMPARE( foundPath, projectPath + "/" + c.expectedOutput );
   }
 }
+
+void TestCoreUtils::testHasProjecFileExtension()
+{
+  QVERIFY( CoreUtils::hasProjecFileExtension( QStringLiteral( "project.qgs" ) ) );
+  QVERIFY( CoreUtils::hasProjecFileExtension( QStringLiteral( "project.QGZ" ) ) );
+  QVERIFY( !CoreUtils::hasProjecFileExtension( QStringLiteral( "project.qg" ) ) );
+}

--- a/app/test/testcoreutils.h
+++ b/app/test/testcoreutils.h
@@ -22,6 +22,7 @@ class TestCoreUtils : public QObject
 
     void testConflictFileNames();
     void testFindUniquePath();
+    void testHasProjecFileExtension();
 };
 
 #endif // TESTCOREUTILS_H

--- a/app/test/testcoreutils.h
+++ b/app/test/testcoreutils.h
@@ -22,7 +22,7 @@ class TestCoreUtils : public QObject
 
     void testConflictFileNames();
     void testFindUniquePath();
-    void testHasProjecFileExtension();
+    void testHasProjectFileExtension();
 };
 
 #endif // TESTCOREUTILS_H

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -214,7 +214,12 @@ QString CoreUtils::generateConflictedCopyFileName( const QString &file, const QS
 
   QFileInfo f( file );
 
-  return QString( "%1/%2 (conflicted copy, %3 v%4).%5" ).arg( f.path(), f.baseName(), username, QString::number( version ), f.completeSuffix() );
+  QString suffix = f.completeSuffix();
+  if ( !suffix.compare( QStringLiteral( "qgs" ), Qt::CaseInsensitive ) || !suffix.compare( QStringLiteral( "qgz" ), Qt::CaseInsensitive ) )
+  {
+    suffix += "~";
+  }
+  return QString( "%1/%2 (conflicted copy, %3 v%4).%5" ).arg( f.path(), f.baseName(), username, QString::number( version ), suffix );
 }
 
 QString CoreUtils::generateEditConflictFileName( const QString &file, const QString &username, int version )

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -215,7 +215,7 @@ QString CoreUtils::generateConflictedCopyFileName( const QString &file, const QS
   QFileInfo f( file );
 
   QString suffix = f.completeSuffix();
-  if ( !suffix.compare( QStringLiteral( "qgs" ), Qt::CaseInsensitive ) || !suffix.compare( QStringLiteral( "qgz" ), Qt::CaseInsensitive ) )
+  if ( hasProjecFileExtension( file ) )
   {
     suffix += "~";
   }
@@ -229,4 +229,9 @@ QString CoreUtils::generateEditConflictFileName( const QString &file, const QStr
 
   QFileInfo f( file );
   return QString( "%1/%2 (edit conflict, %3 v%4).json" ).arg( f.path(), f.baseName(), username, QString::number( version ) );
+}
+
+bool CoreUtils::hasProjecFileExtension( const QString filePath )
+{
+  return filePath.contains( ".qgs", Qt::CaseInsensitive ) || filePath.contains( ".qgz", Qt::CaseInsensitive );
 }

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -215,7 +215,7 @@ QString CoreUtils::generateConflictedCopyFileName( const QString &file, const QS
   QFileInfo f( file );
 
   QString suffix = f.completeSuffix();
-  if ( hasProjecFileExtension( file ) )
+  if ( hasProjectFileExtension( file ) )
   {
     suffix += "~";
   }
@@ -231,7 +231,7 @@ QString CoreUtils::generateEditConflictFileName( const QString &file, const QStr
   return QString( "%1/%2 (edit conflict, %3 v%4).json" ).arg( f.path(), f.baseName(), username, QString::number( version ) );
 }
 
-bool CoreUtils::hasProjecFileExtension( const QString filePath )
+bool CoreUtils::hasProjectFileExtension( const QString filePath )
 {
   return filePath.contains( ".qgs", Qt::CaseInsensitive ) || filePath.contains( ".qgz", Qt::CaseInsensitive );
 }

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -79,6 +79,9 @@ class CoreUtils
      */
     static void log( const QString &topic, const QString &info );
 
+    //! Checks whether file path has a QGIS project suffix (qgs or qgz)
+    static bool hasProjecFileExtension( const QString filePath );
+
   private:
     static QString sLogFile;
     static void appendLog( const QByteArray &data, const QString &path );

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -80,7 +80,7 @@ class CoreUtils
     static void log( const QString &topic, const QString &info );
 
     //! Checks whether file path has a QGIS project suffix (qgs or qgz)
-    static bool hasProjecFileExtension( const QString filePath );
+    static bool hasProjectFileExtension( const QString filePath );
 
   private:
     static QString sLogFile;

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -223,13 +223,13 @@ bool MerginApi::projectFileHasBeenUpdated( const ProjectDiff &diff )
 {
   for ( QString filePath : diff.remoteAdded )
   {
-    if ( CoreUtils::hasProjecFileExtension( filePath ) )
+    if ( CoreUtils::hasProjectFileExtension( filePath ) )
       return true;
   }
 
   for ( QString filePath : diff.remoteUpdated )
   {
-    if ( CoreUtils::hasProjecFileExtension( filePath ) )
+    if ( CoreUtils::hasProjectFileExtension( filePath ) )
       return true;
   }
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -223,22 +223,17 @@ bool MerginApi::projectFileHasBeenUpdated( const ProjectDiff &diff )
 {
   for ( QString filePath : diff.remoteAdded )
   {
-    if ( hasProjecFileExtension( filePath ) )
+    if ( CoreUtils::hasProjecFileExtension( filePath ) )
       return true;
   }
 
   for ( QString filePath : diff.remoteUpdated )
   {
-    if ( hasProjecFileExtension( filePath ) )
+    if ( CoreUtils::hasProjecFileExtension( filePath ) )
       return true;
   }
 
   return false;
-}
-
-bool MerginApi::hasProjecFileExtension( const QString filePath )
-{
-  return filePath.contains( ".qgs" ) || filePath.contains( ".qgz" );
 }
 
 bool MerginApi::supportsSelectiveSync() const

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -604,8 +604,6 @@ class MerginApi: public QObject
 
     bool projectFileHasBeenUpdated( const ProjectDiff &diff );
 
-    bool hasProjecFileExtension( const QString filePath );
-
     QNetworkAccessManager mManager;
     QString mApiRoot;
     LocalProjectsManager &mLocalProjects;


### PR DESCRIPTION
As discussed in https://github.com/lutraconsulting/qgis-mergin-plugin/issues/382 add `~` at the end of the conflicted copy if this is a QGIS project file.