### PR TITLE
hide delete button when adding new features (fix #2101)

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -787,7 +787,7 @@ bool AttributeController::deleteFeature()
   bool isDeleted = mFeatureLayerPair.layer()->deleteFeature( mFeatureLayerPair.feature().id() );
   rv = commit();
 
-  if ( !isDeleted )
+  if ( !isDeleted || !rv )
   {
     QgsMessageLog::logMessage( tr( "Cannot delete feature" ),
                                QStringLiteral( "Input" ),

--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -787,7 +787,7 @@ bool AttributeController::deleteFeature()
   bool isDeleted = mFeatureLayerPair.layer()->deleteFeature( mFeatureLayerPair.feature().id() );
   rv = commit();
 
-  if ( !isDeleted || !rv )
+  if ( !isDeleted )
   {
     QgsMessageLog::logMessage( tr( "Cannot delete feature" ),
                                QStringLiteral( "Input" ),

--- a/app/qml/form/FeatureToolbar.qml
+++ b/app/qml/form/FeatureToolbar.qml
@@ -24,13 +24,13 @@ Item {
 
     states: [
         State {
-            name: "edit"
+            name: "edit" // edit existing feature
             PropertyChanges { target: editRow; visible: true }
             PropertyChanges { target: readOnlyRow; visible: false }
             PropertyChanges { target: addRow; visible: false }
         }
         ,State {
-            name: "add"
+            name: "add" // add new feature
             PropertyChanges { target: editRow; visible: false }
             PropertyChanges { target: readOnlyRow; visible: false }
             PropertyChanges { target: addRow; visible: true }

--- a/app/qml/form/FeatureToolbar.qml
+++ b/app/qml/form/FeatureToolbar.qml
@@ -27,16 +27,19 @@ Item {
             name: "edit"
             PropertyChanges { target: editRow; visible: true }
             PropertyChanges { target: readOnlyRow; visible: false }
+            PropertyChanges { target: addRow; visible: false }
         }
         ,State {
             name: "add"
-            PropertyChanges { target: editRow; visible: true }
+            PropertyChanges { target: editRow; visible: false }
             PropertyChanges { target: readOnlyRow; visible: false }
+            PropertyChanges { target: addRow; visible: true }
         }
         ,State {
             name: "readOnly"
             PropertyChanges { target: editRow; visible: false }
             PropertyChanges { target: readOnlyRow; visible: true }
+            PropertyChanges { target: addRow; visible: false }
         }
     ]
 
@@ -106,4 +109,28 @@ Item {
             }
         }
     }
+
+    Row {
+        id: addRow
+        height: parent.height
+        width: parent.width
+        anchors.fill: parent
+
+        Item {
+            width: parent.width/parent.children.length
+            height: parent.height
+
+            MainPanelButton {
+                width: toolbar.itemSize
+                text: qsTr("Edit geometry")
+                imageSource: InputStyle.editIcon
+                enabled: isFeaturePoint
+
+                onActivated: {
+                    toolbar.editGeometryClicked()
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Hides "Delete" button when new features are created. To cancel editing session user should use Cancel button in the top left corner.

![зображення](https://user-images.githubusercontent.com/776954/168279560-4cc01ed0-d627-4f6b-8393-1c133a3e1f7c.png)

Fixes #2101.