### PR TITLE
Add delete account functionality (fix #1896)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
       CCACHE_DIR: /Users/runner/work/ccache
       GITHUB_TOKEN: ${{ secrets.INPUTAPP_BOT_GITHUB_TOKEN }}
       INPUTKEYSTORE_STOREPASS: ${{ secrets.INPUTKEYSTORE_STOREPASS }}
-      CACHE_VERSION: 0
+      CACHE_VERSION: 1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -21,7 +21,7 @@ env:
   XC_VERSION: ${{ '13.2.1' }}
   IOS_MIN_SDK_VERSION: ${{ '14.0' }}
   CCACHE_DIR: /Users/runner/work/ccache
-  CACHE_VERSION: 0
+  CACHE_VERSION: 1
 
 concurrency:
   group: ci-${{github.ref}}-ios

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,7 +19,7 @@ env:
   QMAKE_MACOSX_DEPLOYMENT_TARGET: 10.15.0
   INPUT_SDK_VERSION: mac-20220422-69
   CCACHE_DIR: /Users/runner/work/ccache
-  CACHE_VERSION: 0
+  CACHE_VERSION: 1
 
 concurrency:
   group: ci-${{github.ref}}-macos

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -326,14 +326,15 @@ Page {
       visible: false
       title: qsTr( "Delete account?" )
 
-      ColumnLayout {
+      contentItem: ColumnLayout {
         id: column
         width: parent.width
         Label {
           id: label
-          text: qsTr("This will remove all local projects from the device and your Mergin Maps account." +
-                     "If you have an Apple subscription you should cancel it manually.\n\n" +
-                     "To continue enter your username in the field below and click Yes.")
+          text: qsTr("This action will delete your Mergin Maps account with all your projects, " +
+                     "both on the device and on the server. This action cannot be undone." +
+                     "If you have an Apple subscription you need to cancel it manually.\n\n" +
+                     "In order to delete your account, enter your username in the field below and click Yes.")
           Layout.fillWidth: true
           wrapMode: Text.WordWrap
         }

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -10,6 +10,8 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtGraphicalEffects 1.14
+import QtQuick.Layouts 1.12
+import QtQuick.Dialogs 1.3 as Dialogs
 import lc 1.0
 import "."  // import InputStyle singleton
 import "./components"
@@ -19,6 +21,7 @@ Page {
   signal managePlansClicked
   signal signOutClicked
   signal restorePurchasesClicked
+  signal accountDeleted
   property color bgColor: "white"
   property real fieldHeight: InputStyle.rowHeight
 
@@ -303,6 +306,8 @@ Page {
             color: root.bgColor
           }
 
+          onClicked: accountDeleteDialog.open()
+
           contentItem: Text {
             text: deleteAccountButton.text
             font: deleteAccountButton.font
@@ -313,6 +318,68 @@ Page {
           }
         }
 
+      }
+    }
+
+    Dialog {
+      id: accountDeleteDialog
+      visible: false
+      title: qsTr( "Delete account?" )
+
+      ColumnLayout {
+        id: column
+        width: parent.width
+        Label {
+          id: label
+          text: qsTr("This will remove all local projects from the device and your Mergin Maps account." +
+                     "If you have an Apple subscription you should cancel it manually.\n\n" +
+                     "To continue enter your username in the field below and click Yes.")
+          Layout.fillWidth: true
+          wrapMode: Text.WordWrap
+        }
+        TextField {
+          id: usernameField
+          placeholderText: qsTr("Enter username")
+          Layout.fillWidth: true
+          onTextEdited: {
+            buttons.standardButton(Dialog.Yes).enabled = (text == username)
+          }
+        }
+      }
+
+      footer: DialogButtonBox {
+        id: buttons
+        standardButtons: Dialog.Yes | Dialog.No
+      }
+
+      onAboutToShow: {
+        buttons.standardButton(Dialog.Yes).enabled = false;
+      }
+
+      onAboutToHide: {
+        usernameField.clear()
+      }
+
+      onAccepted: {
+         close()
+      }
+      onRejected: {
+        close()
+      }
+    }
+
+    Dialogs.MessageDialog {
+      id: accountDeletionFailedDialog
+
+      property string messageText
+
+      visible: false
+      title: qsTr( "Failed to remove account" )
+      text: messageText
+      icon: StandardIcon.Warning
+      standardButtons: StandardButton.Close
+      onRejected: {
+        close()
       }
     }
   }

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -361,6 +361,7 @@ Page {
       }
 
       onAccepted: {
+         __merginApi.deleteAccount()
          close()
       }
       onRejected: {
@@ -376,10 +377,33 @@ Page {
       visible: false
       title: qsTr( "Failed to remove account" )
       text: messageText
-      icon: StandardIcon.Warning
-      standardButtons: StandardButton.Close
+      icon: Dialogs.StandardIcon.Warning
+      standardButtons: Dialogs.StandardButton.Close
       onRejected: {
         close()
+        accountDeleted()
+      }
+    }
+
+    Connections {
+      target: __merginApi
+
+      onUserIsAnOrgOwner: {
+        console.log("Can not close account because user is the only owner of organisation.")
+        accountDeletionFailedDialog.messageText = qsTr("Can not close account because user is the only owner of organisation.\n\n" +
+                                                       "Please go to the Mergin Maps <a href='%1'>dashboard</a> to remove it manually.".arg(__merginApi.apiRoot()))
+        accountDeletionFailedDialog.open()
+      }
+      onAccountDeleted: {
+        console.log("Account removal ", result)
+        if ( result ) {
+            accountDeleted()
+        }
+        else {
+          console.log("Failed to remove account")
+          accountDeletionFailedDialog.messageText = qsTr( "Failed to remove account" )
+          accountDeletionFailedDialog.open()
+        }
       }
     }
   }

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -10,7 +10,7 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtGraphicalEffects 1.14
-import QtQuick.Layouts 1.12
+import QtQuick.Layouts 1.14
 import QtQuick.Dialogs 1.3 as Dialogs
 import lc 1.0
 import "."  // import InputStyle singleton

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -388,7 +388,7 @@ Page {
     Connections {
       target: __merginApi
 
-      onUserIsAnOrgOwner: {
+      onUserIsAnOrgOwnerError: {
         console.log("Can not close account because user is the only owner of organisation.")
         accountDeletionFailedDialog.messageText = qsTr("Can not close account because user is the only owner of organisation.\n\n" +
                                                        "Please go to the Mergin Maps <a href='%1'>dashboard</a> to remove it manually.".arg(__merginApi.apiRoot()))

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -324,15 +324,19 @@ Page {
     Dialog {
       id: accountDeleteDialog
       visible: false
+      modal: true
+      spacing: InputStyle.panelSpacing
+      anchors.centerIn: parent
+      leftMargin: InputStyle.panelMargin
+      rightMargin: InputStyle.panelMargin
       title: qsTr( "Delete account?" )
 
       contentItem: ColumnLayout {
         id: column
-        width: parent.width
         Label {
           id: label
           text: qsTr("This action will delete your Mergin Maps account with all your projects, " +
-                     "both on the device and on the server. This action cannot be undone." +
+                     "both on the device and on the server. This action cannot be undone. " +
                      "If you have an Apple subscription you need to cancel it manually.\n\n" +
                      "In order to delete your account, enter your username in the field below and click Yes.")
           Layout.fillWidth: true

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -366,8 +366,9 @@ Page {
       }
 
       onAccepted: {
-         __merginApi.deleteAccount()
          close()
+         accountDeleteIndicator.running = true
+         __merginApi.deleteAccount()
       }
       onRejected: {
         close()
@@ -390,15 +391,27 @@ Page {
       }
     }
 
+    BusyIndicator {
+      id: accountDeleteIndicator
+      width: root.width/8
+      height: width
+      running: false
+      visible: running
+      anchors.centerIn: parent
+      z: root.z + 1
+    }
+
     Connections {
       target: __merginApi
 
       onUserIsAnOrgOwnerError: {
+        accountDeleteIndicator.running = false
         accountDeletionFailedDialog.messageText = qsTr("Can not close account because user is the only owner of organisation.\n\n" +
                                                        "Please go to the Mergin Maps <a href='%1'>dashboard</a> to remove it manually.".arg(__merginApi.apiRoot()))
         accountDeletionFailedDialog.open()
       }
       onAccountDeleted: {
+        accountDeleteIndicator.running = false
         if ( result ) {
             accountDeleted()
         }

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -259,35 +259,61 @@ Page {
     // Footer
     Item {
       id: footer
-      height: InputStyle.rowHeight
+      height: InputStyle.rowHeight * 2
       width: parent.width
       anchors.bottom: parent.bottom
       anchors.horizontalCenter: parent.horizontalCenter
 
-      Button {
-        id: signOutButton
-        height: InputStyle.rowHeightHeader
-        text: qsTr("Sign out")
-        font.pixelSize: InputStyle.fontPixelSizeNormal
-        font.bold: true
+      Column {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
-        background: Rectangle {
-          color: root.bgColor
+        spacing: 5
+
+        Button {
+          id: signOutButton
+          height: InputStyle.rowHeightHeader
+          text: qsTr("Sign out")
+          font.pixelSize: InputStyle.fontPixelSizeNormal
+          font.bold: true
+          anchors.horizontalCenter: parent.horizontalCenter
+          background: Rectangle {
+            color: root.bgColor
+          }
+
+          onClicked: signOutClicked()
+
+          contentItem: Text {
+            text: signOutButton.text
+            font: signOutButton.font
+            color: InputStyle.highlightColor
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+          }
         }
 
-        onClicked: signOutClicked()
+        Button {
+          id: deleteAccountButton
+          height: InputStyle.rowHeightHeader
+          text: qsTr("Delete account")
+          font.pixelSize: InputStyle.fontPixelSizeNormal
+          font.bold: true
+          anchors.horizontalCenter: parent.horizontalCenter
+          background: Rectangle {
+            color: root.bgColor
+          }
 
-        contentItem: Text {
-          text: signOutButton.text
-          font: signOutButton.font
-          color: InputStyle.highlightColor
-          horizontalAlignment: Text.AlignHCenter
-          verticalAlignment: Text.AlignVCenter
-          elide: Text.ElideRight
+          contentItem: Text {
+            text: deleteAccountButton.text
+            font: deleteAccountButton.font
+            color: InputStyle.invalidButtonColor
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+          }
         }
+
       }
     }
   }
 }
-

--- a/app/qml/AccountPage.qml
+++ b/app/qml/AccountPage.qml
@@ -389,18 +389,15 @@ Page {
       target: __merginApi
 
       onUserIsAnOrgOwnerError: {
-        console.log("Can not close account because user is the only owner of organisation.")
         accountDeletionFailedDialog.messageText = qsTr("Can not close account because user is the only owner of organisation.\n\n" +
                                                        "Please go to the Mergin Maps <a href='%1'>dashboard</a> to remove it manually.".arg(__merginApi.apiRoot()))
         accountDeletionFailedDialog.open()
       }
       onAccountDeleted: {
-        console.log("Account removal ", result)
         if ( result ) {
             accountDeleted()
         }
         else {
-          console.log("Failed to remove account")
           accountDeletionFailedDialog.messageText = qsTr( "Failed to remove account" )
           accountDeletionFailedDialog.open()
         }

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -29,7 +29,7 @@ Item {
 
   function openPanel() {
     root.visible = true
-    stackView.visible = true  
+    stackView.visible = true
     getServiceInfo() // ensure attention banner status is refreshed
   }
 
@@ -548,7 +548,6 @@ Item {
         __purchasing.restore()
       }
       onAccountDeleted: {
-        console.log("DELETE ACCOUNT - OK!")
         stackView.popOnePageOrClose()
         root.resetView()
       }

--- a/app/qml/ProjectPanel.qml
+++ b/app/qml/ProjectPanel.qml
@@ -547,6 +547,11 @@ Item {
       onRestorePurchasesClicked: {
         __purchasing.restore()
       }
+      onAccountDeleted: {
+        console.log("DELETE ACCOUNT - OK!")
+        stackView.popOnePageOrClose()
+        root.resetView()
+      }
     }
   }
 

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2488,7 +2488,7 @@ void TestMerginApi::testAccountDelete()
   // now delete user
   QSignalSpy spyDelete( mApi,  &MerginApi::accountDeleted );
   mApi->deleteAccount();
-  QVERIFY( spy.wait( TestUtils::SHORT_REPLY ) );
+  QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
   QList<QVariant> arguments = spyDelete.takeFirst();
   QVERIFY( arguments.at( 0 ).toBool() == true );
 }

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2450,12 +2450,10 @@ void TestMerginApi::testAutosyncFailure()
   // Will be added with incremental requests
 }
 
-void TestMerginApi::testRegister()
+void TestMerginApi::testRegisterAndDelete()
 {
   QString password = mApi->userAuth()->password();
 
-  // we do not have a method to delete existing user in the mApi, so for now just make sure
-  // the name does not exists
   QString quiteRandom = CoreUtils::uuidWithoutBraces( QUuid::createUuid() ).right( 15 ).replace( "-", "" );
   QString username = "test_" + quiteRandom;
   QString email = username + "@nonexistant.email.com";
@@ -2467,28 +2465,16 @@ void TestMerginApi::testRegister()
   QSignalSpy spy( mApi,  &MerginApi::registrationSucceeded );
   mApi->registerUser( username, email, password, password, true );
   QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
-}
 
-void TestMerginApi::testAccountDelete()
-{
-  QString password = mApi->userAuth()->password();
-
-  // create random user
-  QString quiteRandom = CoreUtils::uuidWithoutBraces( QUuid::createUuid() ).right( 15 ).replace( "-", "" );
-  QString username = "test_" + quiteRandom;
-  QString email = username + "@nonexistant.email.com";
-
-  // do not want to be authorized
-  mApi->clearAuth();
-
-  QSignalSpy spy( mApi,  &MerginApi::registrationSucceeded );
-  mApi->registerUser( username, email, password, password, true );
-  QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
+  mApi->authorize( username, password );
+  int i = 0;
+  while ( !mApi->userAuth()->hasAuthData() && i++ < 50 )
+    QTest::qWait( 250 );
 
   // now delete user
   QSignalSpy spyDelete( mApi,  &MerginApi::accountDeleted );
   mApi->deleteAccount();
-  QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
+  QVERIFY( spyDelete.wait( TestUtils::LONG_REPLY ) );
   QList<QVariant> arguments = spyDelete.takeFirst();
   QVERIFY( arguments.at( 0 ).toBool() == true );
 }

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2466,10 +2466,9 @@ void TestMerginApi::testRegisterAndDelete()
   mApi->registerUser( username, email, password, password, true );
   QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
 
+  QSignalSpy spyAuth( mApi->userAuth(),  &MerginUserAuth::authChanged );
   mApi->authorize( username, password );
-  int i = 0;
-  while ( !mApi->userAuth()->hasAuthData() && i++ < 50 )
-    QTest::qWait( 250 );
+  QVERIFY( spyAuth.wait( TestUtils::LONG_REPLY * 5 ) );
 
   // now delete user
   QSignalSpy spyDelete( mApi,  &MerginApi::accountDeleted );

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2478,7 +2478,6 @@ void TestMerginApi::testAccountDelete()
   QString username = "test_" + quiteRandom;
   QString email = username + "@nonexistant.email.com";
 
-  qDebug() << "username:" << username;
   // do not want to be authorized
   mApi->clearAuth();
 

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2488,7 +2488,7 @@ void TestMerginApi::testAccountDelete()
   // now delete user
   QSignalSpy spyDelete( mApi,  &MerginApi::accountDeleted );
   mApi->deleteAccount();
-  QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
+  QVERIFY( spy.wait( TestUtils::SHORT_REPLY ) );
   QList<QVariant> arguments = spyDelete.takeFirst();
   QVERIFY( arguments.at( 0 ).toBool() == true );
 }

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2469,6 +2469,31 @@ void TestMerginApi::testRegister()
   QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
 }
 
+void TestMerginApi::testAccountDelete()
+{
+  QString password = mApi->userAuth()->password();
+
+  // create random user
+  QString quiteRandom = CoreUtils::uuidWithoutBraces( QUuid::createUuid() ).right( 15 ).replace( "-", "" );
+  QString username = "test_" + quiteRandom;
+  QString email = username + "@nonexistant.email.com";
+
+  qDebug() << "username:" << username;
+  // do not want to be authorized
+  mApi->clearAuth();
+
+  QSignalSpy spy( mApi,  &MerginApi::registrationSucceeded );
+  mApi->registerUser( username, email, password, password, true );
+  QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
+
+  // now delete user
+  QSignalSpy spyDelete( mApi,  &MerginApi::accountDeleted );
+  mApi->deleteAccount();
+  QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
+  QList<QVariant> arguments = spyDelete.takeFirst();
+  QVERIFY(arguments.at(0).toBool() == true);
+}
+
 void TestMerginApi::testExcludeFromSync()
 {
   // Set selective sync directory

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2491,7 +2491,7 @@ void TestMerginApi::testAccountDelete()
   mApi->deleteAccount();
   QVERIFY( spy.wait( TestUtils::LONG_REPLY ) );
   QList<QVariant> arguments = spyDelete.takeFirst();
-  QVERIFY(arguments.at(0).toBool() == true);
+  QVERIFY( arguments.at( 0 ).toBool() == true );
 }
 
 void TestMerginApi::testExcludeFromSync()

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -80,6 +80,7 @@ class TestMerginApi: public QObject
     void testAutosyncFailure();
 
     void testRegister();
+    void testAccountDelete();
 
     // mergin functions
     void testExcludeFromSync();

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -79,8 +79,7 @@ class TestMerginApi: public QObject
     void testAutosync();
     void testAutosyncFailure();
 
-    void testRegister();
-    void testAccountDelete();
+    void testRegisterAndDelete();
 
     // mergin functions
     void testExcludeFromSync();

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -3042,7 +3042,7 @@ void MerginApi::deleteAccountFinished()
     CoreUtils::log( "delete account " + mUserAuth->username(), QStringLiteral( "FAILED - %1. %2" ).arg( r->errorString(), serverMsg ) );
     if ( statusCode == 422 )
     {
-      emit userIsAnOrgOwner();
+      emit userIsAnOrgOwnerError();
     }
     else
     {

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -3002,22 +3002,11 @@ QSet<QString> MerginApi::listFiles( const QString &path )
 
 void MerginApi::deleteAccount()
 {
-  qDebug() << "CALLED deleteAccount";
-
-  // delete account itself
   if ( !validateAuth() || mApiVersionStatus != MerginApiStatus::OK )
   {
     return;
   }
 
-  // first remove all local projects from the device
-  LocalProjectsList projects = mLocalProjects.projects();
-  for ( const LocalProject &info : projects )
-  {
-    mLocalProjects.removeLocalProject( info.id() );
-  }
-
-  // then remove account itself
   QNetworkRequest request = getDefaultRequest();
   QUrl url( mApiRoot + QStringLiteral( "/v1/user" ) );
   request.setUrl( url );
@@ -3034,6 +3023,16 @@ void MerginApi::deleteAccountFinished()
   if ( r->error() == QNetworkReply::NoError )
   {
     CoreUtils::log( "delete account " + mUserAuth->username(), QStringLiteral( "Success" ) );
+
+    // remove all local projects from the device
+    LocalProjectsList projects = mLocalProjects.projects();
+    for ( const LocalProject &info : projects )
+    {
+      mLocalProjects.removeLocalProject( info.id() );
+    }
+
+    clearAuth();
+
     emit accountDeleted( true );
   }
   else
@@ -3053,7 +3052,6 @@ void MerginApi::deleteAccountFinished()
     emit accountDeleted( false );
   }
 
-  clearAuth();
   r->deleteLater();
 }
 

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -327,6 +327,11 @@ class MerginApi: public QObject
     */
     Q_INVOKABLE void detachProjectFromMergin( const QString &projectNamespace, const QString &projectName, bool informUser = true );
 
+    /**
+    * Deletes all local projects and then tries to remove user account.
+    */
+    Q_INVOKABLE void deleteAccount();
+
     static const int MERGIN_API_VERSION_MAJOR = 2020;
     static const int MERGIN_API_VERSION_MINOR = 4;
     static const QString sMetadataFile;
@@ -485,6 +490,8 @@ class MerginApi: public QObject
 
     void projectAlreadyOnLatestVersion( const QString &projectFullName );
     void missingAuthorizationError( const QString &projectFullName );
+    void accountDeleted( bool result );
+    void userIsAnOrgOwner();
 
   private slots:
     void listProjectsReplyFinished( QString requestId );
@@ -510,6 +517,8 @@ class MerginApi: public QObject
     void authorizeFinished();
     void registrationFinished( const QString &username = QStringLiteral(), const QString &password = QStringLiteral() );
     void pingMerginReplyFinished();
+    void deleteAccountFinished();
+
     /**
      * @brief When plan has been changed, an extra userInfo request is needed to update also storage.
      * Calls user info only when has authData, otherwise slots catches the signal from clearing user data after signing out.

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -491,7 +491,7 @@ class MerginApi: public QObject
     void projectAlreadyOnLatestVersion( const QString &projectFullName );
     void missingAuthorizationError( const QString &projectFullName );
     void accountDeleted( bool result );
-    void userIsAnOrgOwner();
+    void userIsAnOrgOwnerError();
 
   private slots:
     void listProjectsReplyFinished( QString requestId );


### PR DESCRIPTION
Add button to the Account page allowing user to remove Mergin Maps account.
![зображення](https://user-images.githubusercontent.com/776954/167840689-e006eadf-b3d9-4e67-bcb6-6b18bb2e3354.png)
When account removal requested user is informed that all local projects will be removed from the device and that he should manually cancel Apple subscription if there is one. Also user should type his username in the text field before proceeding.
![зображення](https://user-images.githubusercontent.com/776954/168007840-310cae2b-dcea-416e-8a99-4104db6630e6.png)
In case if account removal failed an error message is shown.

Fixes #1896.