### PR TITLE
trigger layer repaint after successful commit (fix #2100)

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -912,6 +912,7 @@ bool AttributeController::commit()
   }
   else
   {
+    mFeatureLayerPair.layer()->triggerRepaint();
     return true;
   }
 }


### PR DESCRIPTION
Request layer repaint request on successful commit, so any changes made in it will be immediately visible.

Fixes #2100.