### PR TITLE
create directories used in the attachment widget configuration if they are not exists.

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -78,11 +78,27 @@ bool InputUtils::copyFile( const QString &srcPath, const QString &dstPath )
     modSrcPath = modSrcPath.replace( "file://", "" );
   }
 
+  QFileInfo fi( dstPath );
+  QDir dir = fi.absoluteDir();
+  if ( !dir.exists() )
+  {
+    if ( !dir.mkpath( dir.path() ) )
+    {
+      return false;
+    }
+  }
+
   // https://github.com/lutraconsulting/input/issues/418
   // does not work for iOS files with format
   // file:assets-library://asset/asset.PNG%3Fid=A53AB989-6354-433A-9CB9-958179B7C14D&ext=PNG
 
   return QFile::copy( modSrcPath, dstPath );
+}
+
+bool InputUtils::createDirectory( const QString &path )
+{
+  QDir dir;
+  return dir.mkpath( path );
 }
 
 QString InputUtils::getFileName( const QString &filePath )
@@ -748,8 +764,6 @@ QString InputUtils::resolveTargetDir( const QString &homePath, const QVariantMap
       return defaultRoot;
     }
   }
-
-
 }
 
 QString InputUtils::resolvePrefixForRelativePath( int relativeStorageMode, const QString &homePath, const QString &targetDir )

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -79,13 +79,9 @@ bool InputUtils::copyFile( const QString &srcPath, const QString &dstPath )
   }
 
   QFileInfo fi( dstPath );
-  QDir dir = fi.absoluteDir();
-  if ( !dir.exists() )
+  if ( !InputUtils::createDirectory( fi.absoluteDir().path() ) )
   {
-    if ( !dir.mkpath( dir.path() ) )
-    {
-      return false;
-    }
+    return false;
   }
 
   // https://github.com/lutraconsulting/input/issues/418

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -52,7 +52,22 @@ class InputUtils: public QObject
     explicit InputUtils( AndroidUtils *au, QObject *parent = nullptr );
     ~InputUtils() override = default;
 
+    /**
+     * Copies file from srcPath to dstPath. If destination directory is
+     * not exists — tries to create it first.
+     * \param srcPath Absolute path to a source file.
+     * \param dstPath Absolute path to a destination file.
+     * \result True on success, False otherwise.
+     */
     Q_INVOKABLE static bool copyFile( const QString &srcPath, const QString &dstPath );
+
+    /**
+     * Creates the directory path. It will also create all parent
+     * directories necessary to create the directory.
+     * \param path directory path to create.
+     * \result True on success, False otherwise.
+     */
+    Q_INVOKABLE static bool createDirectory( const QString &path );
 
     Q_INVOKABLE QString getFileName( const QString &filePath );
     Q_INVOKABLE QString formatProjectName( const QString &fullProjectName );
@@ -218,7 +233,6 @@ class InputUtils: public QObject
      * 3. use project home folder
      */
     Q_INVOKABLE static QString resolveTargetDir( const QString &homePath, const QVariantMap &config, const FeatureLayerPair &pair, QgsProject *activeProject );
-
 
     /**
      * Function used for resolving path of an image for a field with ExternalResource widget type.

--- a/app/qml/ExternalResourceBundle.qml
+++ b/app/qml/ExternalResourceBundle.qml
@@ -29,6 +29,12 @@ Item {
          */
         property var capturePhoto: function capturePhoto(itemWidget) {
           externalResourceHandler.itemWidget = itemWidget
+          if ( !__inputUtils.createDirectory( itemWidget.targetDir ) )
+          {
+            errorDialog.errorText = qsTr( "Could not create directory %1. Please ensure that your project configured correctly" ).arg( itemWidget.targetDir )
+            errorDialog.open()
+          }
+
           if (__androidUtils.isAndroid) {
               __androidUtils.callCamera(itemWidget.targetDir)
           } else if (__iosUtils.isIos) {
@@ -117,7 +123,8 @@ Item {
             var success = __inputUtils.copyFile(imagePath, absolutePath)
             if (!success)
             {
-                console.log("error: Unable to copy file " + imagePath + " to the project directory")
+              errorDialog.errorText = qsTr( "Failed to copy image file to %1. Please ensure that your project configured correctly" ).arg( absolutePath )
+              errorDialog.open()
             }
           }
           externalResourceHandler.confirmImage(externalResourceHandler.itemWidget, externalResourceHandler.itemWidget.prefixToRelativePath, absolutePath)
@@ -221,6 +228,18 @@ Item {
         }
     }
 
+    MessageDialog {
+        property string errorText
+
+        id: errorDialog
+        visible: false
+        title: qsTr( "Failed to copy image" )
+        text: errorText
+        icon: StandardIcon.Warning
+        standardButtons: StandardButton.Ok
+        onAccepted: {
+            externalResourceHandler.itemWidget.editorValueChanged("", false)
+            visible = false
+        }
+    }
 }
-
-

--- a/app/qml/ExternalResourceBundle.qml
+++ b/app/qml/ExternalResourceBundle.qml
@@ -31,7 +31,8 @@ Item {
           externalResourceHandler.itemWidget = itemWidget
           if ( !__inputUtils.createDirectory( itemWidget.targetDir ) )
           {
-            errorDialog.errorText = qsTr( "Could not create directory %1. Please ensure that your project configured correctly" ).arg( itemWidget.targetDir )
+            __inputUtils.log("Capture photo", "Could not create directory " + itemWidget.targetDir);
+            errorDialog.errorText = qsTr( "Could not create directory %1." ).arg( itemWidget.targetDir )
             errorDialog.open()
           }
 
@@ -123,7 +124,8 @@ Item {
             var success = __inputUtils.copyFile(imagePath, absolutePath)
             if (!success)
             {
-              errorDialog.errorText = qsTr( "Failed to copy image file to %1. Please ensure that your project configured correctly" ).arg( absolutePath )
+              __inputUtils.log("Select image", "Failed to copy image file to " + absolutePath);
+              errorDialog.errorText = qsTr( "Failed to copy image file to %1." ).arg( absolutePath )
               errorDialog.open()
             }
           }


### PR DESCRIPTION
This is needed as geodiff works only with files and empty directories are not synced. As a result if attachment widget is configured to use subfolder and this path does not exists capturing photos will fail.

Also show a warning dialog if copying image to the destination directory fails.

Refs #1611 and https://github.com/lutraconsulting/qgis-mergin-plugin/issues/278